### PR TITLE
feat: GassmaClientOptions 型生成

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -2,11 +2,36 @@ import { getGassmaMain } from "../../../generate/typeGenerate/gassmaMain";
 
 describe("getGassmaMain", () => {
   it("should generate namespace declaration with GassmaClient class", () => {
-    const result = getGassmaMain();
+    const result = getGassmaMain(["User", "Post"]);
 
     expect(result).toContain("declare namespace Gassma");
     expect(result).toContain("class GassmaClient");
-    expect(result).toContain("constructor(id?: string)");
+    expect(result).toContain(
+      "constructor(idOrOptions?: string | GassmaClientOptions)",
+    );
     expect(result).toContain("readonly sheets: GassmaSheet");
+  });
+
+  it("should generate GassmaClientOptions type", () => {
+    const result = getGassmaMain(["User", "Post"]);
+
+    expect(result).toContain("declare type GassmaClientOptions");
+    expect(result).toContain("id?: string");
+    expect(result).toContain("relations?: Gassma.RelationsConfig");
+    expect(result).toContain("omit?: GassmaGlobalOmitConfig");
+  });
+
+  it("should generate GassmaGlobalOmitConfig with model-specific omit", () => {
+    const result = getGassmaMain(["User", "Post"]);
+
+    expect(result).toContain("declare type GassmaGlobalOmitConfig");
+    expect(result).toContain('"User"?: GassmaUserOmit');
+    expect(result).toContain('"Post"?: GassmaPostOmit');
+  });
+
+  it("should handle sheet names with special characters", () => {
+    const result = getGassmaMain(["My Sheet"]);
+
+    expect(result).toContain('"My Sheet"?: GassmaMySheetOmit');
   });
 });

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -32,9 +32,9 @@ import { getGassmaUpsertData } from "./typeGenerate/gassmaUpsertData";
 import { getGassmaWhereUse } from "./typeGenerate/gassmaWhereUse";
 
 const generater = (dictYaml: Record<string, Record<string, unknown[]>>) => {
-  let result = getGassmaMain();
-
   const sheetNames = Object.keys(dictYaml);
+  let result = getGassmaMain(sheetNames);
+
   result += getGassmaSheet(sheetNames);
   result += getGassmaController(sheetNames);
   result += getGassmaManyCount();

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -1,7 +1,26 @@
-const getGassmaMain = () => {
+import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+
+const getGassmaGlobalOmitConfig = (sheetNames: string[]) => {
+  const body = sheetNames.reduce((pre, sheetName) => {
+    const cleanName = getRemovedCantUseVarChar(sheetName);
+    return `${pre}  "${sheetName}"?: Gassma${cleanName}Omit;\n`;
+  }, "");
+
+  return `declare type GassmaGlobalOmitConfig = {\n${body}};\n`;
+};
+
+const getGassmaClientOptions = () => {
+  return `declare type GassmaClientOptions = {
+  id?: string;
+  relations?: Gassma.RelationsConfig;
+  omit?: GassmaGlobalOmitConfig;
+};\n`;
+};
+
+const getGassmaMain = (sheetNames: string[]) => {
   const mainTypeDeclare = `declare namespace Gassma {
   class GassmaClient {
-    constructor(id?: string);
+    constructor(idOrOptions?: string | GassmaClientOptions);
 
     readonly sheets: GassmaSheet;
   }
@@ -9,7 +28,11 @@ const getGassmaMain = () => {
 
 `;
 
-  return mainTypeDeclare;
+  return (
+    mainTypeDeclare +
+    getGassmaGlobalOmitConfig(sheetNames) +
+    getGassmaClientOptions()
+  );
 };
 
 export { getGassmaMain };


### PR DESCRIPTION
## 概要
- gassma本体の `GassmaClientOptions`（relations / omit）をCLI型生成に反映
- `GassmaClient` のコンストラクタが `string | GassmaClientOptions` を受け取るように

## 変更内容
- `gassmaMain.ts`: `GassmaClientOptions` と `GassmaGlobalOmitConfig` の型生成を追加
- `generator.ts`: `getGassmaMain` に `sheetNames` を渡すように変更

## 生成される型の例
```typescript
declare type GassmaGlobalOmitConfig = {
  "User"?: GassmaUserOmit;
  "Post"?: GassmaPostOmit;
};

declare type GassmaClientOptions = {
  id?: string;
  relations?: Gassma.RelationsConfig;
  omit?: GassmaGlobalOmitConfig;
};

declare namespace Gassma {
  class GassmaClient {
    constructor(idOrOptions?: string | GassmaClientOptions);
    readonly sheets: GassmaSheet;
  }
}
```

## テスト計画
- [x] `getGassmaMain` 4テスト PASS
- [x] 全84テスト PASS
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)