### PR TITLE
feat: FieldRef/NumberOperation/mode/FilterConditions 対応

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -25,6 +25,12 @@ describe("getOneGassmaController", () => {
     expect(result).toContain("deleteMany(");
   });
 
+  it("should include fields property", () => {
+    expect(result).toContain(
+      "readonly fields: Record<string, Gassma.FieldRef>",
+    );
+  });
+
   it("should include aggregation methods", () => {
     expect(result).toContain("aggregate<T extends GassmaUserAggregateData>");
     expect(result).toContain("count(");

--- a/src/__test__/generate/typeGenerate/gassmaFilterConditions.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFilterConditions.test.ts
@@ -1,0 +1,24 @@
+import { getOneSheetGassmaFilterConditions } from "../../../generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions";
+
+describe("getOneSheetGassmaFilterConditions", () => {
+  it("should include mode property", () => {
+    const sheetContent = { id: ["number"] };
+    const result = getOneSheetGassmaFilterConditions(sheetContent, "User");
+
+    expect(result).toContain('mode?: "default" | "insensitive"');
+  });
+
+  it("should include FieldRef in comparison operators", () => {
+    const sheetContent = { id: ["number"] };
+    const result = getOneSheetGassmaFilterConditions(sheetContent, "User");
+
+    expect(result).toContain("equals?: number | Gassma.FieldRef");
+    expect(result).toContain("lt?: number | Gassma.FieldRef");
+    expect(result).toContain("lte?: number | Gassma.FieldRef");
+    expect(result).toContain("gt?: number | Gassma.FieldRef");
+    expect(result).toContain("gte?: number | Gassma.FieldRef");
+    expect(result).toContain("contains?: string | Gassma.FieldRef");
+    expect(result).toContain("startsWith?: string | Gassma.FieldRef");
+    expect(result).toContain("endsWith?: string | Gassma.FieldRef");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -29,6 +29,14 @@ describe("getGassmaMain", () => {
     expect(result).toContain('"Post"?: GassmaPostOmit');
   });
 
+  it("should generate FieldRef class in namespace", () => {
+    const result = getGassmaMain(["User"]);
+
+    expect(result).toContain("class FieldRef");
+    expect(result).toContain("readonly modelName: string");
+    expect(result).toContain("readonly name: string");
+  });
+
   it("should handle sheet names with special characters", () => {
     const result = getGassmaMain(["My Sheet"]);
 

--- a/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
@@ -2,11 +2,13 @@ import { getOneGassmaUpdateData } from "../../../generate/typeGenerate/gassmaUpd
 import type { RelationsConfig } from "../../../generate/read/extractRelations";
 
 describe("getOneGassmaUpdateData", () => {
-  it("should generate UpdateData without relations", () => {
+  it("should generate UpdateData with NumberOperation support", () => {
     const result = getOneGassmaUpdateData("User");
 
     expect(result).toContain("declare type GassmaUserUpdateData");
-    expect(result).toContain("data: GassmaUserUse;");
+    expect(result).toContain(
+      "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
+    );
   });
 
   it("should add nested write operations for relations", () => {

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -3,6 +3,7 @@ const getOneGassmaController = (sheetName: string) => {
 declare class Gassma${sheetName}Controller {
   constructor(sheetName: string, id?: string);
 
+  readonly fields: Record<string, Gassma.FieldRef>;
   changeSettings(
     startRowNumber: number,
     startColumnNumber: number,

--- a/src/generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions.ts
+++ b/src/generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions.ts
@@ -18,17 +18,18 @@ const getOneSheetGassmaFilterConditions = (
 
       const oneFilterConditionsType = `
 declare type Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions = {
-  equals?: ${now}${isQuestionMark ? " | null" : ""};
+  equals?: ${now}${isQuestionMark ? " | null" : ""} | Gassma.FieldRef;
   not?: ${now}${isQuestionMark ? " | null" : ""};
   in?: ${isOneType ? `${now}[]` : `(${now})[]`};
   notIn?: ${isOneType ? `${now}[]` : `(${now})[]`};
-  lt?: ${now};
-  lte?: ${now};
-  gt?: ${now};
-  gte?: ${now};
-  contains?: string;
-  startsWith?: string;
-  endsWith?: string;
+  lt?: ${now} | Gassma.FieldRef;
+  lte?: ${now} | Gassma.FieldRef;
+  gt?: ${now} | Gassma.FieldRef;
+  gte?: ${now} | Gassma.FieldRef;
+  contains?: string | Gassma.FieldRef;
+  startsWith?: string | Gassma.FieldRef;
+  endsWith?: string | Gassma.FieldRef;
+  mode?: "default" | "insensitive";
 };
 `;
 

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -19,6 +19,12 @@ const getGassmaClientOptions = () => {
 
 const getGassmaMain = (sheetNames: string[]) => {
   const mainTypeDeclare = `declare namespace Gassma {
+  class FieldRef {
+    readonly modelName: string;
+    readonly name: string;
+    constructor(modelName: string, name: string);
+  }
+
   class GassmaClient {
     constructor(idOrOptions?: string | GassmaClientOptions);
 

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
@@ -6,9 +6,10 @@ const getOneGassmaUpdateData = (
   relations?: RelationsConfig,
 ) => {
   const nestedFields = getNestedWriteFields(sheetName, relations);
+  const baseDataType = `{ [K in keyof Gassma${sheetName}Use]: Gassma${sheetName}Use[K] | Gassma.NumberOperation }`;
   const dataType = nestedFields
-    ? `Gassma${sheetName}Use & {\n${nestedFields}  }`
-    : `Gassma${sheetName}Use`;
+    ? `${baseDataType} & {\n${nestedFields}  }`
+    : baseDataType;
 
   return `
 declare type Gassma${sheetName}UpdateData = {


### PR DESCRIPTION
## 概要
複数のCLI未反映タスクをまとめて対応:
- 優先7-8: FieldRef クラス + Controller の fields プロパティ
- 優先10: UpdateData に NumberOperation（increment/decrement/multiply/divide）
- 優先11: FilterConditions に mode（insensitive）+ FieldRef

## 変更内容
- `oneGassmaController.ts`: `readonly fields: Record<string, Gassma.FieldRef>` 追加
- `gassmaMain.ts`: `FieldRef` クラスを namespace 内に追加
- `oneGassmaUpdateData.ts`: mapped type で NumberOperation をユニオン追加
- `oneSheetGassmaFilterConditions.ts`: `| Gassma.FieldRef` を比較演算子に追加、`mode` プロパティ追加

## テスト計画
- [x] Controller テスト PASS
- [x] Main テスト PASS
- [x] UpdateData テスト PASS
- [x] FilterConditions テスト PASS
- [x] 全111テスト PASS
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)