### PR TITLE
feat: delete/upsert に select/omit/include 追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -31,15 +31,15 @@ describe("getOneGassmaController", () => {
     );
   });
 
-  it("should include delete method", () => {
+  it("should have generic delete method with model-specific type", () => {
     expect(result).toContain(
-      "delete(deleteData: Gassma.DeleteSingleData): Record<string, unknown> | null",
+      'delete<T extends GassmaUserDeleteSingleData>(deleteData: T): GassmaUserFindResult<T["select"]> | null',
     );
   });
 
-  it("should include upsert method", () => {
+  it("should have generic upsert method with model-specific type", () => {
     expect(result).toContain(
-      "upsert(upsertData: Gassma.UpsertSingleData): Record<string, unknown>",
+      'upsert<T extends GassmaUserUpsertSingleData>(upsertData: T): GassmaUserFindResult<T["select"]>',
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaDeleteSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteSingleData.test.ts
@@ -1,0 +1,33 @@
+import { getOneGassmaDeleteSingleData } from "../../../generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData";
+
+describe("getOneGassmaDeleteSingleData", () => {
+  it("should generate DeleteSingleData type", () => {
+    const result = getOneGassmaDeleteSingleData("User");
+
+    expect(result).toContain("declare type GassmaUserDeleteSingleData");
+  });
+
+  it("should include where property", () => {
+    const result = getOneGassmaDeleteSingleData("User");
+
+    expect(result).toContain("where: GassmaUserWhereUse;");
+  });
+
+  it("should include select property", () => {
+    const result = getOneGassmaDeleteSingleData("User");
+
+    expect(result).toContain("select?: GassmaUserSelect;");
+  });
+
+  it("should include include property", () => {
+    const result = getOneGassmaDeleteSingleData("User");
+
+    expect(result).toContain("include?: Gassma.IncludeData;");
+  });
+
+  it("should include omit property", () => {
+    const result = getOneGassmaDeleteSingleData("User");
+
+    expect(result).toContain("omit?: GassmaUserOmit;");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
@@ -1,0 +1,65 @@
+import { getOneGassmaUpsertSingleData } from "../../../generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData";
+import type { RelationsConfig } from "../../../generate/read/extractRelations";
+
+describe("getOneGassmaUpsertSingleData", () => {
+  it("should generate UpsertSingleData type", () => {
+    const result = getOneGassmaUpsertSingleData("User");
+
+    expect(result).toContain("declare type GassmaUserUpsertSingleData");
+  });
+
+  it("should include where property", () => {
+    const result = getOneGassmaUpsertSingleData("User");
+
+    expect(result).toContain("where: GassmaUserWhereUse;");
+  });
+
+  it("should include create property", () => {
+    const result = getOneGassmaUpsertSingleData("User");
+
+    expect(result).toContain("create: GassmaUserUse");
+  });
+
+  it("should include update with NumberOperation", () => {
+    const result = getOneGassmaUpsertSingleData("User");
+
+    expect(result).toContain(
+      "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
+    );
+  });
+
+  it("should include select property", () => {
+    const result = getOneGassmaUpsertSingleData("User");
+
+    expect(result).toContain("select?: GassmaUserSelect;");
+  });
+
+  it("should include include property", () => {
+    const result = getOneGassmaUpsertSingleData("User");
+
+    expect(result).toContain("include?: Gassma.IncludeData;");
+  });
+
+  it("should include omit property", () => {
+    const result = getOneGassmaUpsertSingleData("User");
+
+    expect(result).toContain("omit?: GassmaUserOmit;");
+  });
+
+  it("should add nested write operations for relations in create and update", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+
+    const result = getOneGassmaUpsertSingleData("User", relations);
+
+    expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
+  });
+});

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -11,6 +11,7 @@ import { getGassmaCreateMany } from "./typeGenerate/gassmaCreateMany";
 import { getGassmaCreateReturn } from "./typeGenerate/gassmaCreateReturn";
 import { getGassmaDefaultFindResult } from "./typeGenerate/gassmaDefaultFindResult";
 import { getGassmaDeleteData } from "./typeGenerate/gassmaDeleteData";
+import { getGassmaDeleteSingleData } from "./typeGenerate/gassmaDeleteSingleData";
 import { getGassmaFilterCoditions } from "./typeGenerate/gassmaFilterConditions";
 import { getGassmaFindData } from "./typeGenerate/gassmaFindData";
 import { getGassmaFindManyData } from "./typeGenerate/gassmaFindManyData";
@@ -30,6 +31,7 @@ import { getGassmaSheet } from "./typeGenerate/gassmaSheet";
 import { getGassmaUpdateData } from "./typeGenerate/gassmaUpdateData";
 import { getGassmaUpdateSingleData } from "./typeGenerate/gassmaUpdateSingleData";
 import { getGassmaUpsertData } from "./typeGenerate/gassmaUpsertData";
+import { getGassmaUpsertSingleData } from "./typeGenerate/gassmaUpsertSingleData";
 import { getGassmaWhereUse } from "./typeGenerate/gassmaWhereUse";
 import type { RelationsConfig } from "./read/extractRelations";
 
@@ -55,7 +57,9 @@ const generater = (
   result += getGassmaUpdateData(sheetNames, relations);
   result += getGassmaUpdateSingleData(sheetNames, relations);
   result += getGassmaUpsertData(sheetNames);
+  result += getGassmaUpsertSingleData(sheetNames, relations);
   result += getGassmaDeleteData(sheetNames);
+  result += getGassmaDeleteSingleData(sheetNames);
   result += getGassmaAggregateData(sheetNames);
   result += getGassmaGroupByData(dictYaml);
   result += getGassmaOrderBy(dictYaml);

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -18,9 +18,9 @@ declare class Gassma${sheetName}Controller {
   update<T extends Gassma${sheetName}UpdateSingleData>(updateData: T): Gassma${sheetName}FindResult<T["select"]> | null;
   updateMany(updateData: Gassma${sheetName}UpdateData): UpdateManyReturn;
   updateManyAndReturn(updateData: Gassma${sheetName}UpdateData): Record<string, unknown>[];
-  upsert(upsertData: Gassma.UpsertSingleData): Record<string, unknown>;
+  upsert<T extends Gassma${sheetName}UpsertSingleData>(upsertData: T): Gassma${sheetName}FindResult<T["select"]>;
   upsertMany(upsertData: Gassma${sheetName}UpsertData): UpsertManyReturn;
-  delete(deleteData: Gassma.DeleteSingleData): Record<string, unknown> | null;
+  delete<T extends Gassma${sheetName}DeleteSingleData>(deleteData: T): Gassma${sheetName}FindResult<T["select"]> | null;
   deleteMany(deleteData: Gassma${sheetName}DeleteData): DeleteManyReturn;
   aggregate<T extends Gassma${sheetName}AggregateData>(aggregateData: T): Gassma${sheetName}AggregateResult<T>;
   count(coutData: Gassma${sheetName}CountData): number;

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
@@ -1,0 +1,12 @@
+const getOneGassmaDeleteSingleData = (sheetName: string) => {
+  return `
+declare type Gassma${sheetName}DeleteSingleData = {
+  where: Gassma${sheetName}WhereUse;
+  select?: Gassma${sheetName}Select;
+  include?: Gassma.IncludeData;
+  omit?: Gassma${sheetName}Omit;
+};
+`;
+};
+
+export { getOneGassmaDeleteSingleData };

--- a/src/generate/typeGenerate/gassmaDeleteSingleData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteSingleData.ts
@@ -1,0 +1,15 @@
+import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getOneGassmaDeleteSingleData } from "./gassmaDeleteManyData/oneGassmaDeleteSingleData";
+
+const getGassmaDeleteSingleData = (sheetNames: string[]) => {
+  const deleteSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
+    const removedSpaceCurrentSheetName =
+      getRemovedCantUseVarChar(currentSheetName);
+
+    return pre + getOneGassmaDeleteSingleData(removedSpaceCurrentSheetName);
+  }, "");
+
+  return deleteSingleDataDeclare;
+};
+
+export { getGassmaDeleteSingleData };

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
@@ -1,0 +1,31 @@
+import type { RelationsConfig } from "../../read/extractRelations";
+import { getNestedWriteFields } from "../util/getNestedWriteFields";
+
+const getOneGassmaUpsertSingleData = (
+  sheetName: string,
+  relations?: RelationsConfig,
+) => {
+  const nestedFields = getNestedWriteFields(sheetName, relations);
+
+  const createType = nestedFields
+    ? `Gassma${sheetName}Use & {\n${nestedFields}  }`
+    : `Gassma${sheetName}Use`;
+
+  const baseUpdateType = `{ [K in keyof Gassma${sheetName}Use]: Gassma${sheetName}Use[K] | Gassma.NumberOperation }`;
+  const updateType = nestedFields
+    ? `${baseUpdateType} & {\n${nestedFields}  }`
+    : baseUpdateType;
+
+  return `
+declare type Gassma${sheetName}UpsertSingleData = {
+  where: Gassma${sheetName}WhereUse;
+  create: ${createType};
+  update: ${updateType};
+  select?: Gassma${sheetName}Select;
+  include?: Gassma.IncludeData;
+  omit?: Gassma${sheetName}Omit;
+};
+`;
+};
+
+export { getOneGassmaUpsertSingleData };

--- a/src/generate/typeGenerate/gassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertSingleData.ts
@@ -1,0 +1,22 @@
+import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getOneGassmaUpsertSingleData } from "./gassmaUpsertData/oneGassmaUpsertSingleData";
+import type { RelationsConfig } from "../read/extractRelations";
+
+const getGassmaUpsertSingleData = (
+  sheetNames: string[],
+  relations?: RelationsConfig,
+) => {
+  const upsertSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
+    const removedSpaceCurrentSheetName =
+      getRemovedCantUseVarChar(currentSheetName);
+
+    return (
+      pre +
+      getOneGassmaUpsertSingleData(removedSpaceCurrentSheetName, relations)
+    );
+  }, "");
+
+  return upsertSingleDataDeclare;
+};
+
+export { getGassmaUpsertSingleData };


### PR DESCRIPTION
## 概要

- モデル固有の `DeleteSingleData` 型を新規作成（`where`, `select`, `include`, `omit`）
- モデル固有の `UpsertSingleData` 型を新規作成（`where`, `create`, `update`, `select`, `include`, `omit`）
  - `create` は `Use` + nested write、`update` は `Use` + `NumberOperation` + nested write
- コントローラーの `delete` / `upsert` をジェネリック化し `FindResult<T["select"]>` を返すように変更

## 対応する gassma 本体 PR

- #91（delete）、#92（upsert）

## テスト計画

- [x] DeleteSingleData の各プロパティ（where, select, include, omit）を確認
- [x] UpsertSingleData の各プロパティ（where, create, update, select, include, omit, nested write）を確認
- [x] コントローラーのジェネリックシグネチャを確認
- [x] 全テスト通過（139 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)