### PR TITLE
feat: @gassma.addType によるユニオン型サポート

### DIFF
--- a/src/__test__/generate/read/extractAddTypes.test.ts
+++ b/src/__test__/generate/read/extractAddTypes.test.ts
@@ -1,0 +1,94 @@
+import { extractAddTypes } from "../../../generate/read/extractAddTypes";
+
+describe("extractAddTypes", () => {
+  it("should extract addType for a field", () => {
+    const schema = `
+model User {
+  /// @gassma.addType string
+  id Int @id
+}
+`;
+    const result = extractAddTypes(schema);
+
+    expect(result).toEqual({
+      User: { id: ["string"] },
+    });
+  });
+
+  it("should extract multiple addTypes with comma separation", () => {
+    const schema = `
+model User {
+  /// @gassma.addType string, boolean
+  id Int @id
+}
+`;
+    const result = extractAddTypes(schema);
+
+    expect(result).toEqual({
+      User: { id: ["string", "boolean"] },
+    });
+  });
+
+  it("should return empty object when no addType comments exist", () => {
+    const schema = `
+model User {
+  id Int @id
+  name String
+}
+`;
+    const result = extractAddTypes(schema);
+
+    expect(result).toEqual({});
+  });
+
+  it("should handle multiple fields with addType", () => {
+    const schema = `
+model User {
+  /// @gassma.addType string
+  id Int @id
+  /// @gassma.addType number
+  name String
+}
+`;
+    const result = extractAddTypes(schema);
+
+    expect(result).toEqual({
+      User: {
+        id: ["string"],
+        name: ["number"],
+      },
+    });
+  });
+
+  it("should handle multiple models", () => {
+    const schema = `
+model User {
+  /// @gassma.addType string
+  id Int @id
+}
+
+model Post {
+  /// @gassma.addType boolean
+  title String
+}
+`;
+    const result = extractAddTypes(schema);
+
+    expect(result).toEqual({
+      User: { id: ["string"] },
+      Post: { title: ["boolean"] },
+    });
+  });
+
+  it("should ignore regular comments", () => {
+    const schema = `
+model User {
+  /// This is a regular comment
+  id Int @id
+}
+`;
+    const result = extractAddTypes(schema);
+
+    expect(result).toEqual({});
+  });
+});

--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -163,6 +163,32 @@ model User {
     expect(Object.keys(result)).toEqual(["User"]);
   });
 
+  it("should add types from @gassma.addType comment", () => {
+    const schema = `
+model User {
+  /// @gassma.addType string
+  id    Int    @id
+  name  String
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User.id).toEqual(["number", "string"]);
+    expect(result.User.name).toEqual(["string"]);
+  });
+
+  it("should add multiple types from @gassma.addType comment", () => {
+    const schema = `
+model User {
+  /// @gassma.addType string, boolean
+  id Int @id
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User.id).toEqual(["number", "string", "boolean"]);
+  });
+
   it("should ignore relation fields (list types referencing other models)", () => {
     const schema = `
 model User {

--- a/src/generate/read/extractAddTypes.ts
+++ b/src/generate/read/extractAddTypes.ts
@@ -1,0 +1,50 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import type { ModelDeclaration } from "@loancrate/prisma-schema-parser";
+
+type AddTypesConfig = {
+  [modelName: string]: {
+    [fieldName: string]: string[];
+  };
+};
+
+const GASSMA_ADD_TYPE_PREFIX = "@gassma.addType ";
+
+const extractAddTypes = (schemaText: string): AddTypesConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: AddTypesConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+    processModel(decl, result);
+  });
+
+  return result;
+};
+
+const processModel = (
+  model: ModelDeclaration,
+  result: AddTypesConfig,
+): void => {
+  const members = model.members;
+
+  members.forEach((member, index) => {
+    if (member.kind !== "commentBlock") return;
+
+    const nextMember = members[index + 1];
+    if (!nextMember || nextMember.kind !== "field") return;
+
+    member.comments.forEach((comment) => {
+      if (comment.kind !== "docComment") return;
+      if (!comment.text.startsWith(GASSMA_ADD_TYPE_PREFIX)) return;
+
+      const typesString = comment.text.slice(GASSMA_ADD_TYPE_PREFIX.length);
+      const types = typesString.split(",").map((t) => t.trim());
+
+      if (!result[model.name.value]) result[model.name.value] = {};
+      result[model.name.value][nextMember.name.value] = types;
+    });
+  });
+};
+
+export { extractAddTypes };
+export type { AddTypesConfig };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -1,11 +1,13 @@
 import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
 import { mapPrismaType } from "./mapPrismaType";
 import { isScalarField } from "./isScalarField";
+import { extractAddTypes } from "./extractAddTypes";
 
 function prismaReader(
   schemaText: string,
 ): Record<string, Record<string, unknown[]>> {
   const ast = parsePrismaSchema(schemaText);
+  const addTypes = extractAddTypes(schemaText);
   const result: Record<string, Record<string, unknown[]>> = {};
 
   ast.declarations.forEach((decl) => {
@@ -30,7 +32,8 @@ function prismaReader(
         ? `${member.name.value}?`
         : member.name.value;
 
-      fields[fieldName] = [tsType];
+      const extra = addTypes[modelName]?.[member.name.value] ?? [];
+      fields[fieldName] = [tsType, ...extra];
     });
 
     result[modelName] = fields;


### PR DESCRIPTION
## 概要
- `.prisma` ファイルの `///` ドキュメントコメントで `@gassma.addType` を記述すると、フィールドの型にユニオン型を追加できる
- Prisma の文法を壊さずに GASsma 固有のユニオン型を表現可能

## 使い方
```prisma
model User {
  /// @gassma.addType string
  id Int @id          // → number | string

  /// @gassma.addType string, boolean
  data Int             // → number | string | boolean

  name String          // → string（コメントなしなら通常通り）
}
```

## 仕組み
- `extractAddTypes.ts`: AST の `commentBlock` → 直後の `field` を関連付けて `@gassma.addType` を抽出
- `prismaReader.ts`: `extractAddTypes` の結果をフィールドの型配列に追加
- 既存の `getColumnType` / `getManyColumnType` がユニオン型（`|` 区切り）を生成

## テスト計画
- [x] `extractAddTypes` 6テスト PASS
- [x] `prismaReader` 11テスト PASS（addType 2テスト追加）
- [x] 全92テスト PASS
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)