### PR TITLE
feat: UpdateData/DeleteData に limit プロパティ追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaDeleteManyData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteManyData.test.ts
@@ -1,0 +1,21 @@
+import { getOneGassmaDeleteData } from "../../../generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData";
+
+describe("getOneGassmaDeleteData", () => {
+  it("should generate DeleteData type", () => {
+    const result = getOneGassmaDeleteData("User");
+
+    expect(result).toContain("declare type GassmaUserDeleteData");
+  });
+
+  it("should include where property", () => {
+    const result = getOneGassmaDeleteData("User");
+
+    expect(result).toContain("where: GassmaUserWhereUse;");
+  });
+
+  it("should include limit property", () => {
+    const result = getOneGassmaDeleteData("User");
+
+    expect(result).toContain("limit?: number;");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
@@ -27,4 +27,10 @@ describe("getOneGassmaUpdateData", () => {
 
     expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
   });
+
+  it("should include limit property", () => {
+    const result = getOneGassmaUpdateData("User");
+
+    expect(result).toContain("limit?: number;");
+  });
 });

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
@@ -2,6 +2,7 @@ const getOneGassmaDeleteData = (sheetName: string) => {
   return `
 declare type Gassma${sheetName}DeleteData = {
   where: Gassma${sheetName}WhereUse;
+  limit?: number;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
@@ -15,6 +15,7 @@ const getOneGassmaUpdateData = (
 declare type Gassma${sheetName}UpdateData = {
   where?: Gassma${sheetName}WhereUse;
   data: ${dataType};
+  limit?: number;
 };
 `;
 };


### PR DESCRIPTION
## 概要

- `UpdateData`（updateMany 用）に `limit?: number` プロパティを追加
- `DeleteData`（deleteMany 用）に `limit?: number` プロパティを追加

## 対応する gassma 本体 PR

- #88（updateMany / deleteMany の limit）

## テスト計画

- [x] UpdateData に `limit` が含まれることを確認
- [x] DeleteData に `limit` が含まれることを確認
- [x] 全テスト通過（151 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)