### PR TITLE
feat: create/update に select/omit 追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -17,7 +17,7 @@ describe("getOneGassmaController", () => {
 
   it("should include CRUD methods", () => {
     expect(result).toContain("createMany(");
-    expect(result).toContain("create(");
+    expect(result).toContain("create<T extends GassmaUserCreateData>");
     expect(result).toContain("findFirst<T extends GassmaUserFindData>");
     expect(result).toContain("findMany<T extends GassmaUserFindManyData>");
     expect(result).toContain("updateMany(");
@@ -57,6 +57,18 @@ describe("getOneGassmaController", () => {
 
   it("should include findFirstOrThrow method", () => {
     expect(result).toContain("findFirstOrThrow<T extends GassmaUserFindData>");
+  });
+
+  it("should have generic create method with FindResult return", () => {
+    expect(result).toContain(
+      'create<T extends GassmaUserCreateData>(createdData: T): GassmaUserFindResult<T["select"]>',
+    );
+  });
+
+  it("should have generic update method with model-specific type", () => {
+    expect(result).toContain(
+      'update<T extends GassmaUserUpdateSingleData>(updateData: T): GassmaUserFindResult<T["select"]> | null',
+    );
   });
 
   it("should include aggregation methods", () => {

--- a/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
@@ -52,6 +52,18 @@ describe("getOneGassmaCreate", () => {
     expect(result).toContain('"profile"?: Gassma.NestedWriteOperation');
   });
 
+  it("should include select property", () => {
+    const result = getOneGassmaCreate("User");
+
+    expect(result).toContain("select?: GassmaUserSelect;");
+  });
+
+  it("should include omit property", () => {
+    const result = getOneGassmaCreate("User");
+
+    expect(result).toContain("omit?: GassmaUserOmit;");
+  });
+
   it("should not add relation fields when no relations for model", () => {
     const relations: RelationsConfig = {
       Post: {

--- a/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
@@ -1,0 +1,53 @@
+import { getOneGassmaUpdateSingleData } from "../../../generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData";
+import type { RelationsConfig } from "../../../generate/read/extractRelations";
+
+describe("getOneGassmaUpdateSingleData", () => {
+  it("should generate UpdateSingleData type", () => {
+    const result = getOneGassmaUpdateSingleData("User");
+
+    expect(result).toContain("declare type GassmaUserUpdateSingleData");
+  });
+
+  it("should include where property", () => {
+    const result = getOneGassmaUpdateSingleData("User");
+
+    expect(result).toContain("where: GassmaUserWhereUse;");
+  });
+
+  it("should include data with NumberOperation", () => {
+    const result = getOneGassmaUpdateSingleData("User");
+
+    expect(result).toContain(
+      "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
+    );
+  });
+
+  it("should include select property", () => {
+    const result = getOneGassmaUpdateSingleData("User");
+
+    expect(result).toContain("select?: GassmaUserSelect;");
+  });
+
+  it("should include omit property", () => {
+    const result = getOneGassmaUpdateSingleData("User");
+
+    expect(result).toContain("omit?: GassmaUserOmit;");
+  });
+
+  it("should add nested write operations for relations", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+
+    const result = getOneGassmaUpdateSingleData("User", relations);
+
+    expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
+  });
+});

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -28,6 +28,7 @@ import { getGassmaOrderBy } from "./typeGenerate/gassmaOrderBy";
 import { getGassmaSelect } from "./typeGenerate/gassmaSelect";
 import { getGassmaSheet } from "./typeGenerate/gassmaSheet";
 import { getGassmaUpdateData } from "./typeGenerate/gassmaUpdateData";
+import { getGassmaUpdateSingleData } from "./typeGenerate/gassmaUpdateSingleData";
 import { getGassmaUpsertData } from "./typeGenerate/gassmaUpsertData";
 import { getGassmaWhereUse } from "./typeGenerate/gassmaWhereUse";
 import type { RelationsConfig } from "./read/extractRelations";
@@ -52,6 +53,7 @@ const generater = (
   result += getGassmaFindData(dictYaml);
   result += getGassmaFindManyData(sheetNames);
   result += getGassmaUpdateData(sheetNames, relations);
+  result += getGassmaUpdateSingleData(sheetNames, relations);
   result += getGassmaUpsertData(sheetNames);
   result += getGassmaDeleteData(sheetNames);
   result += getGassmaAggregateData(sheetNames);

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -11,11 +11,11 @@ declare class Gassma${sheetName}Controller {
   ): void;
   createMany(createdData: Gassma${sheetName}CreateManyData): CreateManyReturn;
   createManyAndReturn(createdData: Gassma${sheetName}CreateManyData): Record<string, unknown>[];
-  create(createdData: Gassma${sheetName}CreateData): Gassma${sheetName}CreateReturn;
+  create<T extends Gassma${sheetName}CreateData>(createdData: T): Gassma${sheetName}FindResult<T["select"]>;
   findFirst<T extends Gassma${sheetName}FindData>(findData: T): Gassma${sheetName}FindResult<T["select"]> | null;
   findFirstOrThrow<T extends Gassma${sheetName}FindData>(findData: T): Gassma${sheetName}FindResult<T["select"]>;
   findMany<T extends Gassma${sheetName}FindManyData>(findData: T): Gassma${sheetName}FindResult<T["select"]>[];
-  update(updateData: Gassma.UpdateSingleData): Record<string, unknown> | null;
+  update<T extends Gassma${sheetName}UpdateSingleData>(updateData: T): Gassma${sheetName}FindResult<T["select"]> | null;
   updateMany(updateData: Gassma${sheetName}UpdateData): UpdateManyReturn;
   updateManyAndReturn(updateData: Gassma${sheetName}UpdateData): Record<string, unknown>[];
   upsert(upsertData: Gassma.UpsertSingleData): Record<string, unknown>;

--- a/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
+++ b/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
@@ -10,6 +10,8 @@ const getOneGassmaCreate = (sheetName: string, relations?: RelationsConfig) => {
   return `
 declare type Gassma${sheetName}CreateData = {
   data: ${dataType};
+  select?: Gassma${sheetName}Select;
+  omit?: Gassma${sheetName}Omit;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
@@ -1,0 +1,24 @@
+import type { RelationsConfig } from "../../read/extractRelations";
+import { getNestedWriteFields } from "../util/getNestedWriteFields";
+
+const getOneGassmaUpdateSingleData = (
+  sheetName: string,
+  relations?: RelationsConfig,
+) => {
+  const nestedFields = getNestedWriteFields(sheetName, relations);
+  const baseDataType = `{ [K in keyof Gassma${sheetName}Use]: Gassma${sheetName}Use[K] | Gassma.NumberOperation }`;
+  const dataType = nestedFields
+    ? `${baseDataType} & {\n${nestedFields}  }`
+    : baseDataType;
+
+  return `
+declare type Gassma${sheetName}UpdateSingleData = {
+  where: Gassma${sheetName}WhereUse;
+  data: ${dataType};
+  select?: Gassma${sheetName}Select;
+  omit?: Gassma${sheetName}Omit;
+};
+`;
+};
+
+export { getOneGassmaUpdateSingleData };

--- a/src/generate/typeGenerate/gassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateSingleData.ts
@@ -1,0 +1,22 @@
+import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getOneGassmaUpdateSingleData } from "./gassmaUpdateData/oneGassmaUpdateSingleData";
+import type { RelationsConfig } from "../read/extractRelations";
+
+const getGassmaUpdateSingleData = (
+  sheetNames: string[],
+  relations?: RelationsConfig,
+) => {
+  const updateSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
+    const removedSpaceCurrentSheetName =
+      getRemovedCantUseVarChar(currentSheetName);
+
+    return (
+      pre +
+      getOneGassmaUpdateSingleData(removedSpaceCurrentSheetName, relations)
+    );
+  }, "");
+
+  return updateSingleDataDeclare;
+};
+
+export { getGassmaUpdateSingleData };


### PR DESCRIPTION
## 概要

- `CreateData` に `select` / `omit` プロパティを追加
- モデル固有の `UpdateSingleData` 型を新規作成（`where`, `data`, `select`, `omit`）
- コントローラーの `create` / `update` メソッドをジェネリック化し、`select` に応じた戻り値型（`FindResult<T["select"]>`）を返すように変更

## 対応する gassma 本体 PR

- #99（グローバル omit + create/update に select/omit 追加）

## 変更ファイル

- `oneGassmaCreate.ts`: `select` / `omit` プロパティ追加
- `oneGassmaUpdateSingleData.ts`: 新規作成（モデル固有 UpdateSingleData）
- `gassmaUpdateSingleData.ts`: ラッパー関数
- `oneGassmaController.ts`: `create` / `update` をジェネリック化
- `generator.ts`: UpdateSingleData 生成を追加
- テストファイル 3 件

## テスト計画

- [x] CreateData に select/omit が含まれることを確認
- [x] UpdateSingleData の各プロパティ（where, data, select, omit）を確認
- [x] コントローラーのジェネリックシグネチャを確認
- [x] 全テスト通過（126 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)