### PR TITLE
feat: リレーション定義済み GassmaClient の JS 生成

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -1,0 +1,62 @@
+import { generateClientJs } from "../../../generate/jsGenerate/generateClientJs";
+
+describe("generateClientJs", () => {
+  it("should generate JS with embedded relations config", () => {
+    const relations = {
+      User: {
+        posts: {
+          type: "oneToMany" as const,
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+      Post: {
+        author: {
+          type: "manyToOne" as const,
+          to: "User",
+          field: "authorId",
+          reference: "id",
+        },
+      },
+    };
+
+    const result = generateClientJs(relations);
+
+    expect(result).toContain("const relations =");
+    expect(result).toContain('"User"');
+    expect(result).toContain('"posts"');
+    expect(result).toContain('"oneToMany"');
+    expect(result).toContain('"Post"');
+    expect(result).toContain('"author"');
+    expect(result).toContain('"manyToOne"');
+    expect(result).toContain("function createGassmaClient");
+  });
+
+  it("should generate JS with empty relations when none exist", () => {
+    const result = generateClientJs({});
+
+    expect(result).toContain("const relations = {}");
+    expect(result).toContain("function createGassmaClient");
+  });
+
+  it("should include onDelete and onUpdate when present", () => {
+    const relations = {
+      Post: {
+        author: {
+          type: "manyToOne" as const,
+          to: "User",
+          field: "authorId",
+          reference: "id",
+          onDelete: "Cascade",
+          onUpdate: "SetNull",
+        },
+      },
+    };
+
+    const result = generateClientJs(relations);
+
+    expect(result).toContain('"onDelete": "Cascade"');
+    expect(result).toContain('"onUpdate": "SetNull"');
+  });
+});

--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -59,4 +59,29 @@ describe("generateClientJs", () => {
     expect(result).toContain('"onDelete": "Cascade"');
     expect(result).toContain('"onUpdate": "SetNull"');
   });
+
+  it("should include through property for manyToMany relations", () => {
+    const relations = {
+      Post: {
+        tags: {
+          type: "manyToMany" as const,
+          to: "Tag",
+          field: "id",
+          reference: "id",
+          through: {
+            sheet: "_PostToTag",
+            field: "postId",
+            reference: "tagId",
+          },
+        },
+      },
+    };
+
+    const result = generateClientJs(relations);
+
+    expect(result).toContain('"through"');
+    expect(result).toContain('"_PostToTag"');
+    expect(result).toContain('"postId"');
+    expect(result).toContain('"tagId"');
+  });
 });

--- a/src/__test__/generate/read/extractRelations.test.ts
+++ b/src/__test__/generate/read/extractRelations.test.ts
@@ -1,0 +1,144 @@
+import { extractRelations } from "../../../generate/read/extractRelations";
+
+describe("extractRelations", () => {
+  it("should extract oneToMany relation", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  name  String
+  posts Post[]
+}
+
+model Post {
+  id       Int    @id
+  title    String
+  author   User   @relation(fields: [authorId], references: [id])
+  authorId Int
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result).toEqual({
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+      Post: {
+        author: {
+          type: "manyToOne",
+          to: "User",
+          field: "authorId",
+          reference: "id",
+        },
+      },
+    });
+  });
+
+  it("should extract oneToOne relation", () => {
+    const schema = `
+model User {
+  id      Int      @id
+  profile Profile?
+}
+
+model Profile {
+  id     Int  @id
+  user   User @relation(fields: [userId], references: [id])
+  userId Int  @unique
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result).toEqual({
+      User: {
+        profile: {
+          type: "oneToOne",
+          to: "Profile",
+          field: "id",
+          reference: "userId",
+        },
+      },
+      Profile: {
+        user: {
+          type: "oneToOne",
+          to: "User",
+          field: "userId",
+          reference: "id",
+        },
+      },
+    });
+  });
+
+  it("should return empty object when no relations exist", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result).toEqual({});
+  });
+
+  it("should extract onDelete and onUpdate actions", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id       Int    @id
+  author   User   @relation(fields: [authorId], references: [id], onDelete: Cascade, onUpdate: SetNull)
+  authorId Int
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Post.author.onDelete).toBe("Cascade");
+    expect(result.Post.author.onUpdate).toBe("SetNull");
+  });
+
+  it("should handle multiple relations on the same model", () => {
+    const schema = `
+model User {
+  id             Int    @id
+  writtenPosts   Post[] @relation("WrittenPosts")
+  favoritePosts  Post[] @relation("FavoritePosts")
+}
+
+model Post {
+  id          Int    @id
+  author      User   @relation("WrittenPosts", fields: [authorId], references: [id])
+  authorId    Int
+  favoritedBy User?  @relation("FavoritePosts", fields: [favoritedById], references: [id])
+  favoritedById Int?
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.User.writtenPosts).toEqual({
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "authorId",
+    });
+    expect(result.User.favoritePosts).toEqual({
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "favoritedById",
+    });
+    expect(result.Post.author).toEqual({
+      type: "manyToOne",
+      to: "User",
+      field: "authorId",
+      reference: "id",
+    });
+  });
+});

