### PR TITLE
feat: エラークラス群の型宣言を生成に追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -1,0 +1,143 @@
+import { getGassmaErrorClasses } from "../../../generate/typeGenerate/gassmaErrorClasses";
+
+describe("getGassmaErrorClasses", () => {
+  const result = getGassmaErrorClasses();
+
+  it("should include GassmaSkipNegativeError", () => {
+    expect(result).toContain("class GassmaSkipNegativeError extends Error");
+    expect(result).toContain("constructor(value: number)");
+  });
+
+  it("should include GassmaLimitNegativeError", () => {
+    expect(result).toContain("class GassmaLimitNegativeError extends Error");
+  });
+
+  it("should include NotFoundError", () => {
+    expect(result).toContain("class NotFoundError extends Error");
+  });
+
+  it("should include GassmaFindSelectOmitConflictError", () => {
+    expect(result).toContain(
+      "class GassmaFindSelectOmitConflictError extends Error",
+    );
+  });
+
+  it("should include GassmaInValidColumnValueError", () => {
+    expect(result).toContain(
+      "class GassmaInValidColumnValueError extends Error",
+    );
+  });
+
+  it("should include GassmaGroupByHavingDontWriteByError", () => {
+    expect(result).toContain(
+      "class GassmaGroupByHavingDontWriteByError extends Error",
+    );
+  });
+
+  it("should include aggregate error classes with inheritance", () => {
+    expect(result).toContain("class GassmaAggregateMaxError extends Error");
+    expect(result).toContain(
+      "class GassmaAggregateMinError extends GassmaAggregateMaxError",
+    );
+    expect(result).toContain(
+      "class GassmaAggregateSumError extends GassmaAggregateMaxError",
+    );
+    expect(result).toContain(
+      "class GassmaAggregateAvgError extends GassmaAggregateMaxError",
+    );
+    expect(result).toContain("class GassmaAggregateTypeError extends Error");
+    expect(result).toContain("class GassmaAggregateSumTypeError extends Error");
+    expect(result).toContain(
+      "class GassmaAggregateAvgTypeError extends GassmaAggregateSumTypeError",
+    );
+  });
+
+  it("should include relation validation errors", () => {
+    expect(result).toContain("class RelationSheetNotFoundError extends Error");
+    expect(result).toContain(
+      "class RelationMissingPropertyError extends Error",
+    );
+    expect(result).toContain(
+      "class RelationInvalidPropertyTypeError extends Error",
+    );
+    expect(result).toContain("class RelationInvalidTypeError extends Error");
+    expect(result).toContain("class RelationColumnNotFoundError extends Error");
+  });
+
+  it("should include include-related errors", () => {
+    expect(result).toContain(
+      "class IncludeWithoutRelationsError extends Error",
+    );
+    expect(result).toContain(
+      "class IncludeInvalidOptionTypeError extends Error",
+    );
+    expect(result).toContain(
+      "class IncludeSelectOmitConflictError extends Error",
+    );
+    expect(result).toContain(
+      "class IncludeSelectIncludeConflictError extends Error",
+    );
+  });
+
+  it("should include where relation errors", () => {
+    expect(result).toContain(
+      "class WhereRelationInvalidFilterError extends Error",
+    );
+    expect(result).toContain(
+      "class WhereRelationWithoutContextError extends Error",
+    );
+  });
+
+  it("should include referential action errors", () => {
+    expect(result).toContain(
+      "class RelationOnDeleteRestrictError extends Error",
+    );
+    expect(result).toContain(
+      "class RelationInvalidOnDeleteError extends Error",
+    );
+    expect(result).toContain(
+      "class RelationOnUpdateRestrictError extends Error",
+    );
+    expect(result).toContain(
+      "class RelationInvalidOnUpdateError extends Error",
+    );
+  });
+
+  it("should include nested write errors", () => {
+    expect(result).toContain(
+      "class NestedWriteConnectNotFoundError extends Error",
+    );
+    expect(result).toContain(
+      "class NestedWriteRelationNotFoundError extends Error",
+    );
+    expect(result).toContain(
+      "class NestedWriteInvalidOperationError extends Error",
+    );
+    expect(result).toContain(
+      "class NestedWriteWithoutRelationsError extends Error",
+    );
+  });
+
+  it("should include orderBy errors", () => {
+    expect(result).toContain(
+      "class RelationOrderByUnsupportedTypeError extends Error",
+    );
+    expect(result).toContain(
+      "class RelationOrderByCountUnsupportedTypeError extends Error",
+    );
+  });
+
+  it("should include relation errors from relationError.ts", () => {
+    expect(result).toContain("class GassmaRelationNotFoundError extends Error");
+    expect(result).toContain(
+      "class GassmaTargetSheetNotFoundError extends Error",
+    );
+    expect(result).toContain("class GassmaThroughRequiredError extends Error");
+    expect(result).toContain(
+      "class GassmaIncludeSelectConflictError extends Error",
+    );
+    expect(result).toContain(
+      "class GassmaRelationDuplicateError extends Error",
+    );
+  });
+});

