### PR TITLE
生成された.d.tsの型チェックテスト追加

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.2/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { 
+  "files": {
     "includes": ["src/**/*.{js,mjs,cjs,ts,tsx,json,jsonc}"]
   },
   "formatter": { "enabled": true, "indentStyle": "space", "indentWidth": 2 },
@@ -217,6 +217,14 @@
   },
   "overrides": [
     { "includes": ["**/*.{js,mjs,cjs,ts}"] },
+    {
+      "includes": ["src/__test__/typecheck/gassma-stubs.d.ts"],
+      "linter": {
+        "rules": {
+          "style": { "noNamespace": "off" }
+        }
+      }
+    },
     {
       "includes": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
       "linter": {

--- a/src/__test__/typecheck/fixture.prisma
+++ b/src/__test__/typecheck/fixture.prisma
@@ -11,6 +11,8 @@ model User {
   isActive  Boolean  @default(true)
   /// @gassma.addType boolean
   score     Float
+  /// @gassma.addType string, boolean
+  rating    Int?
   createdAt DateTime @default(now())
   posts     Post[]
   profile   Profile?
@@ -19,6 +21,7 @@ model User {
 model Post {
   id        Int      @id @default(autoincrement())
   title     String
+  /// @gassma.addType number
   content   String?
   published Boolean  @default(false)
   authorId  Int

--- a/src/__test__/typecheck/fixture.prisma
+++ b/src/__test__/typecheck/fixture.prisma
@@ -1,0 +1,40 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  age       Int?
+  isActive  Boolean  @default(true)
+  /// @gassma.addType boolean
+  score     Float
+  createdAt DateTime @default(now())
+  posts     Post[]
+  profile   Profile?
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  content   String?
+  published Boolean  @default(false)
+  authorId  Int
+  author    User     @relation(fields: [authorId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  tags      Tag[]
+}
+
+model Profile {
+  id     Int    @id @default(autoincrement())
+  bio    String
+  userId Int    @unique
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Tag {
+  id    Int    @id @default(autoincrement())
+  name  String @unique
+  posts Post[]
+}

--- a/src/__test__/typecheck/gassma-stubs.d.ts
+++ b/src/__test__/typecheck/gassma-stubs.d.ts
@@ -1,4 +1,3 @@
-const gassmaStubs = `
 declare namespace Gassma {
   type RelationsConfig = Record<string, Record<string, unknown>>;
 
@@ -57,6 +56,3 @@ declare namespace Gassma {
   type DeleteManyReturn = ManyReturn;
   type UpsertManyReturn = ManyReturn;
 }
-`;
-
-export { gassmaStubs };

--- a/src/__test__/typecheck/gassmaStubs.ts
+++ b/src/__test__/typecheck/gassmaStubs.ts
@@ -1,0 +1,62 @@
+const gassmaStubs = `
+declare namespace Gassma {
+  type RelationsConfig = Record<string, Record<string, unknown>>;
+
+  type IncludeData = {
+    [relationName: string]: unknown;
+  };
+
+  type CountSelectItem = true | { where?: Record<string, unknown> };
+  type CountSelect = { select: { [relationName: string]: CountSelectItem } };
+  type CountValue = true | CountSelect;
+
+  type NumberOperation = {
+    increment?: number;
+    decrement?: number;
+    multiply?: number;
+    divide?: number;
+  };
+
+  type NestedWriteOperation = {
+    create?: unknown;
+    connect?: unknown;
+    connectOrCreate?: unknown;
+    update?: unknown;
+    delete?: unknown;
+    deleteMany?: unknown;
+    disconnect?: unknown;
+    set?: unknown;
+  };
+
+  type SortOrderInput = {
+    sort: "asc" | "desc";
+    nulls?: "first" | "last";
+  };
+
+  type RelationOrderBy = {
+    [key: string]: "asc" | "desc";
+  };
+
+  type RelationListFilter = {
+    some?: Record<string, unknown>;
+    every?: Record<string, unknown>;
+    none?: Record<string, unknown>;
+  };
+
+  type RelationSingleFilter = {
+    is?: Record<string, unknown>;
+    isNot?: Record<string, unknown>;
+  };
+
+  type ManyReturn = {
+    count: number;
+  };
+
+  type CreateManyReturn = ManyReturn;
+  type UpdateManyReturn = ManyReturn;
+  type DeleteManyReturn = ManyReturn;
+  type UpsertManyReturn = ManyReturn;
+}
+`;
+
+export { gassmaStubs };

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -39,7 +39,16 @@ describe("generated .d.ts type check", () => {
 
       let result = "";
       try {
-        result = execSync(`npx tsc --project ${tsconfigPath} 2>&1`, {
+        const tscPath = path.join(
+          __dirname,
+          "..",
+          "..",
+          "..",
+          "node_modules",
+          ".bin",
+          "tsc",
+        );
+        result = execSync(`${tscPath} --project ${tsconfigPath} 2>&1`, {
           encoding: "utf-8",
           cwd: tmpDir,
         });

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -5,10 +5,10 @@ import os from "os";
 import { generater } from "../../generate/generator";
 import { prismaReader } from "../../generate/read/prismaReader";
 import { extractRelations } from "../../generate/read/extractRelations";
-import { gassmaStubs } from "./gassmaStubs";
 
 describe("generated .d.ts type check", () => {
   const prismaPath = path.join(__dirname, "fixture.prisma");
+  const stubsSourcePath = path.join(__dirname, "gassma-stubs.d.ts");
 
   it("should pass tsc --noEmit without type errors", () => {
     const schemaText = fs.readFileSync(prismaPath, "utf-8");
@@ -22,7 +22,7 @@ describe("generated .d.ts type check", () => {
     const tsconfigPath = path.join(tmpDir, "tsconfig.json");
 
     try {
-      fs.writeFileSync(stubsPath, gassmaStubs);
+      fs.copyFileSync(stubsSourcePath, stubsPath);
       fs.writeFileSync(generatedPath, generated);
       fs.writeFileSync(
         tsconfigPath,

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -37,10 +37,16 @@ describe("generated .d.ts type check", () => {
         }),
       );
 
-      const result = execSync(`npx tsc --project ${tsconfigPath} 2>&1`, {
-        encoding: "utf-8",
-        cwd: tmpDir,
-      });
+      let result = "";
+      try {
+        result = execSync(`npx tsc --project ${tsconfigPath} 2>&1`, {
+          encoding: "utf-8",
+          cwd: tmpDir,
+        });
+      } catch (e) {
+        const error = e as { stdout?: string; stderr?: string };
+        result = error.stdout ?? error.stderr ?? "unknown error";
+      }
 
       expect(result).toBe("");
     } finally {

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -1,0 +1,50 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { generater } from "../../generate/generator";
+import { prismaReader } from "../../generate/read/prismaReader";
+import { extractRelations } from "../../generate/read/extractRelations";
+import { gassmaStubs } from "./gassmaStubs";
+
+describe("generated .d.ts type check", () => {
+  const prismaPath = path.join(__dirname, "fixture.prisma");
+
+  it("should pass tsc --noEmit without type errors", () => {
+    const schemaText = fs.readFileSync(prismaPath, "utf-8");
+    const parsed = prismaReader(schemaText);
+    const relations = extractRelations(schemaText);
+    const generated = generater(parsed, relations);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-typecheck-"));
+    const generatedPath = path.join(tmpDir, "generated.d.ts");
+    const stubsPath = path.join(tmpDir, "gassma-stubs.d.ts");
+    const tsconfigPath = path.join(tmpDir, "tsconfig.json");
+
+    try {
+      fs.writeFileSync(stubsPath, gassmaStubs);
+      fs.writeFileSync(generatedPath, generated);
+      fs.writeFileSync(
+        tsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            strict: true,
+            noEmit: true,
+            skipLibCheck: false,
+            lib: ["ES2021"],
+          },
+          include: ["*.d.ts"],
+        }),
+      );
+
+      const result = execSync(`npx tsc --project ${tsconfigPath} 2>&1`, {
+        encoding: "utf-8",
+        cwd: tmpDir,
+      });
+
+      expect(result).toBe("");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- 生成された `.d.ts` ファイルに型エラーがないことを検証するテストを追加
- fixture.prisma（User, Post, Profile, Tag の4モデル）を用意し、`generater()` で生成 → `tsc --noEmit` で型チェック
- gassma 本体の namespace 型を `.d.ts` スタブファイルとして配置（biome override で namespace ルールを除外）

## Test plan
- [x] `npx jest typecheck` で型チェックテストが通ること
- [x] 全166テストが通ること
- [x] biome チェックが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)