### PR TITLE
feat: WhereUse にリレーションフィルタ追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
@@ -1,0 +1,106 @@
+import { getOneGassmaWhereUse } from "../../../generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse";
+import type { RelationsConfig } from "../../../generate/read/extractRelations";
+
+describe("getOneGassmaWhereUse", () => {
+  const sheetContent = {
+    id: ["number"],
+    name: ["string"],
+  };
+
+  it("should generate WhereUse without relations", () => {
+    const result = getOneGassmaWhereUse(sheetContent, "User");
+
+    expect(result).toContain("declare type GassmaUserWhereUse");
+    expect(result).toContain('"id"?:');
+    expect(result).toContain('"name"?:');
+    expect(result).toContain("AND?: GassmaUserWhereUse[]");
+    expect(result).toContain("OR?: GassmaUserWhereUse[]");
+    expect(result).toContain("NOT?: GassmaUserWhereUse[]");
+  });
+
+  it("should add oneToMany relation filter with some/every/none", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+
+    const result = getOneGassmaWhereUse(sheetContent, "User", relations);
+
+    expect(result).toContain('"posts"?: Gassma.RelationListFilter');
+  });
+
+  it("should add manyToOne relation filter with is/isNot", () => {
+    const relations: RelationsConfig = {
+      Post: {
+        author: {
+          type: "manyToOne",
+          to: "User",
+          field: "authorId",
+          reference: "id",
+        },
+      },
+    };
+
+    const result = getOneGassmaWhereUse(sheetContent, "Post", relations);
+
+    expect(result).toContain('"author"?: Gassma.RelationSingleFilter');
+  });
+
+  it("should add oneToOne relation filter with is/isNot", () => {
+    const relations: RelationsConfig = {
+      User: {
+        profile: {
+          type: "oneToOne",
+          to: "Profile",
+          field: "id",
+          reference: "userId",
+        },
+      },
+    };
+
+    const result = getOneGassmaWhereUse(sheetContent, "User", relations);
+
+    expect(result).toContain('"profile"?: Gassma.RelationSingleFilter');
+  });
+
+  it("should add manyToMany relation filter with some/every/none", () => {
+    const relations: RelationsConfig = {
+      Post: {
+        tags: {
+          type: "manyToMany",
+          to: "Tag",
+          field: "id",
+          reference: "id",
+        },
+      },
+    };
+
+    const result = getOneGassmaWhereUse(sheetContent, "Post", relations);
+
+    expect(result).toContain('"tags"?: Gassma.RelationListFilter');
+  });
+
+  it("should not add relation fields when no relations for model", () => {
+    const relations: RelationsConfig = {
+      Post: {
+        author: {
+          type: "manyToOne",
+          to: "User",
+          field: "authorId",
+          reference: "id",
+        },
+      },
+    };
+
+    const result = getOneGassmaWhereUse(sheetContent, "User", relations);
+
+    expect(result).not.toContain("RelationListFilter");
+    expect(result).not.toContain("RelationSingleFilter");
+  });
+});

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -43,11 +43,10 @@ function generate(customDir?: string) {
       );
 
     const parsed = prismaReader(schemaText);
-    const resultString = generater(parsed);
+    const relations = extractRelations(schemaText);
+    const resultString = generater(parsed, relations);
     const baseName = path.basename(file, ".prisma");
     writer(resultString, baseName, outputPath);
-
-    const relations = extractRelations(schemaText);
     const clientJs = generateClientJs(relations);
     jsWriter(clientJs, "client", outputPath);
   });

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -30,8 +30,12 @@ import { getGassmaSheet } from "./typeGenerate/gassmaSheet";
 import { getGassmaUpdateData } from "./typeGenerate/gassmaUpdateData";
 import { getGassmaUpsertData } from "./typeGenerate/gassmaUpsertData";
 import { getGassmaWhereUse } from "./typeGenerate/gassmaWhereUse";
+import type { RelationsConfig } from "./read/extractRelations";
 
