### PR TITLE
feat: Controller に不足メソッド一括追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -31,6 +31,34 @@ describe("getOneGassmaController", () => {
     );
   });
 
+  it("should include delete method", () => {
+    expect(result).toContain(
+      "delete(deleteData: Gassma.DeleteSingleData): Record<string, unknown> | null",
+    );
+  });
+
+  it("should include upsert method", () => {
+    expect(result).toContain(
+      "upsert(upsertData: Gassma.UpsertSingleData): Record<string, unknown>",
+    );
+  });
+
+  it("should include createManyAndReturn method", () => {
+    expect(result).toContain(
+      "createManyAndReturn(createdData: GassmaUserCreateManyData): Record<string, unknown>[]",
+    );
+  });
+
+  it("should include updateManyAndReturn method", () => {
+    expect(result).toContain(
+      "updateManyAndReturn(updateData: GassmaUserUpdateData): Record<string, unknown>[]",
+    );
+  });
+
+  it("should include findFirstOrThrow method", () => {
+    expect(result).toContain("findFirstOrThrow<T extends GassmaUserFindData>");
+  });
+
   it("should include aggregation methods", () => {
     expect(result).toContain("aggregate<T extends GassmaUserAggregateData>");
     expect(result).toContain("count(");

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -10,11 +10,17 @@ declare class Gassma${sheetName}Controller {
     endColumnNumber: number
   ): void;
   createMany(createdData: Gassma${sheetName}CreateManyData): CreateManyReturn;
+  createManyAndReturn(createdData: Gassma${sheetName}CreateManyData): Record<string, unknown>[];
   create(createdData: Gassma${sheetName}CreateData): Gassma${sheetName}CreateReturn;
   findFirst<T extends Gassma${sheetName}FindData>(findData: T): Gassma${sheetName}FindResult<T["select"]> | null;
+  findFirstOrThrow<T extends Gassma${sheetName}FindData>(findData: T): Gassma${sheetName}FindResult<T["select"]>;
   findMany<T extends Gassma${sheetName}FindManyData>(findData: T): Gassma${sheetName}FindResult<T["select"]>[];
+  update(updateData: Gassma.UpdateSingleData): Record<string, unknown> | null;
   updateMany(updateData: Gassma${sheetName}UpdateData): UpdateManyReturn;
+  updateManyAndReturn(updateData: Gassma${sheetName}UpdateData): Record<string, unknown>[];
+  upsert(upsertData: Gassma.UpsertSingleData): Record<string, unknown>;
   upsertMany(upsertData: Gassma${sheetName}UpsertData): UpsertManyReturn;
+  delete(deleteData: Gassma.DeleteSingleData): Record<string, unknown> | null;
   deleteMany(deleteData: Gassma${sheetName}DeleteData): DeleteManyReturn;
   aggregate<T extends Gassma${sheetName}AggregateData>(aggregateData: T): Gassma${sheetName}AggregateResult<T>;
   count(coutData: Gassma${sheetName}CountData): number;


### PR DESCRIPTION
## 概要
gassma 本体に存在するが CLI 型生成で未反映だった Controller メソッドを一括追加

## 追加メソッド
| メソッド | 戻り値 |
|---------|--------|
| `delete(DeleteSingleData)` | `Record<string, unknown> \| null` |
| `upsert(UpsertSingleData)` | `Record<string, unknown>` |
| `update(UpdateSingleData)` | `Record<string, unknown> \| null` |
| `createManyAndReturn(CreateManyData)` | `Record<string, unknown>[]` |
| `updateManyAndReturn(UpdateData)` | `Record<string, unknown>[]` |
| `findFirstOrThrow(FindData)` | non-nullable（null なし） |

## テスト計画
- [x] Controller テスト 11テスト PASS
- [x] 全116テスト PASS
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)