### PR TITLE
feat: FindData に include プロパティ追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
@@ -1,0 +1,33 @@
+import { getOneGassmaFindData } from "../../../generate/typeGenerate/gassmaFindData/oneGassmaFindData";
+
+describe("getOneGassmaFindData", () => {
+  const sheetContent = {
+    id: ["number"],
+    name: ["string"],
+    "email?": ["string"],
+  };
+
+  it("should generate FindData type with where, select, omit, orderBy", () => {
+    const result = getOneGassmaFindData(sheetContent, "User");
+
+    expect(result).toContain("declare type GassmaUserFindData");
+    expect(result).toContain("where?: GassmaUserWhereUse");
+    expect(result).toContain("select?: GassmaUserSelect");
+    expect(result).toContain("omit?: GassmaUserOmit");
+    expect(result).toContain("orderBy?: GassmaUserOrderBy");
+  });
+
+  it("should include take, skip, and distinct", () => {
+    const result = getOneGassmaFindData(sheetContent, "User");
+
+    expect(result).toContain("take?: number");
+    expect(result).toContain("skip?: number");
+    expect(result).toContain("distinct?:");
+  });
+
+  it("should include include property", () => {
+    const result = getOneGassmaFindData(sheetContent, "User");
+
+    expect(result).toContain("include?: Gassma.IncludeData");
+  });
+});

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -31,7 +31,8 @@ const getOneGassmaFindData = (
   orderBy?: Gassma${sheetName}OrderBy;
   take?: number;
   skip?: number;
-  distinct?: ${distinctData}(${distinctArrayData})[]
+  distinct?: ${distinctData}(${distinctArrayData})[];
+  include?: Gassma.IncludeData;
 };\n`;
 };
 


### PR DESCRIPTION
## 概要
- 生成される `FindData` 型に `include?: Gassma.IncludeData` を追加
- `FindManyData` は `FindData` のエイリアスなので自動的に反映

## 変更内容
- `oneGassmaFindData.ts`: `include?: Gassma.IncludeData` プロパティ追加
- `gassmaFindData.test.ts`: FindData 型生成のテスト新規作成

## 備考
- 現時点では汎用の `Gassma.IncludeData`（`index.d.ts` 由来）を使用
- モデル固有の include 型（リレーション名をキーに制限）は後続タスクで対応

## テスト計画
- [x] `gassmaFindData` 3テスト PASS
- [x] 全95テスト PASS
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)