-const generater = (dictYaml: Record<string, Record<string, unknown[]>>) => {
+const generater = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  relations?: RelationsConfig,
+) => {
   const sheetNames = Object.keys(dictYaml);
   let result = getGassmaMain(sheetNames);
 
@@ -42,7 +46,7 @@ const generater = (dictYaml: Record<string, Record<string, unknown[]>>) => {
   result += getGassmaCreate(sheetNames);
   result += getGassmaCreateMany(sheetNames);
   result += getGassmaFilterCoditions(dictYaml);
-  result += getGassmaWhereUse(dictYaml);
+  result += getGassmaWhereUse(dictYaml, relations);
   result += getGassmaHavingCore(dictYaml);
   result += getGassmaHavingUse(dictYaml);
   result += getGassmaFindData(dictYaml);

--- a/src/generate/typeGenerate/gassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse.ts
@@ -1,8 +1,10 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaWhereUse } from "./gassmaWhereUse/oneGassmaWhereUse";
+import type { RelationsConfig } from "../read/extractRelations";
 
 const getGassmaWhereUse = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  relations?: RelationsConfig,
 ) => {
   const whereUseDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -11,7 +13,12 @@ const getGassmaWhereUse = (
         getRemovedCantUseVarChar(currentSheetName);
 
       return (
-        pre + getOneGassmaWhereUse(sheetContent, removedSpaceCurrentSheetName)
+        pre +
+        getOneGassmaWhereUse(
+          sheetContent,
+          removedSpaceCurrentSheetName,
+          relations,
+        )
       );
     },
     "",

--- a/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
@@ -1,9 +1,32 @@
 import { getColumnType } from "../../util/getColumnType";
 import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+import type { RelationsConfig } from "../../read/extractRelations";
+
+const isListRelation = (type: string): boolean =>
+  type === "oneToMany" || type === "manyToMany";
+
+const getRelationFields = (
+  sheetName: string,
+  relations?: RelationsConfig,
+): string => {
+  if (!relations) return "";
+  const modelRelations = relations[sheetName];
+  if (!modelRelations) return "";
+
+  return Object.keys(modelRelations).reduce((pre, relationName) => {
+    const rel = modelRelations[relationName];
+    const filterType = isListRelation(rel.type)
+      ? "Gassma.RelationListFilter"
+      : "Gassma.RelationSingleFilter";
+
+    return `${pre}  "${relationName}"?: ${filterType};\n`;
+  }, "");
+};
 
 const getOneGassmaWhereUse = (
   sheetContent: Record<string, unknown[]>,
   sheetName: string,
+  relations?: RelationsConfig,
 ) => {
   const oneWhereUse = Object.keys(sheetContent).reduce((pre, columnName) => {
     const columnTypes = sheetContent[columnName];
@@ -18,7 +41,9 @@ const getOneGassmaWhereUse = (
     return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;\n`;
   }, `\ndeclare type Gassma${sheetName}WhereUse = {\n`);
 
-  return `${oneWhereUse}
+  const relationFields = getRelationFields(sheetName, relations);
+
+  return `${oneWhereUse}${relationFields}
   AND?: Gassma${sheetName}WhereUse[] | Gassma${sheetName}WhereUse;
   OR?: Gassma${sheetName}WhereUse[];
   NOT?: Gassma${sheetName}WhereUse[] | Gassma${sheetName}WhereUse;


### PR DESCRIPTION
## 概要
- 生成される `WhereUse` 型にリレーションフィルタプロパティを追加
- `some`/`every`/`none`（リスト系）と `is`/`isNot`（単一系）を適切に振り分け

## 変更内容
- `oneGassmaWhereUse.ts`: `RelationsConfig` を受け取り、リレーションフィルタを生成
  - `oneToMany` / `manyToMany` → `Gassma.RelationListFilter`
  - `manyToOne` / `oneToOne` → `Gassma.RelationSingleFilter`
- `generator.ts`: `RelationsConfig` を第2引数で受け取り `getGassmaWhereUse` に渡す
- `generate.ts`: `extractRelations` を `generater` 呼び出し前に移動し、結果を渡す

## 生成例
```typescript
declare type GassmaUserWhereUse = {
  "id"?: number | GassmaUseridFilterConditions;
  "name"?: string | GassmaUsernameFilterConditions;
  "posts"?: Gassma.RelationListFilter;    // oneToMany
  "profile"?: Gassma.RelationSingleFilter; // oneToOne
  AND?: GassmaUserWhereUse[] | GassmaUserWhereUse;
  OR?: GassmaUserWhereUse[];
  NOT?: GassmaUserWhereUse[] | GassmaUserWhereUse;
};
```

## テスト計画
- [x] `gassmaWhereUse` 6テスト PASS
- [x] 全101テスト PASS
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)