--- a/src/__test__/generate/read/extractRelations.test.ts
+++ b/src/__test__/generate/read/extractRelations.test.ts
@@ -142,6 +142,72 @@ model Post {
     });
   });
 
+  it("should extract implicit manyToMany relation", () => {
+    const schema = `
+model Post {
+  id    Int    @id
+  title String
+  tags  Tag[]
+}
+
+model Tag {
+  id    Int    @id
+  name  String
+  posts Post[]
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Post.tags).toEqual({
+      type: "manyToMany",
+      to: "Tag",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "_PostToTag",
+        field: "postId",
+        reference: "tagId",
+      },
+    });
+    expect(result.Tag.posts).toEqual({
+      type: "manyToMany",
+      to: "Post",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "_PostToTag",
+        field: "tagId",
+        reference: "postId",
+      },
+    });
+  });
+
+  it("should sort implicit manyToMany table name alphabetically", () => {
+    const schema = `
+model Zebra {
+  id    Int    @id
+  apples Apple[]
+}
+
+model Apple {
+  id     Int    @id
+  zebras Zebra[]
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Zebra.apples.through).toEqual({
+      sheet: "_AppleToZebra",
+      field: "zebraId",
+      reference: "appleId",
+    });
+    expect(result.Apple.zebras.through).toEqual({
+      sheet: "_AppleToZebra",
+      field: "appleId",
+      reference: "zebraId",
+    });
+  });
+
   it("should extract manyToMany relation with through table", () => {
     const schema = `
 model Post {

--- a/src/__test__/generate/read/extractRelations.test.ts
+++ b/src/__test__/generate/read/extractRelations.test.ts
@@ -141,4 +141,55 @@ model Post {
       reference: "id",
     });
   });
+
+  it("should extract manyToMany relation with through table", () => {
+    const schema = `
+model Post {
+  id       Int       @id
+  title    String
+  postTags PostTag[]
+}
+
+model Tag {
+  id       Int       @id
+  name     String
+  postTags PostTag[]
+}
+
+model PostTag {
+  postId Int
+  tagId  Int
+  post   Post @relation(fields: [postId], references: [id])
+  tag    Tag  @relation(fields: [tagId], references: [id])
+
+  @@id([postId, tagId])
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Post.postTags).toEqual({
+      type: "oneToMany",
+      to: "PostTag",
+      field: "id",
+      reference: "postId",
+    });
+    expect(result.Tag.postTags).toEqual({
+      type: "oneToMany",
+      to: "PostTag",
+      field: "id",
+      reference: "tagId",
+    });
+    expect(result.PostTag.post).toEqual({
+      type: "manyToOne",
+      to: "Post",
+      field: "postId",
+      reference: "id",
+    });
+    expect(result.PostTag.tag).toEqual({
+      type: "manyToOne",
+      to: "Tag",
+      field: "tagId",
+      reference: "id",
+    });
+  });
 });

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -1,9 +1,12 @@
 import fs from "fs";
 import path from "path";
 import { generater } from "./generator";
