### PR TITLE
feat: FindData に _count プロパティ追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
@@ -30,4 +30,10 @@ describe("getOneGassmaFindData", () => {
 
     expect(result).toContain("include?: Gassma.IncludeData");
   });
+
+  it("should include _count property", () => {
+    const result = getOneGassmaFindData(sheetContent, "User");
+
+    expect(result).toContain("_count?: Gassma.CountValue;");
+  });
 });

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -33,6 +33,7 @@ const getOneGassmaFindData = (
   skip?: number;
   distinct?: ${distinctData}(${distinctArrayData})[];
   include?: Gassma.IncludeData;
+  _count?: Gassma.CountValue;
 };\n`;
 };
 


### PR DESCRIPTION
## 概要

- `FindData` に `_count?: Gassma.CountValue` プロパティを追加
- `FindManyData` は `FindData` の別名のため自動的に対応
- `Gassma.CountValue` は gassma 本体の namespace に定義済み（`true | { select: { [relationName]: true | { where: ... } } }`）

## 対応する gassma 本体 PR

- #93（_count リレーション件数）

## テスト計画

- [x] FindData に `_count?: Gassma.CountValue` が含まれることを確認
- [x] 全テスト通過（140 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)