### PR TITLE
ci: add test job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,34 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.11.0'
+          cache: 'npm'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-24.11.0-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-24.11.0-
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 概要
- GitHub Actions の CI ワークフローに `test` ジョブを追加
- PR / push 時に `npm test` が自動実行されるように

## 変更内容
- `.github/workflows/ci.yml` に `test` ジョブ追加（lint, build と並列実行）

## テスト計画
- [x] CI が正常に動作することを PR 上で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)