+import { generateClientJs } from "./jsGenerate/generateClientJs";
 import { extractOutputPath } from "./read/extractOutputPath";
+import { extractRelations } from "./read/extractRelations";
 import { prismaReader } from "./read/prismaReader";
 import { writer } from "./writer";
+import { jsWriter } from "./jsWriter";
 
 function generate(customDir?: string) {
   const gassmaDir = customDir || "./gassma";
@@ -43,6 +46,10 @@ function generate(customDir?: string) {
     const resultString = generater(parsed);
     const baseName = path.basename(file, ".prisma");
     writer(resultString, baseName, outputPath);
+
+    const relations = extractRelations(schemaText);
+    const clientJs = generateClientJs(relations);
+    jsWriter(clientJs, "client", outputPath);
   });
 
   console.log(`✅ Generated ${prismaFiles.length} type definition file(s)`);

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -1,0 +1,18 @@
+import type { RelationsConfig } from "../read/extractRelations";
+
+const generateClientJs = (relations: RelationsConfig): string => {
+  const relationsJson =
+    Object.keys(relations).length === 0
+      ? "{}"
+      : JSON.stringify(relations, null, 2);
+
+  return `const relations = ${relationsJson};
+
+function createGassmaClient(options) {
+  const mergedOptions = Object.assign({}, options, { relations: relations });
+  return new Gassma.GassmaClient(mergedOptions);
+}
+`;
+};
+
+export { generateClientJs };

