### PR TITLE
共通型をgetGassmaMainで生成する

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -218,14 +218,6 @@
   "overrides": [
     { "includes": ["**/*.{js,mjs,cjs,ts}"] },
     {
-      "includes": ["src/__test__/typecheck/gassma-stubs.d.ts"],
-      "linter": {
-        "rules": {
-          "style": { "noNamespace": "off" }
-        }
-      }
-    },
-    {
       "includes": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
       "linter": {
         "rules": {

--- a/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -1,0 +1,68 @@
+import { getGassmaCommonTypes } from "../../../generate/typeGenerate/gassmaCommonTypes";
+
+describe("getGassmaCommonTypes", () => {
+  const result = getGassmaCommonTypes();
+
+  it("should generate RelationsConfig type", () => {
+    expect(result).toContain("type RelationsConfig =");
+  });
+
+  it("should generate IncludeData type", () => {
+    expect(result).toContain("type IncludeData =");
+  });
+
+  it("should generate CountValue related types", () => {
+    expect(result).toContain("type CountSelectItem =");
+    expect(result).toContain("type CountSelect =");
+    expect(result).toContain("type CountValue =");
+  });
+
+  it("should generate NumberOperation type", () => {
+    expect(result).toContain("type NumberOperation =");
+    expect(result).toContain("increment?: number");
+    expect(result).toContain("decrement?: number");
+    expect(result).toContain("multiply?: number");
+    expect(result).toContain("divide?: number");
+  });
+
+  it("should generate NestedWriteOperation type", () => {
+    expect(result).toContain("type NestedWriteOperation =");
+    expect(result).toContain("create?: unknown");
+    expect(result).toContain("connect?: unknown");
+    expect(result).toContain("connectOrCreate?: unknown");
+    expect(result).toContain("disconnect?: unknown");
+    expect(result).toContain("set?: unknown");
+  });
+
+  it("should generate SortOrderInput type", () => {
+    expect(result).toContain("type SortOrderInput =");
+    expect(result).toContain('sort: "asc" | "desc"');
+    expect(result).toContain('nulls?: "first" | "last"');
+  });
+
+  it("should generate RelationOrderBy type", () => {
+    expect(result).toContain("type RelationOrderBy =");
+  });
+
+  it("should generate RelationListFilter type", () => {
+    expect(result).toContain("type RelationListFilter =");
+    expect(result).toContain("some?:");
+    expect(result).toContain("every?:");
+    expect(result).toContain("none?:");
+  });
+
+  it("should generate RelationSingleFilter type", () => {
+    expect(result).toContain("type RelationSingleFilter =");
+    expect(result).toContain("is?:");
+    expect(result).toContain("isNot?:");
+  });
+
+  it("should generate ManyReturn types", () => {
+    expect(result).toContain("type ManyReturn =");
+    expect(result).toContain("count: number");
+    expect(result).toContain("type CreateManyReturn = ManyReturn");
+    expect(result).toContain("type UpdateManyReturn = ManyReturn");
+    expect(result).toContain("type DeleteManyReturn = ManyReturn");
+    expect(result).toContain("type UpsertManyReturn = ManyReturn");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -42,4 +42,16 @@ describe("getGassmaMain", () => {
 
     expect(result).toContain('"My Sheet"?: GassmaMySheetOmit');
   });
+
+  it("should include common types in namespace", () => {
+    const result = getGassmaMain(["User"]);
+
+    expect(result).toContain("type RelationsConfig =");
+    expect(result).toContain("type NumberOperation =");
+    expect(result).toContain("type ManyReturn =");
+    expect(result).toContain("type NestedWriteOperation =");
+    expect(result).toContain("type SortOrderInput =");
+    expect(result).toContain("type IncludeData =");
+    expect(result).toContain("type CountValue =");
+  });
 });

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -8,7 +8,6 @@ import { extractRelations } from "../../generate/read/extractRelations";
 
 describe("generated .d.ts type check", () => {
   const prismaPath = path.join(__dirname, "fixture.prisma");
-  const stubsSourcePath = path.join(__dirname, "gassma-stubs.d.ts");
 
   it("should pass tsc --noEmit without type errors", () => {
     const schemaText = fs.readFileSync(prismaPath, "utf-8");
@@ -18,11 +17,9 @@ describe("generated .d.ts type check", () => {
 
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-typecheck-"));
     const generatedPath = path.join(tmpDir, "generated.d.ts");
-    const stubsPath = path.join(tmpDir, "gassma-stubs.d.ts");
     const tsconfigPath = path.join(tmpDir, "tsconfig.json");
 
     try {
-      fs.copyFileSync(stubsSourcePath, stubsPath);
       fs.writeFileSync(generatedPath, generated);
       fs.writeFileSync(
         tsconfigPath,

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -1,5 +1,5 @@
-declare namespace Gassma {
-  type RelationsConfig = Record<string, Record<string, unknown>>;
+const getGassmaCommonTypes = () => {
+  return `  type RelationsConfig = Record<string, Record<string, unknown>>;
 
   type IncludeData = {
     [relationName: string]: unknown;
@@ -55,4 +55,7 @@ declare namespace Gassma {
   type UpdateManyReturn = ManyReturn;
   type DeleteManyReturn = ManyReturn;
   type UpsertManyReturn = ManyReturn;
-}
+`;
+};
+
+export { getGassmaCommonTypes };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -1,4 +1,5 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getGassmaCommonTypes } from "./gassmaCommonTypes";
 import { getGassmaErrorClasses } from "./gassmaErrorClasses";
 
 const getGassmaGlobalOmitConfig = (sheetNames: string[]) => {
@@ -20,8 +21,10 @@ const getGassmaClientOptions = () => {
 
 const getGassmaMain = (sheetNames: string[]) => {
   const errorClasses = getGassmaErrorClasses();
+  const commonTypes = getGassmaCommonTypes();
 
   const mainTypeDeclare = `declare namespace Gassma {
+${commonTypes}
   class FieldRef {
     readonly modelName: string;
     readonly name: string;


### PR DESCRIPTION
## Summary
- `getGassmaCommonTypes()` を新規作成し、`RelationsConfig`, `CountValue`, `NumberOperation` 等の共通型を `declare namespace Gassma` 内で生成するように変更
- 外部スタブファイル（`gassma-stubs.d.ts`）を削除し、生成される `.d.ts` が自己完結するように
- 型チェックテストからスタブ依存を除去
- biome の `noNamespace` override も不要になったため削除

## Test plan
- [x] `getGassmaCommonTypes` の単体テスト（10件）
- [x] `getGassmaMain` に共通型が含まれることのテスト
- [x] 型チェックテスト（スタブなしで `tsc --noEmit` 通過）
- [x] 全177テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)