### PR TITLE
fix: Revert export statements to declare in type generators

### DIFF
--- a/src/generate/typeGenerate/gassmaAggregateBaseReturn/oneGassmaAggregateBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaAggregateBaseReturn/oneGassmaAggregateBaseReturn.ts
@@ -19,7 +19,7 @@ const getOneGassmaAggregateBaseReturn = (
     "",
   );
 
-  return `\nexport type Gassma${sheetName}AggregateBaseReturn = {
+  return `\ndeclare type Gassma${sheetName}AggregateBaseReturn = {
 ${oneAggregateBaseReturn}};
 `;
 };

--- a/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
+++ b/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
@@ -1,6 +1,6 @@
 const getOneGassmaAggregateData = (sheetName: string) => {
   return `
-export type Gassma${sheetName}AggregateData = {
+declare type Gassma${sheetName}AggregateData = {
   where?: Gassma${sheetName}WhereUse;
   orderBy?: Gassma${sheetName}OrderBy;
   take?: number;

--- a/src/generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField.ts
+++ b/src/generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField.ts
@@ -1,6 +1,6 @@
 const getOneGassmaAggregateField = (sheetName: string) => {
   return `
-export type Gassma${sheetName}AggregateField<T, K extends string> = T extends undefined
+declare type Gassma${sheetName}AggregateField<T, K extends string> = T extends undefined
   ? never
   : K extends "_count"
     ? { [P in keyof T as T[P] extends true ? P : never]: number }

--- a/src/generate/typeGenerate/gassmaAggregateResult/oneGassmaAggregateResult.ts
+++ b/src/generate/typeGenerate/gassmaAggregateResult/oneGassmaAggregateResult.ts
@@ -1,6 +1,6 @@
 const getOneGassmaAggregateResult = (sheetName: string) => {
   return `
-export type Gassma${sheetName}AggregateResult<T extends Gassma${sheetName}AggregateData> = {
+declare type Gassma${sheetName}AggregateResult<T extends Gassma${sheetName}AggregateData> = {
   [K in keyof T as K extends "_avg" | "_count" | "_max" | "_min" | "_sum"
     ? T[K] extends undefined
       ? never

--- a/src/generate/typeGenerate/gassmaAnyUse/oneGassmaAnyUse.ts
+++ b/src/generate/typeGenerate/gassmaAnyUse/oneGassmaAnyUse.ts
@@ -18,7 +18,7 @@ const getOneGassmaAnyUse = (
       : `"${removedQuestionMark}"`;
 
     return `${pre}  ${insertColumnName}: ${now};\n`;
-  }, `\nexport type Gassma${sheetName}Use = {\n`);
+  }, `\ndeclare type Gassma${sheetName}Use = {\n`);
 
   return `${oneAnyUse}};\n`;
 };

--- a/src/generate/typeGenerate/gassmaByField/oneGassmaByField.ts
+++ b/src/generate/typeGenerate/gassmaByField/oneGassmaByField.ts
@@ -1,6 +1,6 @@
 const getOneGassmaByField = (sheetName: string) => {
   return `
-export type Gassma${sheetName}ByField<T extends Gassma${sheetName}GroupByKeyOfBaseReturn | Gassma${sheetName}GroupByKeyOfBaseReturn[]> =
+declare type Gassma${sheetName}ByField<T extends Gassma${sheetName}GroupByKeyOfBaseReturn | Gassma${sheetName}GroupByKeyOfBaseReturn[]> =
   T extends Gassma${sheetName}GroupByKeyOfBaseReturn[]
     ? {
         [K in T[number]]: Gassma${sheetName}GroupByBaseReturn[K & keyof Gassma${sheetName}GroupByBaseReturn];

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -1,6 +1,6 @@
 const getOneGassmaController = (sheetName: string) => {
   return `
-export class Gassma${sheetName}Controller {
+declare class Gassma${sheetName}Controller {
   constructor(sheetName: string, id?: string);
 
   changeSettings(

--- a/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
+++ b/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
@@ -1,6 +1,6 @@
 const getOneGassmaCountData = (sheetName: string) => {
   return `
-export type Gassma${sheetName}CountData = {
+declare type Gassma${sheetName}CountData = {
   where?: Gassma${sheetName}WhereUse;
   orderBy?: Gassma${sheetName}OrderBy;
   take?: number;

--- a/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
+++ b/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
@@ -1,6 +1,6 @@
 const getOneGassmaCreate = (sheetName: string) => {
   return `
-export type Gassma${sheetName}CreateData = {
+declare type Gassma${sheetName}CreateData = {
   data: Gassma${sheetName}Use;
 };
 `;

--- a/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany.ts
+++ b/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany.ts
@@ -1,6 +1,6 @@
 const getOneGassmaCreateMany = (sheetName: string) => {
   return `
-export type Gassma${sheetName}CreateManyData = {
+declare type Gassma${sheetName}CreateManyData = {
   data: Gassma${sheetName}Use[];
 };
 `;

--- a/src/generate/typeGenerate/gassmaCreateReturn/oneGassmaCreateReturn.ts
+++ b/src/generate/typeGenerate/gassmaCreateReturn/oneGassmaCreateReturn.ts
@@ -17,7 +17,7 @@ const getOneGassmaCreateReturn = (
 
       return `${pre} "${removedQuestionMark}": ${now}${isQuestionMark ? " | null" : ""};\n`;
     },
-    `\nexport type Gassma${sheetName}CreateReturn = {\n`,
+    `\ndeclare type Gassma${sheetName}CreateReturn = {\n`,
   );
 
   return `${oneCreateReturn}};\n`;

--- a/src/generate/typeGenerate/gassmaDefaultFindResult/oneGassmaDefaultFindResult.ts
+++ b/src/generate/typeGenerate/gassmaDefaultFindResult/oneGassmaDefaultFindResult.ts
@@ -1,6 +1,6 @@
 const getOneGassmaDefaultFindResult = (sheetName: string) => {
   return `
-export type Gassma${sheetName}DefaultFindResult = Gassma${sheetName}CreateReturn;
+declare type Gassma${sheetName}DefaultFindResult = Gassma${sheetName}CreateReturn;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
@@ -1,6 +1,6 @@
 const getOneGassmaDeleteData = (sheetName: string) => {
   return `
-export type Gassma${sheetName}DeleteData = {
+declare type Gassma${sheetName}DeleteData = {
   where: Gassma${sheetName}WhereUse;
 };
 `;

--- a/src/generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions.ts
+++ b/src/generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions.ts
@@ -17,7 +17,7 @@ const getOneSheetGassmaFilterConditions = (
       const isOneType = columnTypes.length === 1;
 
       const oneFilterConditionsType = `
-export type Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions = {
+declare type Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions = {
   equals?: ${now}${isQuestionMark ? " | null" : ""};
   not?: ${now}${isQuestionMark ? " | null" : ""};
   in?: ${isOneType ? `${now}[]` : `(${now})[]`};

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -24,7 +24,7 @@ const getOneGassmaFindData = (
     return `${pre}"${removedQuestionMark}" | `;
   }, "");
 
-  return `\nexport type Gassma${sheetName}FindData = {
+  return `\ndeclare type Gassma${sheetName}FindData = {
   where?: Gassma${sheetName}WhereUse;
   select?: Gassma${sheetName}Select;
   omit?: Gassma${sheetName}Omit;

--- a/src/generate/typeGenerate/gassmaFindManyData/oneGassmaFindManyData.ts
+++ b/src/generate/typeGenerate/gassmaFindManyData/oneGassmaFindManyData.ts
@@ -1,6 +1,6 @@
 const getOneGassmaFindManyData = (sheetName: string) => {
   return `
-export type Gassma${sheetName}FindManyData = Gassma${sheetName}FindData;    
+declare type Gassma${sheetName}FindManyData = Gassma${sheetName}FindData;    
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -1,6 +1,6 @@
 const getOneGassmaFindResult = (sheetName: string) => {
   return `
-export type Gassma${sheetName}FindResult<T> = T extends undefined
+declare type Gassma${sheetName}FindResult<T> = T extends undefined
   ? Gassma${sheetName}DefaultFindResult
   : T extends Gassma${sheetName}Select
     ? {

--- a/src/generate/typeGenerate/gassmaGroupByBaseReturn/oneGassmaGroupByBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaGroupByBaseReturn/oneGassmaGroupByBaseReturn.ts
@@ -1,6 +1,6 @@
 const getOneGassmaGroupByBaseReturn = (sheetName: string) => {
   return `
-export type Gassma${sheetName}GroupByBaseReturn = Gassma${sheetName}CreateReturn;
+declare type Gassma${sheetName}GroupByBaseReturn = Gassma${sheetName}CreateReturn;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
+++ b/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
@@ -24,7 +24,7 @@ const getOneGassmaGroupByData = (
     return `${pre}"${removedQuestionMark}" | `;
   }, "");
 
-  return `\nexport type Gassma${sheetName}GroupByData = Gassma${sheetName}AggregateData & {
+  return `\ndeclare type Gassma${sheetName}GroupByData = Gassma${sheetName}AggregateData & {
   by: ${byData}(${byArrayData})[];
   having?: Gassma${sheetName}HavingUse;
 };

--- a/src/generate/typeGenerate/gassmaGroupByKeyOfBaseReturn/oneGassmaGroupByKeyOfBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaGroupByKeyOfBaseReturn/oneGassmaGroupByKeyOfBaseReturn.ts
@@ -1,6 +1,6 @@
 const getOneGassmaGroupByKeyOfBaseReturn = (sheetName: string) => {
   return `
-export type Gassma${sheetName}GroupByKeyOfBaseReturn = keyof Gassma${sheetName}GroupByBaseReturn;
+declare type Gassma${sheetName}GroupByKeyOfBaseReturn = keyof Gassma${sheetName}GroupByBaseReturn;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaGroupByResult/oneGassmaGroupByResult.ts
+++ b/src/generate/typeGenerate/gassmaGroupByResult/oneGassmaGroupByResult.ts
@@ -1,6 +1,6 @@
 const getOneGassmaGroupByResult = (sheetName: string) => {
   return `
-export type Gassma${sheetName}GroupByResult<T extends Gassma${sheetName}GroupByData> = Gassma${sheetName}ByField<T["by"]> & {
+declare type Gassma${sheetName}GroupByResult<T extends Gassma${sheetName}GroupByData> = Gassma${sheetName}ByField<T["by"]> & {
   [K in keyof T as K extends "_avg" | "_count" | "_max" | "_min" | "_sum"
     ? T[K] extends undefined
       ? never

--- a/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
+++ b/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
@@ -8,7 +8,7 @@ const getOneGassmaHavingCore = (
     const removedSpaceCurrentColumnName = getRemovedCantUseVarChar(columnName);
 
     const oneHavingCoreType = `
-export type Gassma${sheetName}${removedSpaceCurrentColumnName}HavingCore = {
+declare type Gassma${sheetName}${removedSpaceCurrentColumnName}HavingCore = {
   _avg?: Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
   _count?: Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
   _max?: Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;

--- a/src/generate/typeGenerate/gassmaHavingUse/oneGassmaHavingUse.ts
+++ b/src/generate/typeGenerate/gassmaHavingUse/oneGassmaHavingUse.ts
@@ -16,7 +16,7 @@ const getOneGassmaHavingUse = (
       : columnName;
 
     return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${sheetName}${removedSpaceCurrentColumnName}HavingCore;\n`;
-  }, `\nexport type Gassma${sheetName}HavingUse = {\n`);
+  }, `\ndeclare type Gassma${sheetName}HavingUse = {\n`);
 
   return `${oneHavingUse}
   AND?: Gassma${sheetName}HavingUse[] | Gassma${sheetName}HavingUse;

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -1,6 +1,6 @@
 const getGassmaMain = () => {
-  const mainTypeDeclare = `export namespace Gassma {
-  export class GassmaClient {
+  const mainTypeDeclare = `declare namespace Gassma {
+  class GassmaClient {
     constructor(id?: string);
 
     readonly sheets: GassmaSheet;

--- a/src/generate/typeGenerate/gassmaManyCount.ts
+++ b/src/generate/typeGenerate/gassmaManyCount.ts
@@ -1,13 +1,13 @@
 const getGassmaManyCount = () => {
   return `
-export type ManyReturn = {
+declare type ManyReturn = {
   count: number;
 };
 
-export type CreateManyReturn = ManyReturn;
-export type UpdateManyReturn = ManyReturn;
-export type DeleteManyReturn = ManyReturn;
-export type UpsertManyReturn = ManyReturn;
+declare type CreateManyReturn = ManyReturn;
+declare type UpdateManyReturn = ManyReturn;
+declare type DeleteManyReturn = ManyReturn;
+declare type UpsertManyReturn = ManyReturn;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaOmit/oneGassmaOmit.ts
+++ b/src/generate/typeGenerate/gassmaOmit/oneGassmaOmit.ts
@@ -9,7 +9,7 @@ const getOneGassmaOmit = (
       : columnName;
 
     return `${pre}  "${removedQuestionMark}"?: true;\n`;
-  }, `\nexport type Gassma${sheetName}Omit = {\n`);
+  }, `\ndeclare type Gassma${sheetName}Omit = {\n`);
 
   return `${oneOmit}};\n`;
 };

--- a/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
+++ b/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
@@ -9,7 +9,7 @@ const getOneGassmaOrderBy = (
       : columnName;
 
     return `${pre}  "${removedQuestionMark}"?: "asc" | "desc";\n`;
-  }, `\nexport type Gassma${sheetName}OrderBy = {\n`);
+  }, `\ndeclare type Gassma${sheetName}OrderBy = {\n`);
 
   return `${oneAnyUse}};\n`;
 };

--- a/src/generate/typeGenerate/gassmaSelect/oneGassmaSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect/oneGassmaSelect.ts
@@ -9,7 +9,7 @@ const getOneGassmaSelect = (
       : columnName;
 
     return `${pre}  "${removedQuestionMark}"?: true;\n`;
-  }, `\nexport type Gassma${sheetName}Select = {\n`);
+  }, `\ndeclare type Gassma${sheetName}Select = {\n`);
 
   return `${oneSelct}};\n`;
 };

--- a/src/generate/typeGenerate/gassmaSheet.ts
+++ b/src/generate/typeGenerate/gassmaSheet.ts
@@ -5,7 +5,7 @@ const getGassmaSheet = (sheetNames: string[]) => {
     const removedSpaceCurrentSheetName = getRemovedCantUseVarChar(current);
 
     return `${pre}  "${current}": Gassma${removedSpaceCurrentSheetName}Controller;\n`;
-  }, "export type GassmaSheet = {\n");
+  }, "declare type GassmaSheet = {\n");
 
   return sheetTypeDeclare + "};\n";
 };

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
@@ -1,6 +1,6 @@
 const getOneGassmaUpdateData = (sheetName: string) => {
   return `
-export type Gassma${sheetName}UpdateData = {
+declare type Gassma${sheetName}UpdateData = {
   where?: Gassma${sheetName}WhereUse;
   data: Gassma${sheetName}Use;
 };

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertData.ts
@@ -1,6 +1,6 @@
 const getOneGassmaUpsertData = (sheetName: string) => {
   return `
-export type Gassma${sheetName}UpsertData = {
+declare type Gassma${sheetName}UpsertData = {
   where: Gassma${sheetName}WhereUse;
   update: Gassma${sheetName}Use;
   data: Gassma${sheetName}Use;

--- a/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
@@ -16,7 +16,7 @@ const getOneGassmaWhereUse = (
       : columnName;
 
     return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;\n`;
-  }, `\nexport type Gassma${sheetName}WhereUse = {\n`);
+  }, `\ndeclare type Gassma${sheetName}WhereUse = {\n`);
 
   return `${oneWhereUse}
   AND?: Gassma${sheetName}WhereUse[] | Gassma${sheetName}WhereUse;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
型生成部分の`export`文を`declare`文に戻す修正

## Changes
### 🔧 修正内容
- すべての型生成器で`export`文を`declare`文に変更
- `export namespace` → `declare namespace`
- `export class` → `declare class`
- `export interface` → `declare interface`
- `export type` → `declare type`

### 📝 理由
- 生成される.d.tsファイルはambient declarationである必要がある
- exportでは型の使用時に問題が発生していた

### 🎯 影響範囲
- 32個の型生成ファイルを修正
- 生成される.d.tsファイルがすべて`declare`文になる
- 既存のAPIに影響なし

## Test plan
- [x] ビルドが成功することを確認
- [x] 型生成コマンドが正常に動作することを確認
- [x] 生成される.d.tsファイルが正しく`declare`文になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)