--- a/src/generate/jsWriter.ts
+++ b/src/generate/jsWriter.ts
@@ -1,0 +1,14 @@
+import fs from "fs";
+import path from "path";
+
+const jsWriter = (jsString: string, fileName: string, outputDir: string) => {
+  const targetPath = path.join(outputDir, `${fileName}.js`);
+
+  const dir = path.dirname(targetPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  fs.writeFileSync(targetPath, jsString);
+  console.log(`✅ Generated: ${targetPath}`);
+};
+
+export { jsWriter };

--- a/src/generate/read/detectImplicitManyToMany.ts
+++ b/src/generate/read/detectImplicitManyToMany.ts
@@ -1,0 +1,60 @@
+import { findFirstAttribute } from "@loancrate/prisma-schema-parser";
+import type { ModelDeclaration } from "@loancrate/prisma-schema-parser";
+import type { RelationsConfig } from "./extractRelations";
+import { getFieldReferences } from "./relationHelpers";
+
+const toLowercaseFirst = (s: string): string =>
+  s.charAt(0).toLowerCase() + s.slice(1);
+
+const detectImplicitManyToMany = (
+  models: ModelDeclaration[],
+  result: RelationsConfig,
+): void => {
+  models.forEach((modelA) => {
+    modelA.members.forEach((member) => {
+      if (member.kind !== "field") return;
+      if (member.type.kind !== "list") return;
+
+      const targetType = member.type.type;
+      if (targetType.kind !== "typeId") return;
+      const targetName = targetType.name.value;
+
+      if (result[modelA.name.value]?.[member.name.value]) return;
+
+      const attr = findFirstAttribute(member.attributes, "relation");
+      if (attr) {
+        const fields = getFieldReferences(attr.args, "fields");
+        if (fields) return;
+      }
+
+      const modelB = models.find((m) => m.name.value === targetName);
+      if (!modelB) return;
+
+      const inverseField = modelB.members.find((m) => {
+        if (m.kind !== "field") return false;
+        if (m.type.kind !== "list") return false;
+        const bt = m.type.type;
+        return bt.kind === "typeId" && bt.name.value === modelA.name.value;
+      });
+      if (!inverseField || inverseField.kind !== "field") return;
+
+      const sorted = [modelA.name.value, targetName].sort();
+      const throughSheet = `_${sorted[0]}To${sorted[1]}`;
+
+      if (!result[modelA.name.value]) result[modelA.name.value] = {};
+      result[modelA.name.value][member.name.value] = {
+        type: "manyToMany",
+        to: targetName,
+        field: "id",
+        reference: "id",
+        through: {
+          sheet: throughSheet,
+          field: `${toLowercaseFirst(modelA.name.value)}Id`,
+          reference: `${toLowercaseFirst(targetName)}Id`,
+        },
+      };
+    });
+  });
+};
+
+export { detectImplicitManyToMany };

--- a/src/generate/read/extractRelations.ts
+++ b/src/generate/read/extractRelations.ts
@@ -1,0 +1,202 @@
+import {
+  parsePrismaSchema,
+  findFirstAttribute,
+  findArgument,
+} from "@loancrate/prisma-schema-parser";
+import type {
+  ModelDeclaration,
+  FieldDeclaration,
+  SchemaArgument,
+} from "@loancrate/prisma-schema-parser";
+
+type RelationDefinition = {
+  type: "oneToMany" | "oneToOne" | "manyToOne" | "manyToMany";
+  to: string;
+  field: string;
+  reference: string;
+  onDelete?: string;
+  onUpdate?: string;
+};
+
+type RelationsConfig = {
+  [sheetName: string]: {
+    [relationName: string]: RelationDefinition;
+  };
+};
+
+type FieldsideRelation = {
+  modelName: string;
+  fieldName: string;
+  toModel: string;
+  localField: string;
+  foreignField: string;
+  isOptional: boolean;
+  relationName: string | null;
+  onDelete?: string;
+  onUpdate?: string;
+};
+
+const getRelationName = (field: FieldDeclaration): string | null => {
+  const attr = findFirstAttribute(field.attributes, "relation");
+  if (!attr) return null;
+  const firstArg = attr.args?.[0];
+  if (!firstArg) return null;
+  if ("kind" in firstArg && firstArg.kind !== "namedArgument") {
+    if (firstArg.kind === "literal" && typeof firstArg.value === "string")
+      return firstArg.value;
+  }
+  return null;
+};
+
+const getFieldReferences = (
+  args: readonly SchemaArgument[] | undefined,
+  name: string,
+): string[] | null => {
+  const arg = findArgument(args, name);
+  if (!arg) return null;
+  const expr = arg.expression;
+  if (expr.kind === "array") {
+    return expr.items
+      .filter((item) => item.kind === "path")
+      .map((item) => (item.kind === "path" ? item.value[0] : ""));
+  }
+  return null;
+};
+
+const getActionValue = (
+  args: readonly SchemaArgument[] | undefined,
+  name: string,
+): string | undefined => {
+  const arg = findArgument(args, name);
+  if (!arg) return undefined;
+  const expr = arg.expression;
+  if (expr.kind === "path") return expr.value[0];
+  return undefined;
+};
+
+const extractRelations = (schemaText: string): RelationsConfig => {
+  const ast = parsePrismaSchema(schemaText);
+
+  const models = ast.declarations.filter(
+    (d): d is ModelDeclaration => d.kind === "model",
+  );
+
+  const fieldsideRelations: FieldsideRelation[] = [];
+
+  models.forEach((model) => {
+    model.members.forEach((member) => {
+      if (member.kind !== "field") return;
+
+      const attr = findFirstAttribute(member.attributes, "relation");
+      if (!attr) return;
+
+      const fields = getFieldReferences(attr.args, "fields");
+      const references = getFieldReferences(attr.args, "references");
+      if (!fields || !references) return;
+
+      const baseType =
+        member.type.kind === "optional" ? member.type.type : member.type;
+      if (baseType.kind !== "typeId") return;
+
+      fieldsideRelations.push({
+        modelName: model.name.value,
+        fieldName: member.name.value,
+        toModel: baseType.name.value,
+        localField: fields[0],
+        foreignField: references[0],
+        isOptional: member.type.kind === "optional",
+        relationName: getRelationName(member),
+        onDelete: getActionValue(attr.args, "onDelete"),
+        onUpdate: getActionValue(attr.args, "onUpdate"),
+      });
+    });
+  });
+
+  const result: RelationsConfig = {};
+
+  fieldsideRelations.forEach((rel) => {
+    // The side with @relation(fields, references) - many side or owning oneToOne
+    if (!result[rel.modelName]) result[rel.modelName] = {};
+
+    const isOneToOne = isOneToOneRelation(rel, models);
+    result[rel.modelName][rel.fieldName] = {
+      type: isOneToOne ? "oneToOne" : "manyToOne",
+      to: rel.toModel,
+      field: rel.localField,
+      reference: rel.foreignField,
+      ...(rel.onDelete ? { onDelete: rel.onDelete } : {}),
+      ...(rel.onUpdate ? { onUpdate: rel.onUpdate } : {}),
+    };
+
+    // The inverse side
+    const inverseModel = models.find((m) => m.name.value === rel.toModel);
+    if (!inverseModel) return;
+
+    const inverseField = findInverseField(
+      inverseModel,
+      rel.modelName,
+      rel.relationName,
+    );
+    if (!inverseField) return;
+
+    if (!result[rel.toModel]) result[rel.toModel] = {};
+    const inverseIsListType = inverseField.type.kind === "list";
+
+    result[rel.toModel][inverseField.name.value] = {
+      type: inverseIsListType ? "oneToMany" : "oneToOne",
+      to: rel.modelName,
+      field: rel.foreignField,
+      reference: rel.localField,
+    };
+  });
+
+  return result;
+};
+
+const isOneToOneRelation = (
+  rel: FieldsideRelation,
+  models: ModelDeclaration[],
+): boolean => {
+  const targetModel = models.find((m) => m.name.value === rel.toModel);
+  if (!targetModel) return false;
+
+  const inverseField = findInverseField(
+    targetModel,
+    rel.modelName,
+    rel.relationName,
+  );
+  if (!inverseField) return false;
+
+  return inverseField.type.kind !== "list";
+};
+
+const findInverseField = (
+  model: ModelDeclaration,
+  targetModelName: string,
+  relationName: string | null,
+): FieldDeclaration | undefined => {
+  return model.members.find((m): m is FieldDeclaration => {
+    if (m.kind !== "field") return false;
+
+    const baseType =
+      m.type.kind === "list" || m.type.kind === "optional"
+        ? m.type.type
+        : m.type;
+    if (baseType.kind !== "typeId") return false;
+    if (baseType.name.value !== targetModelName) return false;
+
+    // If relation has a name, match it
+    if (relationName) {
+      return getRelationName(m) === relationName;
+    }
+
+    // No @relation(fields:...) means it's the inverse side
+    const attr = findFirstAttribute(m.attributes, "relation");
+    if (!attr) return true;
+    const fields = getFieldReferences(attr.args, "fields");
+    return fields === null;
+  });
+};
+
+export { extractRelations };
+export type { RelationsConfig, RelationDefinition };

--- a/src/generate/read/extractRelations.ts
+++ b/src/generate/read/extractRelations.ts
@@ -1,13 +1,23 @@
 import {
   parsePrismaSchema,
   findFirstAttribute,
-  findArgument,
 } from "@loancrate/prisma-schema-parser";
-import type {
-  ModelDeclaration,
-  FieldDeclaration,
-  SchemaArgument,
-} from "@loancrate/prisma-schema-parser";
+import type { ModelDeclaration } from "@loancrate/prisma-schema-parser";
+import { detectImplicitManyToMany } from "./detectImplicitManyToMany";
+import {
+  getRelationName,
+  getFieldReferences,
+  getActionValue,
+  findInverseField,
+  isOneToOneRelation,
+} from "./relationHelpers";
+import type { FieldsideRelation } from "./relationHelpers";
+
+type ThroughDefinition = {
+  sheet: string;
+  field: string;
+  reference: string;
+};
 
 type RelationDefinition = {
   type: "oneToMany" | "oneToOne" | "manyToOne" | "manyToMany";
@@ -16,6 +26,7 @@ type RelationDefinition = {
   reference: string;
   onDelete?: string;
   onUpdate?: string;
+  through?: ThroughDefinition;
 };
 
 type RelationsConfig = {
@@ -24,64 +35,10 @@ type RelationsConfig = {
   };
 };
 
-type FieldsideRelation = {
-  modelName: string;
-  fieldName: string;
-  toModel: string;
-  localField: string;
-  foreignField: string;
-  isOptional: boolean;
-  relationName: string | null;
-  onDelete?: string;
-  onUpdate?: string;
-};
-
-const getRelationName = (field: FieldDeclaration): string | null => {
-  const attr = findFirstAttribute(field.attributes, "relation");
-  if (!attr) return null;
-  const firstArg = attr.args?.[0];
-  if (!firstArg) return null;
-  if ("kind" in firstArg && firstArg.kind !== "namedArgument") {
-    if (firstArg.kind === "literal" && typeof firstArg.value === "string")
-      return firstArg.value;
-  }
-  return null;
-};
-
-const getFieldReferences = (
-  args: readonly SchemaArgument[] | undefined,
-  name: string,
-): string[] | null => {
-  const arg = findArgument(args, name);
-  if (!arg) return null;
-  const expr = arg.expression;
-  if (expr.kind === "array") {
-    return expr.items
-      .filter((item) => item.kind === "path")
-      .map((item) => (item.kind === "path" ? item.value[0] : ""));
-  }
-  return null;
-};
-
-const getActionValue = (
-  args: readonly SchemaArgument[] | undefined,
-  name: string,
-): string | undefined => {
-  const arg = findArgument(args, name);
-  if (!arg) return undefined;
-  const expr = arg.expression;
-  if (expr.kind === "path") return expr.value[0];
-  return undefined;
-};
-
-const extractRelations = (schemaText: string): RelationsConfig => {
-  const ast = parsePrismaSchema(schemaText);
-
-  const models = ast.declarations.filter(
-    (d): d is ModelDeclaration => d.kind === "model",
-  );
-
-  const fieldsideRelations: FieldsideRelation[] = [];
+const collectFieldsideRelations = (
+  models: ModelDeclaration[],
+): FieldsideRelation[] => {
+  const relations: FieldsideRelation[] = [];
 
   models.forEach((model) => {
     model.members.forEach((member) => {
@@ -98,7 +55,7 @@ const extractRelations = (schemaText: string): RelationsConfig => {
         member.type.kind === "optional" ? member.type.type : member.type;
       if (baseType.kind !== "typeId") return;
 
-      fieldsideRelations.push({
+      relations.push({
         modelName: model.name.value,
         fieldName: member.name.value,
         toModel: baseType.name.value,
@@ -112,10 +69,16 @@ const extractRelations = (schemaText: string): RelationsConfig => {
     });
   });
 
+  return relations;
+};
+
+const buildRelationsConfig = (
+  fieldsideRelations: FieldsideRelation[],
+  models: ModelDeclaration[],
+): RelationsConfig => {
   const result: RelationsConfig = {};
 
   fieldsideRelations.forEach((rel) => {
-    // The side with @relation(fields, references) - many side or owning oneToOne
     if (!result[rel.modelName]) result[rel.modelName] = {};
 
     const isOneToOne = isOneToOneRelation(rel, models);
@@ -128,7 +91,6 @@ const extractRelations = (schemaText: string): RelationsConfig => {
       ...(rel.onUpdate ? { onUpdate: rel.onUpdate } : {}),
     };
 
-    // The inverse side
     const inverseModel = models.find((m) => m.name.value === rel.toModel);
     if (!inverseModel) return;
 
@@ -153,49 +115,19 @@ const extractRelations = (schemaText: string): RelationsConfig => {
   return result;
 };
 
-const isOneToOneRelation = (
-  rel: FieldsideRelation,
-  models: ModelDeclaration[],
-): boolean => {
-  const targetModel = models.find((m) => m.name.value === rel.toModel);
-  if (!targetModel) return false;
+const extractRelations = (schemaText: string): RelationsConfig => {
+  const ast = parsePrismaSchema(schemaText);
 
-  const inverseField = findInverseField(
-    targetModel,
-    rel.modelName,
-    rel.relationName,
+  const models = ast.declarations.filter(
+    (d): d is ModelDeclaration => d.kind === "model",
   );
-  if (!inverseField) return false;
 
-  return inverseField.type.kind !== "list";
-};
+  const fieldsideRelations = collectFieldsideRelations(models);
+  const result = buildRelationsConfig(fieldsideRelations, models);
 
-const findInverseField = (
-  model: ModelDeclaration,
-  targetModelName: string,
-  relationName: string | null,
-): FieldDeclaration | undefined => {
-  return model.members.find((m): m is FieldDeclaration => {
-    if (m.kind !== "field") return false;
+  detectImplicitManyToMany(models, result);
 
-    const baseType =
-      m.type.kind === "list" || m.type.kind === "optional"
-        ? m.type.type
-        : m.type;
-    if (baseType.kind !== "typeId") return false;
-    if (baseType.name.value !== targetModelName) return false;
-
-    // If relation has a name, match it
-    if (relationName) {
-      return getRelationName(m) === relationName;
-    }
-
-    // No @relation(fields:...) means it's the inverse side
-    const attr = findFirstAttribute(m.attributes, "relation");
-    if (!attr) return true;
-    const fields = getFieldReferences(attr.args, "fields");
-    return fields === null;
-  });
+  return result;
 };
 
 export { extractRelations };

--- a/src/generate/read/relationHelpers.ts
+++ b/src/generate/read/relationHelpers.ts
@@ -1,0 +1,111 @@
+import {
+  findFirstAttribute,
+  findArgument,
+} from "@loancrate/prisma-schema-parser";
+import type {
+  ModelDeclaration,
+  FieldDeclaration,
+  SchemaArgument,
+} from "@loancrate/prisma-schema-parser";
+
+type FieldsideRelation = {
+  modelName: string;
+  fieldName: string;
+  toModel: string;
+  localField: string;
+  foreignField: string;
+  isOptional: boolean;
+  relationName: string | null;
+  onDelete?: string;
+  onUpdate?: string;
+};
+
+const getRelationName = (field: FieldDeclaration): string | null => {
+  const attr = findFirstAttribute(field.attributes, "relation");
+  if (!attr) return null;
+  const firstArg = attr.args?.[0];
+  if (!firstArg) return null;
+  if ("kind" in firstArg && firstArg.kind !== "namedArgument") {
+    if (firstArg.kind === "literal" && typeof firstArg.value === "string")
+      return firstArg.value;
+  }
+  return null;
+};
+
+const getFieldReferences = (
+  args: readonly SchemaArgument[] | undefined,
+  name: string,
+): string[] | null => {
+  const arg = findArgument(args, name);
+  if (!arg) return null;
+  const expr = arg.expression;
+  if (expr.kind === "array") {
+    return expr.items
+      .filter((item) => item.kind === "path")
+      .map((item) => (item.kind === "path" ? item.value[0] : ""));
+  }
+  return null;
+};
+
+const getActionValue = (
+  args: readonly SchemaArgument[] | undefined,
+  name: string,
+): string | undefined => {
+  const arg = findArgument(args, name);
+  if (!arg) return undefined;
+  const expr = arg.expression;
+  if (expr.kind === "path") return expr.value[0];
+  return undefined;
+};
+
+const findInverseField = (
+  model: ModelDeclaration,
+  targetModelName: string,
+  relationName: string | null,
+): FieldDeclaration | undefined => {
+  return model.members.find((m): m is FieldDeclaration => {
+    if (m.kind !== "field") return false;
+
+    const baseType =
+      m.type.kind === "list" || m.type.kind === "optional"
+        ? m.type.type
+        : m.type;
+    if (baseType.kind !== "typeId") return false;
+    if (baseType.name.value !== targetModelName) return false;
+
+    if (relationName) {
+      return getRelationName(m) === relationName;
+    }
+
+    const attr = findFirstAttribute(m.attributes, "relation");
+    if (!attr) return true;
+    const fields = getFieldReferences(attr.args, "fields");
+    return fields === null;
+  });
+};
+
+const isOneToOneRelation = (
+  rel: FieldsideRelation,
+  models: ModelDeclaration[],
+): boolean => {
+  const targetModel = models.find((m) => m.name.value === rel.toModel);
+  if (!targetModel) return false;
+
+  const inverseField = findInverseField(
+    targetModel,
+    rel.modelName,
+    rel.relationName,
+  );
+  if (!inverseField) return false;
+
+  return inverseField.type.kind !== "list";
+};
+
+export {
+  getRelationName,
+  getFieldReferences,
+  getActionValue,
+  findInverseField,
+  isOneToOneRelation,
+};
+export type { FieldsideRelation };


### PR DESCRIPTION
## 概要
- `schema.prisma` の `@relation` を解析し、リレーション定義がプリセットされた `client.js` を自動生成
- ユーザーが手動で `relations` オブジェクトを書く必要がなくなる

## 変更内容
- `extractRelations.ts`: `@relation` からリレーション構造を抽出（oneToMany/manyToOne/oneToOne対応、onDelete/onUpdate対応、名前付きリレーション対応）
- `detectImplicitManyToMany.ts`: 暗黙的 manyToMany リレーションの検出
- `relationHelpers.ts`: リレーション解析用ヘルパー関数群
- `generateClientJs.ts`: リレーション定義を埋め込んだ `client.js` を生成
- `jsWriter.ts`: `.js` ファイル出力用writer
- `generate.ts`: `.d.ts` に加えて `client.js` も出力

## manyToMany の判定条件

### 暗黙的 manyToMany（Prisma 方式）
以下の **すべて** を満たすとき、暗黙的 manyToMany と判定する:

1. モデル A にモデル B の **リスト型フィールド** がある（例: `tags Tag[]`）
2. モデル B にモデル A の **リスト型フィールド** がある（例: `posts Post[]`）
3. どちらのフィールドにも `@relation(fields: [...], references: [...])` が **ない**

```prisma
// 例: 暗黙的 manyToMany
model Post {
  id    Int    @id
  tags  Tag[]       // ← リスト型、@relation(fields) なし
}

model Tag {
  id    Int    @id
  posts Post[]      // ← リスト型、@relation(fields) なし
}
```

### 中間テーブル名の命名規則
- Prisma と同様に `_ModelAToModelB` の形式（**アルファベット順**）
- 例: `Post` と `Tag` → `_PostToTag`、`Apple` と `Zebra` → `_AppleToZebra`
- FK カラム名は `modelName` の先頭を小文字にして `Id` を付与（例: `postId`, `tagId`）

### 明示的 manyToMany（中間テーブルあり）
中間テーブルモデルが明示的に定義されている場合は、通常の oneToMany / manyToOne として解析される（Prisma と同じ扱い）。

```prisma
// 例: 明示的 manyToMany → oneToMany + manyToOne として処理
model PostTag {
  postId Int
  tagId  Int
  post   Post @relation(fields: [postId], references: [id])
  tag    Tag  @relation(fields: [tagId], references: [id])
  @@id([postId, tagId])
}
```

## 生成される client.js の例
```javascript
const relations = {
  "User": {
    "posts": { "type": "oneToMany", "to": "Post", "field": "id", "reference": "authorId" }
  },
  "Post": {
    "author": { "type": "manyToOne", "to": "User", "field": "authorId", "reference": "id" },
    "tags": {
      "type": "manyToMany",
      "to": "Tag",
      "field": "id",
      "reference": "id",
      "through": { "sheet": "_PostToTag", "field": "postId", "reference": "tagId" }
    }
  }
};

function createGassmaClient(options) {
  const mergedOptions = Object.assign({}, options, { relations: relations });
  return new Gassma.GassmaClient(mergedOptions);
}
```

## テスト計画
- [x] `extractRelations` 8テスト PASS（oneToMany/oneToOne/空/onDelete,onUpdate/複数リレーション/暗黙的manyToMany/アルファベット順テーブル名/明示的中間テーブル）
- [x] `generateClientJs` 4テスト PASS（through プロパティ含む）
- [x] 全80テスト PASS
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)