### PR TITLE
feat: FindData に cursor プロパティ追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
@@ -31,6 +31,12 @@ describe("getOneGassmaFindData", () => {
     expect(result).toContain("include?: Gassma.IncludeData");
   });
 
+  it("should include cursor property", () => {
+    const result = getOneGassmaFindData(sheetContent, "User");
+
+    expect(result).toContain("cursor?: Partial<GassmaUserUse>;");
+  });
+
   it("should include _count property", () => {
     const result = getOneGassmaFindData(sheetContent, "User");
 

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -33,6 +33,7 @@ const getOneGassmaFindData = (
   skip?: number;
   distinct?: ${distinctData}(${distinctArrayData})[];
   include?: Gassma.IncludeData;
+  cursor?: Partial<Gassma${sheetName}Use>;
   _count?: Gassma.CountValue;
 };\n`;
 };


### PR DESCRIPTION
## 概要

- `FindData` に `cursor?: Partial<Gassma${sheetName}Use>` プロパティを追加
- モデル固有の `Use` 型の `Partial` を使い、型安全なカーソル指定が可能

## 対応する gassma 本体 PR

- #97（cursor ベースページネーション）

## テスト計画

- [x] FindData に `cursor` が含まれることを確認
- [x] 全テスト通過（141 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)