--- a/src/generate/typeGenerate/gassmaErrorClasses.ts
+++ b/src/generate/typeGenerate/gassmaErrorClasses.ts
@@ -1,0 +1,13 @@
+import { errorClassDefinitions } from "./gassmaErrorClasses/errorClassDefinitions";
+
+const getGassmaErrorClasses = () => {
+  return errorClassDefinitions.reduce((pre, def) => {
+    const ctorLine = def.params
+      ? `    constructor(${def.params});\n`
+      : `    constructor();\n`;
+
+    return `${pre}  class ${def.name} extends ${def.extends} {\n${ctorLine}  }\n`;
+  }, "");
+};
+
+export { getGassmaErrorClasses };

--- a/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -1,0 +1,163 @@
+type ErrorClassDef = {
+  name: string;
+  extends: string;
+  params: string;
+};
+
+const errorClassDefinitions: ErrorClassDef[] = [
+  {
+    name: "GassmaSkipNegativeError",
+    extends: "Error",
+    params: "value: number",
+  },
+  {
+    name: "GassmaLimitNegativeError",
+    extends: "Error",
+    params: "value: number",
+  },
+  { name: "NotFoundError", extends: "Error", params: "" },
+  { name: "GassmaFindSelectOmitConflictError", extends: "Error", params: "" },
+  { name: "GassmaInValidColumnValueError", extends: "Error", params: "" },
+  { name: "GassmaGroupByHavingDontWriteByError", extends: "Error", params: "" },
+  { name: "GassmaAggregateMaxError", extends: "Error", params: "" },
+  {
+    name: "GassmaAggregateMinError",
+    extends: "GassmaAggregateMaxError",
+    params: "",
+  },
+  {
+    name: "GassmaAggregateSumError",
+    extends: "GassmaAggregateMaxError",
+    params: "",
+  },
+  {
+    name: "GassmaAggregateAvgError",
+    extends: "GassmaAggregateMaxError",
+    params: "",
+  },
+  { name: "GassmaAggregateTypeError", extends: "Error", params: "" },
+  { name: "GassmaAggregateSumTypeError", extends: "Error", params: "" },
+  {
+    name: "GassmaAggregateAvgTypeError",
+    extends: "GassmaAggregateSumTypeError",
+    params: "",
+  },
+  {
+    name: "RelationSheetNotFoundError",
+    extends: "Error",
+    params: "sheetName: string",
+  },
+  {
+    name: "RelationMissingPropertyError",
+    extends: "Error",
+    params: "sheetName: string, relationName: string, property: string",
+  },
+  {
+    name: "RelationInvalidPropertyTypeError",
+    extends: "Error",
+    params:
+      "sheetName: string, relationName: string, property: string, expectedType: string",
+  },
+  {
+    name: "RelationInvalidTypeError",
+    extends: "Error",
+    params: "sheetName: string, relationName: string, value: string",
+  },
+  {
+    name: "RelationColumnNotFoundError",
+    extends: "Error",
+    params: "sheetName: string, columnName: string",
+  },
+  { name: "IncludeWithoutRelationsError", extends: "Error", params: "" },
+  {
+    name: "IncludeInvalidOptionTypeError",
+    extends: "Error",
+    params: "relationName: string, option: string, expectedType: string",
+  },
+  {
+    name: "IncludeSelectOmitConflictError",
+    extends: "Error",
+    params: "relationName: string",
+  },
+  {
+    name: "IncludeSelectIncludeConflictError",
+    extends: "Error",
+    params: "relationName: string",
+  },
+  {
+    name: "WhereRelationInvalidFilterError",
+    extends: "Error",
+    params: "relationName: string, relationType: string, filterType: string",
+  },
+  { name: "WhereRelationWithoutContextError", extends: "Error", params: "" },
+  {
+    name: "RelationOnDeleteRestrictError",
+    extends: "Error",
+    params: "relationName: string",
+  },
+  {
+    name: "RelationInvalidOnDeleteError",
+    extends: "Error",
+    params: "sheetName: string, relationName: string, value: string",
+  },
+  {
+    name: "RelationOnUpdateRestrictError",
+    extends: "Error",
+    params: "relationName: string",
+  },
+  {
+    name: "RelationInvalidOnUpdateError",
+    extends: "Error",
+    params: "sheetName: string, relationName: string, value: string",
+  },
+  {
+    name: "NestedWriteConnectNotFoundError",
+    extends: "Error",
+    params: "sheetName: string",
+  },
+  {
+    name: "NestedWriteRelationNotFoundError",
+    extends: "Error",
+    params: "fieldName: string",
+  },
+  {
+    name: "NestedWriteInvalidOperationError",
+    extends: "Error",
+    params: "relationName: string, operation: string, relationType: string",
+  },
+  { name: "NestedWriteWithoutRelationsError", extends: "Error", params: "" },
+  {
+    name: "RelationOrderByUnsupportedTypeError",
+    extends: "Error",
+    params: "relationName: string, relationType: string",
+  },
+  {
+    name: "RelationOrderByCountUnsupportedTypeError",
+    extends: "Error",
+    params: "relationName: string, relationType: string",
+  },
+  {
+    name: "GassmaRelationNotFoundError",
+    extends: "Error",
+    params: "relationName: string, sheetName: string",
+  },
+  {
+    name: "GassmaTargetSheetNotFoundError",
+    extends: "Error",
+    params: "targetSheetName: string",
+  },
+  {
+    name: "GassmaThroughRequiredError",
+    extends: "Error",
+    params: "relationName: string",
+  },
+  { name: "GassmaIncludeSelectConflictError", extends: "Error", params: "" },
+  {
+    name: "GassmaRelationDuplicateError",
+    extends: "Error",
+    params: "sheetName: string, field: string, value: unknown",
+  },
+];
+
+export { errorClassDefinitions };
+export type { ErrorClassDef };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -1,4 +1,5 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getGassmaErrorClasses } from "./gassmaErrorClasses";
 
 const getGassmaGlobalOmitConfig = (sheetNames: string[]) => {
   const body = sheetNames.reduce((pre, sheetName) => {
@@ -18,6 +19,8 @@ const getGassmaClientOptions = () => {
 };
 
 const getGassmaMain = (sheetNames: string[]) => {
+  const errorClasses = getGassmaErrorClasses();
+
   const mainTypeDeclare = `declare namespace Gassma {
   class FieldRef {
     readonly modelName: string;
@@ -30,7 +33,8 @@ const getGassmaMain = (sheetNames: string[]) => {
 
     readonly sheets: GassmaSheet;
   }
-}
+
+${errorClasses}}
 
 `;
 


### PR DESCRIPTION
## 概要

gassma 本体で定義されている全 39 エラークラスの型宣言を CLI の生成出力（`declare namespace Gassma` 内）に追加。

- `errorClassDefinitions.ts`: エラークラス定義データ（名前・継承元・コンストラクタ引数）
- `gassmaErrorClasses.ts`: 定義データからクラス宣言文字列を生成
- `gassmaMain.ts`: namespace 内にエラークラスを出力

### 含まれるエラークラス（39 件）

- find 系: `NotFoundError`, `GassmaFindSelectOmitConflictError`, `GassmaSkipNegativeError`, `GassmaLimitNegativeError`, orderBy 系 2 件
- aggregate 系: `GassmaAggregateMaxError` + サブクラス 3 件、`GassmaAggregateTypeError` + サブクラス 2 件
- relation 系: validation 5 件、include 4 件、where 2 件、referential action 4 件、nested write 4 件、その他 5 件
- settings 系: `GassmaInValidColumnValueError`
- groupBy 系: `GassmaGroupByHavingDontWriteByError`

## テスト計画

- [x] 全エラークラスが生成されることを確認（14 tests）
- [x] 継承関係（extends）が正しいことを確認
- [x] 全テスト通過（165 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)