### PR TITLE
複数スキーマの型名衝突を防止するschemaNameプレフィックス追加

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -1,0 +1,24 @@
+import { generateClientDts } from "../../../generate/jsGenerate/generateClientDts";
+
+describe("generateClientDts", () => {
+  it("should declare createGassmaXxxClient function with schema type parameter", () => {
+    const result = generateClientDts("Hoge");
+
+    expect(result).toContain("function createGassmaHogeClient");
+    expect(result).toContain('Gassma.GassmaClient<"Hoge">');
+  });
+
+  it("should accept optional GassmaClientOptions parameter", () => {
+    const result = generateClientDts("Hoge");
+
+    expect(result).toContain("options?: GassmaHogeClientOptions");
+  });
+
+  it("should work with different schema names", () => {
+    const result = generateClientDts("Fuga");
+
+    expect(result).toContain("function createGassmaFugaClient");
+    expect(result).toContain('Gassma.GassmaClient<"Fuga">');
+    expect(result).toContain("options?: GassmaFugaClientOptions");
+  });
+});

--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -1,7 +1,7 @@
 import { generateClientJs } from "../../../generate/jsGenerate/generateClientJs";
 
 describe("generateClientJs", () => {
-  it("should generate JS with embedded relations config", () => {
+  it("should generate JS with embedded relations config and schema name", () => {
     const relations = {
       User: {
         posts: {
@@ -21,23 +21,23 @@ describe("generateClientJs", () => {
       },
     };
 
-    const result = generateClientJs(relations);
+    const result = generateClientJs(relations, "Hoge");
 
-    expect(result).toContain("const relations =");
+    expect(result).toContain("const hogeRelations =");
     expect(result).toContain('"User"');
     expect(result).toContain('"posts"');
     expect(result).toContain('"oneToMany"');
     expect(result).toContain('"Post"');
     expect(result).toContain('"author"');
     expect(result).toContain('"manyToOne"');
-    expect(result).toContain("function createGassmaClient");
+    expect(result).toContain("function createGassmaHogeClient");
   });
 
   it("should generate JS with empty relations when none exist", () => {
-    const result = generateClientJs({});
+    const result = generateClientJs({}, "Hoge");
 
-    expect(result).toContain("const relations = {}");
-    expect(result).toContain("function createGassmaClient");
+    expect(result).toContain("const hogeRelations = {}");
+    expect(result).toContain("function createGassmaHogeClient");
   });
 
   it("should include onDelete and onUpdate when present", () => {
@@ -54,7 +54,7 @@ describe("generateClientJs", () => {
       },
     };
 
-    const result = generateClientJs(relations);
+    const result = generateClientJs(relations, "Hoge");
 
     expect(result).toContain('"onDelete": "Cascade"');
     expect(result).toContain('"onUpdate": "SetNull"');
@@ -77,11 +77,19 @@ describe("generateClientJs", () => {
       },
     };
 
-    const result = generateClientJs(relations);
+    const result = generateClientJs(relations, "Hoge");
 
     expect(result).toContain('"through"');
     expect(result).toContain('"_PostToTag"');
     expect(result).toContain('"postId"');
     expect(result).toContain('"tagId"');
+  });
+
+  it("should pass schemaName to function name", () => {
+    const result = generateClientJs({}, "Fuga");
+
+    expect(result).toContain("const fugaRelations =");
+    expect(result).toContain("function createGassmaFugaClient");
+    expect(result).toContain("new Gassma.GassmaClient(mergedOptions)");
   });
 });

--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -1,7 +1,7 @@
 import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaController/oneGassmaController";
 
 describe("getOneGassmaController", () => {
-  const result = getOneGassmaController("User");
+  const result = getOneGassmaController("", "User");
 
   it("should generate controller class declaration", () => {
     expect(result).toContain("declare class GassmaUserController");

--- a/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
@@ -3,7 +3,7 @@ import type { RelationsConfig } from "../../../generate/read/extractRelations";
 
 describe("getOneGassmaCreate", () => {
   it("should generate CreateData without relations", () => {
-    const result = getOneGassmaCreate("User");
+    const result = getOneGassmaCreate("", "User");
 
     expect(result).toContain("declare type GassmaUserCreateData");
     expect(result).toContain("data: GassmaUserUse");
@@ -21,7 +21,7 @@ describe("getOneGassmaCreate", () => {
       },
     };
 
-    const result = getOneGassmaCreate("User", relations);
+    const result = getOneGassmaCreate("", "User", relations);
 
     expect(result).toContain(
       'data: GassmaUserUse & {\n    "posts"?: Gassma.NestedWriteOperation;\n  }',
@@ -46,20 +46,20 @@ describe("getOneGassmaCreate", () => {
       },
     };
 
-    const result = getOneGassmaCreate("User", relations);
+    const result = getOneGassmaCreate("", "User", relations);
 
     expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
     expect(result).toContain('"profile"?: Gassma.NestedWriteOperation');
   });
 
   it("should include select property", () => {
-    const result = getOneGassmaCreate("User");
+    const result = getOneGassmaCreate("", "User");
 
     expect(result).toContain("select?: GassmaUserSelect;");
   });
 
   it("should include omit property", () => {
-    const result = getOneGassmaCreate("User");
+    const result = getOneGassmaCreate("", "User");
 
     expect(result).toContain("omit?: GassmaUserOmit;");
   });
@@ -76,7 +76,7 @@ describe("getOneGassmaCreate", () => {
       },
     };
 
-    const result = getOneGassmaCreate("User", relations);
+    const result = getOneGassmaCreate("", "User", relations);
 
     expect(result).toContain("data: GassmaUserUse;");
     expect(result).not.toContain("NestedWriteOperation");

--- a/src/__test__/generate/typeGenerate/gassmaDeleteManyData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteManyData.test.ts
@@ -2,19 +2,19 @@ import { getOneGassmaDeleteData } from "../../../generate/typeGenerate/gassmaDel
 
 describe("getOneGassmaDeleteData", () => {
   it("should generate DeleteData type", () => {
-    const result = getOneGassmaDeleteData("User");
+    const result = getOneGassmaDeleteData("", "User");
 
     expect(result).toContain("declare type GassmaUserDeleteData");
   });
 
   it("should include where property", () => {
-    const result = getOneGassmaDeleteData("User");
+    const result = getOneGassmaDeleteData("", "User");
 
     expect(result).toContain("where: GassmaUserWhereUse;");
   });
 
   it("should include limit property", () => {
-    const result = getOneGassmaDeleteData("User");
+    const result = getOneGassmaDeleteData("", "User");
 
     expect(result).toContain("limit?: number;");
   });

--- a/src/__test__/generate/typeGenerate/gassmaDeleteSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteSingleData.test.ts
@@ -2,31 +2,31 @@ import { getOneGassmaDeleteSingleData } from "../../../generate/typeGenerate/gas
 
 describe("getOneGassmaDeleteSingleData", () => {
   it("should generate DeleteSingleData type", () => {
-    const result = getOneGassmaDeleteSingleData("User");
+    const result = getOneGassmaDeleteSingleData("", "User");
 
     expect(result).toContain("declare type GassmaUserDeleteSingleData");
   });
 
   it("should include where property", () => {
-    const result = getOneGassmaDeleteSingleData("User");
+    const result = getOneGassmaDeleteSingleData("", "User");
 
     expect(result).toContain("where: GassmaUserWhereUse;");
   });
 
   it("should include select property", () => {
-    const result = getOneGassmaDeleteSingleData("User");
+    const result = getOneGassmaDeleteSingleData("", "User");
 
     expect(result).toContain("select?: GassmaUserSelect;");
   });
 
   it("should include include property", () => {
-    const result = getOneGassmaDeleteSingleData("User");
+    const result = getOneGassmaDeleteSingleData("", "User");
 
     expect(result).toContain("include?: Gassma.IncludeData;");
   });
 
   it("should include omit property", () => {
-    const result = getOneGassmaDeleteSingleData("User");
+    const result = getOneGassmaDeleteSingleData("", "User");
 
     expect(result).toContain("omit?: GassmaUserOmit;");
   });

--- a/src/__test__/generate/typeGenerate/gassmaFilterConditions.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFilterConditions.test.ts
@@ -3,14 +3,14 @@ import { getOneSheetGassmaFilterConditions } from "../../../generate/typeGenerat
 describe("getOneSheetGassmaFilterConditions", () => {
   it("should include mode property", () => {
     const sheetContent = { id: ["number"] };
-    const result = getOneSheetGassmaFilterConditions(sheetContent, "User");
+    const result = getOneSheetGassmaFilterConditions(sheetContent, "", "User");
 
     expect(result).toContain('mode?: "default" | "insensitive"');
   });
 
   it("should include FieldRef in comparison operators", () => {
     const sheetContent = { id: ["number"] };
-    const result = getOneSheetGassmaFilterConditions(sheetContent, "User");
+    const result = getOneSheetGassmaFilterConditions(sheetContent, "", "User");
 
     expect(result).toContain("equals?: number | Gassma.FieldRef");
     expect(result).toContain("lt?: number | Gassma.FieldRef");

--- a/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
@@ -8,7 +8,7 @@ describe("getOneGassmaFindData", () => {
   };
 
   it("should generate FindData type with where, select, omit, orderBy", () => {
-    const result = getOneGassmaFindData(sheetContent, "User");
+    const result = getOneGassmaFindData(sheetContent, "", "User");
 
     expect(result).toContain("declare type GassmaUserFindData");
     expect(result).toContain("where?: GassmaUserWhereUse");
@@ -18,7 +18,7 @@ describe("getOneGassmaFindData", () => {
   });
 
   it("should include take, skip, and distinct", () => {
-    const result = getOneGassmaFindData(sheetContent, "User");
+    const result = getOneGassmaFindData(sheetContent, "", "User");
 
     expect(result).toContain("take?: number");
     expect(result).toContain("skip?: number");
@@ -26,19 +26,19 @@ describe("getOneGassmaFindData", () => {
   });
 
   it("should include include property", () => {
-    const result = getOneGassmaFindData(sheetContent, "User");
+    const result = getOneGassmaFindData(sheetContent, "", "User");
 
     expect(result).toContain("include?: Gassma.IncludeData");
   });
 
   it("should include cursor property", () => {
-    const result = getOneGassmaFindData(sheetContent, "User");
+    const result = getOneGassmaFindData(sheetContent, "", "User");
 
     expect(result).toContain("cursor?: Partial<GassmaUserUse>;");
   });
 
   it("should include _count property", () => {
-    const result = getOneGassmaFindData(sheetContent, "User");
+    const result = getOneGassmaFindData(sheetContent, "", "User");
 
     expect(result).toContain("_count?: Gassma.CountValue;");
   });

--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -2,7 +2,7 @@ import { getGassmaMain } from "../../../generate/typeGenerate/gassmaMain";
 
 describe("getGassmaMain", () => {
   it("should generate namespace declaration with GassmaClient class", () => {
-    const result = getGassmaMain(["User", "Post"]);
+    const result = getGassmaMain(["User", "Post"], "");
 
     expect(result).toContain("declare namespace Gassma");
     expect(result).toContain("class GassmaClient");
@@ -13,7 +13,7 @@ describe("getGassmaMain", () => {
   });
 
   it("should generate GassmaClientOptions type", () => {
-    const result = getGassmaMain(["User", "Post"]);
+    const result = getGassmaMain(["User", "Post"], "");
 
     expect(result).toContain("declare type GassmaClientOptions");
     expect(result).toContain("id?: string");
@@ -22,7 +22,7 @@ describe("getGassmaMain", () => {
   });
 
   it("should generate GassmaGlobalOmitConfig with model-specific omit", () => {
-    const result = getGassmaMain(["User", "Post"]);
+    const result = getGassmaMain(["User", "Post"], "");
 
     expect(result).toContain("declare type GassmaGlobalOmitConfig");
     expect(result).toContain('"User"?: GassmaUserOmit');
@@ -30,7 +30,7 @@ describe("getGassmaMain", () => {
   });
 
   it("should generate FieldRef class in namespace", () => {
-    const result = getGassmaMain(["User"]);
+    const result = getGassmaMain(["User"], "");
 
     expect(result).toContain("class FieldRef");
     expect(result).toContain("readonly modelName: string");
@@ -38,13 +38,13 @@ describe("getGassmaMain", () => {
   });
 
   it("should handle sheet names with special characters", () => {
-    const result = getGassmaMain(["My Sheet"]);
+    const result = getGassmaMain(["My Sheet"], "");
 
     expect(result).toContain('"My Sheet"?: GassmaMySheetOmit');
   });
 
   it("should include common types in namespace", () => {
-    const result = getGassmaMain(["User"]);
+    const result = getGassmaMain(["User"], "");
 
     expect(result).toContain("type RelationsConfig =");
     expect(result).toContain("type NumberOperation =");

--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -1,32 +1,41 @@
 import { getGassmaMain } from "../../../generate/typeGenerate/gassmaMain";
 
 describe("getGassmaMain", () => {
-  it("should generate namespace declaration with GassmaClient class", () => {
-    const result = getGassmaMain(["User", "Post"], "");
+  it("should generate GassmaClient with type parameter via GassmaClientMap", () => {
+    const result = getGassmaMain(["User", "Post"], "Test");
 
     expect(result).toContain("declare namespace Gassma");
-    expect(result).toContain("class GassmaClient");
+    expect(result).toContain("interface GassmaClientMap");
     expect(result).toContain(
-      "constructor(idOrOptions?: string | GassmaClientOptions)",
+      "class GassmaClient<T extends keyof GassmaClientMap>",
     );
-    expect(result).toContain("readonly sheets: GassmaSheet");
+    expect(result).toContain('GassmaClientMap[T]["sheets"]');
+    expect(result).toContain('GassmaClientMap[T]["options"]');
   });
 
-  it("should generate GassmaClientOptions type", () => {
-    const result = getGassmaMain(["User", "Post"], "");
+  it("should add schema entry to GassmaClientMap", () => {
+    const result = getGassmaMain(["User", "Post"], "Test");
 
-    expect(result).toContain("declare type GassmaClientOptions");
+    expect(result).toContain('"Test": {');
+    expect(result).toContain("sheets: GassmaTestSheet");
+    expect(result).toContain("options: GassmaTestClientOptions");
+  });
+
+  it("should generate GassmaClientOptions type with schema prefix", () => {
+    const result = getGassmaMain(["User", "Post"], "Test");
+
+    expect(result).toContain("declare type GassmaTestClientOptions");
     expect(result).toContain("id?: string");
     expect(result).toContain("relations?: Gassma.RelationsConfig");
-    expect(result).toContain("omit?: GassmaGlobalOmitConfig");
+    expect(result).toContain("omit?: GassmaTestGlobalOmitConfig");
   });
 
   it("should generate GassmaGlobalOmitConfig with model-specific omit", () => {
-    const result = getGassmaMain(["User", "Post"], "");
+    const result = getGassmaMain(["User", "Post"], "Test");
 
-    expect(result).toContain("declare type GassmaGlobalOmitConfig");
-    expect(result).toContain('"User"?: GassmaUserOmit');
-    expect(result).toContain('"Post"?: GassmaPostOmit');
+    expect(result).toContain("declare type GassmaTestGlobalOmitConfig");
+    expect(result).toContain('"User"?: GassmaTestUserOmit');
+    expect(result).toContain('"Post"?: GassmaTestPostOmit');
   });
 
   it("should generate FieldRef class in namespace", () => {
@@ -38,9 +47,9 @@ describe("getGassmaMain", () => {
   });
 
   it("should handle sheet names with special characters", () => {
-    const result = getGassmaMain(["My Sheet"], "");
+    const result = getGassmaMain(["My Sheet"], "Test");
 
-    expect(result).toContain('"My Sheet"?: GassmaMySheetOmit');
+    expect(result).toContain('"My Sheet"?: GassmaTestMySheetOmit');
   });
 
   it("should include common types in namespace", () => {
@@ -53,5 +62,13 @@ describe("getGassmaMain", () => {
     expect(result).toContain("type SortOrderInput =");
     expect(result).toContain("type IncludeData =");
     expect(result).toContain("type CountValue =");
+  });
+
+  it("should exclude common types when includeCommon is false", () => {
+    const result = getGassmaMain(["User"], "Test", false);
+
+    expect(result).not.toContain("class FieldRef");
+    expect(result).not.toContain("type RelationsConfig =");
+    expect(result).toContain("GassmaClientMap");
   });
 });

--- a/src/__test__/generate/typeGenerate/gassmaOrderBy.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaOrderBy.test.ts
@@ -9,19 +9,19 @@ describe("getOneGassmaOrderBy", () => {
   };
 
   it("should generate OrderBy type", () => {
-    const result = getOneGassmaOrderBy(sheetContent, "User");
+    const result = getOneGassmaOrderBy(sheetContent, "", "User");
 
     expect(result).toContain("declare type GassmaUserOrderBy");
   });
 
   it("should support SortOrderInput with nulls option", () => {
-    const result = getOneGassmaOrderBy(sheetContent, "User");
+    const result = getOneGassmaOrderBy(sheetContent, "", "User");
 
     expect(result).toContain('"id"?: "asc" | "desc" | Gassma.SortOrderInput;');
   });
 
   it("should remove question mark from column names", () => {
-    const result = getOneGassmaOrderBy(sheetContent, "User");
+    const result = getOneGassmaOrderBy(sheetContent, "", "User");
 
     expect(result).toContain('"email"?:');
     expect(result).not.toContain('"email?"');
@@ -39,7 +39,7 @@ describe("getOneGassmaOrderBy", () => {
       },
     };
 
-    const result = getOneGassmaOrderBy(sheetContent, "User", relations);
+    const result = getOneGassmaOrderBy(sheetContent, "", "User", relations);
 
     expect(result).toContain('"posts"?: Gassma.RelationOrderBy;');
   });
@@ -56,7 +56,7 @@ describe("getOneGassmaOrderBy", () => {
       },
     };
 
-    const result = getOneGassmaOrderBy(sheetContent, "User", relations);
+    const result = getOneGassmaOrderBy(sheetContent, "", "User", relations);
 
     expect(result).toContain('"_count"?: Gassma.RelationOrderBy;');
   });
@@ -73,7 +73,7 @@ describe("getOneGassmaOrderBy", () => {
       },
     };
 
-    const result = getOneGassmaOrderBy(sheetContent, "User", relations);
+    const result = getOneGassmaOrderBy(sheetContent, "", "User", relations);
 
     expect(result).not.toContain("Gassma.RelationOrderBy");
   });

--- a/src/__test__/generate/typeGenerate/gassmaSheet.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaSheet.test.ts
@@ -2,7 +2,7 @@ import { getGassmaSheet } from "../../../generate/typeGenerate/gassmaSheet";
 
 describe("getGassmaSheet", () => {
   it("should generate controller type mapping for sheet names", () => {
-    const result = getGassmaSheet(["User", "Post"]);
+    const result = getGassmaSheet(["User", "Post"], "");
 
     expect(result).toContain("declare type GassmaSheet = {");
     expect(result).toContain('"User": GassmaUserController;');
@@ -11,13 +11,13 @@ describe("getGassmaSheet", () => {
   });
 
   it("should remove symbols only from variable name part", () => {
-    const result = getGassmaSheet(["my-sheet"]);
+    const result = getGassmaSheet(["my-sheet"], "");
 
     expect(result).toContain('"my-sheet": GassmamysheetController;');
   });
 
   it("should generate empty object type for empty array", () => {
-    const result = getGassmaSheet([]);
+    const result = getGassmaSheet([], "");
 
     expect(result).toBe("declare type GassmaSheet = {\n};\n");
   });

--- a/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
@@ -3,7 +3,7 @@ import type { RelationsConfig } from "../../../generate/read/extractRelations";
 
 describe("getOneGassmaUpdateData", () => {
   it("should generate UpdateData with NumberOperation support", () => {
-    const result = getOneGassmaUpdateData("User");
+    const result = getOneGassmaUpdateData("", "User");
 
     expect(result).toContain("declare type GassmaUserUpdateData");
     expect(result).toContain(
@@ -23,13 +23,13 @@ describe("getOneGassmaUpdateData", () => {
       },
     };
 
-    const result = getOneGassmaUpdateData("User", relations);
+    const result = getOneGassmaUpdateData("", "User", relations);
 
     expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
   });
 
   it("should include limit property", () => {
-    const result = getOneGassmaUpdateData("User");
+    const result = getOneGassmaUpdateData("", "User");
 
     expect(result).toContain("limit?: number;");
   });

--- a/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
@@ -3,19 +3,19 @@ import type { RelationsConfig } from "../../../generate/read/extractRelations";
 
 describe("getOneGassmaUpdateSingleData", () => {
   it("should generate UpdateSingleData type", () => {
-    const result = getOneGassmaUpdateSingleData("User");
+    const result = getOneGassmaUpdateSingleData("", "User");
 
     expect(result).toContain("declare type GassmaUserUpdateSingleData");
   });
 
   it("should include where property", () => {
-    const result = getOneGassmaUpdateSingleData("User");
+    const result = getOneGassmaUpdateSingleData("", "User");
 
     expect(result).toContain("where: GassmaUserWhereUse;");
   });
 
   it("should include data with NumberOperation", () => {
-    const result = getOneGassmaUpdateSingleData("User");
+    const result = getOneGassmaUpdateSingleData("", "User");
 
     expect(result).toContain(
       "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
@@ -23,13 +23,13 @@ describe("getOneGassmaUpdateSingleData", () => {
   });
 
   it("should include select property", () => {
-    const result = getOneGassmaUpdateSingleData("User");
+    const result = getOneGassmaUpdateSingleData("", "User");
 
     expect(result).toContain("select?: GassmaUserSelect;");
   });
 
   it("should include omit property", () => {
-    const result = getOneGassmaUpdateSingleData("User");
+    const result = getOneGassmaUpdateSingleData("", "User");
 
     expect(result).toContain("omit?: GassmaUserOmit;");
   });
@@ -46,7 +46,7 @@ describe("getOneGassmaUpdateSingleData", () => {
       },
     };
 
-    const result = getOneGassmaUpdateSingleData("User", relations);
+    const result = getOneGassmaUpdateSingleData("", "User", relations);
 
     expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
   });

--- a/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
@@ -3,25 +3,25 @@ import type { RelationsConfig } from "../../../generate/read/extractRelations";
 
 describe("getOneGassmaUpsertSingleData", () => {
   it("should generate UpsertSingleData type", () => {
-    const result = getOneGassmaUpsertSingleData("User");
+    const result = getOneGassmaUpsertSingleData("", "User");
 
     expect(result).toContain("declare type GassmaUserUpsertSingleData");
   });
 
   it("should include where property", () => {
-    const result = getOneGassmaUpsertSingleData("User");
+    const result = getOneGassmaUpsertSingleData("", "User");
 
     expect(result).toContain("where: GassmaUserWhereUse;");
   });
 
   it("should include create property", () => {
-    const result = getOneGassmaUpsertSingleData("User");
+    const result = getOneGassmaUpsertSingleData("", "User");
 
     expect(result).toContain("create: GassmaUserUse");
   });
 
   it("should include update with NumberOperation", () => {
-    const result = getOneGassmaUpsertSingleData("User");
+    const result = getOneGassmaUpsertSingleData("", "User");
 
     expect(result).toContain(
       "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
@@ -29,19 +29,19 @@ describe("getOneGassmaUpsertSingleData", () => {
   });
 
   it("should include select property", () => {
-    const result = getOneGassmaUpsertSingleData("User");
+    const result = getOneGassmaUpsertSingleData("", "User");
 
     expect(result).toContain("select?: GassmaUserSelect;");
   });
 
   it("should include include property", () => {
-    const result = getOneGassmaUpsertSingleData("User");
+    const result = getOneGassmaUpsertSingleData("", "User");
 
     expect(result).toContain("include?: Gassma.IncludeData;");
   });
 
   it("should include omit property", () => {
-    const result = getOneGassmaUpsertSingleData("User");
+    const result = getOneGassmaUpsertSingleData("", "User");
 
     expect(result).toContain("omit?: GassmaUserOmit;");
   });
@@ -58,7 +58,7 @@ describe("getOneGassmaUpsertSingleData", () => {
       },
     };
 
-    const result = getOneGassmaUpsertSingleData("User", relations);
+    const result = getOneGassmaUpsertSingleData("", "User", relations);
 
     expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
   });

--- a/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
@@ -8,7 +8,7 @@ describe("getOneGassmaWhereUse", () => {
   };
 
   it("should generate WhereUse without relations", () => {
-    const result = getOneGassmaWhereUse(sheetContent, "User");
+    const result = getOneGassmaWhereUse(sheetContent, "", "User");
 
     expect(result).toContain("declare type GassmaUserWhereUse");
     expect(result).toContain('"id"?:');
@@ -30,7 +30,7 @@ describe("getOneGassmaWhereUse", () => {
       },
     };
 
-    const result = getOneGassmaWhereUse(sheetContent, "User", relations);
+    const result = getOneGassmaWhereUse(sheetContent, "", "User", relations);
 
     expect(result).toContain('"posts"?: Gassma.RelationListFilter');
   });
@@ -47,7 +47,7 @@ describe("getOneGassmaWhereUse", () => {
       },
     };
 
-    const result = getOneGassmaWhereUse(sheetContent, "Post", relations);
+    const result = getOneGassmaWhereUse(sheetContent, "", "Post", relations);
 
     expect(result).toContain('"author"?: Gassma.RelationSingleFilter');
   });
@@ -64,7 +64,7 @@ describe("getOneGassmaWhereUse", () => {
       },
     };
 
-    const result = getOneGassmaWhereUse(sheetContent, "User", relations);
+    const result = getOneGassmaWhereUse(sheetContent, "", "User", relations);
 
     expect(result).toContain('"profile"?: Gassma.RelationSingleFilter');
   });
@@ -81,7 +81,7 @@ describe("getOneGassmaWhereUse", () => {
       },
     };
 
-    const result = getOneGassmaWhereUse(sheetContent, "Post", relations);
+    const result = getOneGassmaWhereUse(sheetContent, "", "Post", relations);
 
     expect(result).toContain('"tags"?: Gassma.RelationListFilter');
   });
@@ -98,7 +98,7 @@ describe("getOneGassmaWhereUse", () => {
       },
     };
 
-    const result = getOneGassmaWhereUse(sheetContent, "User", relations);
+    const result = getOneGassmaWhereUse(sheetContent, "", "User", relations);
 
     expect(result).not.toContain("RelationListFilter");
     expect(result).not.toContain("RelationSingleFilter");

--- a/src/__test__/typecheck/fixture-fuga.prisma
+++ b/src/__test__/typecheck/fixture-fuga.prisma
@@ -1,0 +1,18 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  username  String   @unique
+  age       Int?
+  orders    Order[]
+}
+
+model Order {
+  id        Int      @id @default(autoincrement())
+  amount    Float
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id])
+}

--- a/src/__test__/typecheck/fixture-hoge.prisma
+++ b/src/__test__/typecheck/fixture-hoge.prisma
@@ -1,0 +1,18 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  posts     Post[]
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  authorId  Int
+  author    User     @relation(fields: [authorId], references: [id])
+}

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { generater } from "../../generate/generator";
+import { generateClientDts } from "../../generate/jsGenerate/generateClientDts";
 import { prismaReader } from "../../generate/read/prismaReader";
 import { extractRelations } from "../../generate/read/extractRelations";
 
@@ -89,6 +90,14 @@ describe("generated .d.ts type check", () => {
     try {
       fs.writeFileSync(path.join(tmpDir, "hoge.d.ts"), hogeGenerated);
       fs.writeFileSync(path.join(tmpDir, "fuga.d.ts"), fugaGenerated);
+      fs.writeFileSync(
+        path.join(tmpDir, "hogeClient.d.ts"),
+        generateClientDts("Hoge"),
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "fugaClient.d.ts"),
+        generateClientDts("Fuga"),
+      );
       writeTsconfig(tsconfigPath);
 
       const result = runTsc(tmpDir, tsconfigPath);

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -6,54 +6,92 @@ import { generater } from "../../generate/generator";
 import { prismaReader } from "../../generate/read/prismaReader";
 import { extractRelations } from "../../generate/read/extractRelations";
 
-describe("generated .d.ts type check", () => {
-  const prismaPath = path.join(__dirname, "fixture.prisma");
+const tscPath = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "node_modules",
+  ".bin",
+  "tsc",
+);
 
+const runTsc = (tmpDir: string, tsconfigPath: string): string => {
+  let result = "";
+  try {
+    result = execSync(`${tscPath} --project ${tsconfigPath} 2>&1`, {
+      encoding: "utf-8",
+      cwd: tmpDir,
+    });
+  } catch (e) {
+    const error = e as { stdout?: string; stderr?: string };
+    result = error.stdout ?? error.stderr ?? "unknown error";
+  }
+  return result;
+};
+
+const writeTsconfig = (tsconfigPath: string) => {
+  fs.writeFileSync(
+    tsconfigPath,
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        skipLibCheck: false,
+        lib: ["ES2021"],
+      },
+      include: ["*.d.ts"],
+    }),
+  );
+};
+
+const generateFromPrisma = (
+  prismaPath: string,
+  schemaName?: string,
+  includeCommon?: boolean,
+): string => {
+  const schemaText = fs.readFileSync(prismaPath, "utf-8");
+  const parsed = prismaReader(schemaText);
+  const relations = extractRelations(schemaText);
+  return generater(parsed, relations, schemaName, includeCommon);
+};
+
+describe("generated .d.ts type check", () => {
   it("should pass tsc --noEmit without type errors", () => {
-    const schemaText = fs.readFileSync(prismaPath, "utf-8");
-    const parsed = prismaReader(schemaText);
-    const relations = extractRelations(schemaText);
-    const generated = generater(parsed, relations);
+    const prismaPath = path.join(__dirname, "fixture.prisma");
+    const generated = generateFromPrisma(prismaPath);
 
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-typecheck-"));
-    const generatedPath = path.join(tmpDir, "generated.d.ts");
     const tsconfigPath = path.join(tmpDir, "tsconfig.json");
 
     try {
-      fs.writeFileSync(generatedPath, generated);
-      fs.writeFileSync(
-        tsconfigPath,
-        JSON.stringify({
-          compilerOptions: {
-            strict: true,
-            noEmit: true,
-            skipLibCheck: false,
-            lib: ["ES2021"],
-          },
-          include: ["*.d.ts"],
-        }),
-      );
+      fs.writeFileSync(path.join(tmpDir, "generated.d.ts"), generated);
+      writeTsconfig(tsconfigPath);
 
-      let result = "";
-      try {
-        const tscPath = path.join(
-          __dirname,
-          "..",
-          "..",
-          "..",
-          "node_modules",
-          ".bin",
-          "tsc",
-        );
-        result = execSync(`${tscPath} --project ${tsconfigPath} 2>&1`, {
-          encoding: "utf-8",
-          cwd: tmpDir,
-        });
-      } catch (e) {
-        const error = e as { stdout?: string; stderr?: string };
-        result = error.stdout ?? error.stderr ?? "unknown error";
-      }
+      const result = runTsc(tmpDir, tsconfigPath);
+      expect(result).toBe("");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 
+  it("should not collide when multiple schemas have the same model name", () => {
+    const hogePath = path.join(__dirname, "fixture-hoge.prisma");
+    const fugaPath = path.join(__dirname, "fixture-fuga.prisma");
+    const hogeGenerated = generateFromPrisma(hogePath, "Hoge");
+    const fugaGenerated = generateFromPrisma(fugaPath, "Fuga", false);
+
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "gassma-typecheck-multi-"),
+    );
+    const tsconfigPath = path.join(tmpDir, "tsconfig.json");
+
+    try {
+      fs.writeFileSync(path.join(tmpDir, "hoge.d.ts"), hogeGenerated);
+      fs.writeFileSync(path.join(tmpDir, "fuga.d.ts"), fugaGenerated);
+      writeTsconfig(tsconfigPath);
+
+      const result = runTsc(tmpDir, tsconfigPath);
       expect(result).toBe("");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -29,6 +29,8 @@ function generate(customDir?: string) {
     `📁 Found ${prismaFiles.length} .prisma file(s) in ${path.basename(gassmaDir)} directory`,
   );
 
+  const commonWritten = new Set<string>();
+
   prismaFiles.forEach((file) => {
     const filePath = path.join(gassmaDir, file);
     console.log(`  📄 Processing: ${file}`);
@@ -44,8 +46,16 @@ function generate(customDir?: string) {
 
     const parsed = prismaReader(schemaText);
     const relations = extractRelations(schemaText);
-    const resultString = generater(parsed, relations);
     const baseName = path.basename(file, ".prisma");
+    const schemaName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
+    const includeCommon = !commonWritten.has(outputPath);
+    commonWritten.add(outputPath);
+    const resultString = generater(
+      parsed,
+      relations,
+      schemaName,
+      includeCommon,
+    );
     writer(resultString, baseName, outputPath);
     const clientJs = generateClientJs(relations);
     jsWriter(clientJs, "client", outputPath);

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { generater } from "./generator";
+import { generateClientDts } from "./jsGenerate/generateClientDts";
 import { generateClientJs } from "./jsGenerate/generateClientJs";
 import { extractOutputPath } from "./read/extractOutputPath";
 import { extractRelations } from "./read/extractRelations";
@@ -57,8 +58,10 @@ function generate(customDir?: string) {
       includeCommon,
     );
     writer(resultString, baseName, outputPath);
-    const clientJs = generateClientJs(relations);
-    jsWriter(clientJs, "client", outputPath);
+    const clientJs = generateClientJs(relations, schemaName);
+    jsWriter(clientJs, `${baseName}Client`, outputPath);
+    const clientDts = generateClientDts(schemaName);
+    writer(clientDts, `${baseName}Client`, outputPath);
   });
 
   console.log(`✅ Generated ${prismaFiles.length} type definition file(s)`);

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -38,44 +38,49 @@ import type { RelationsConfig } from "./read/extractRelations";
 const generater = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   relations?: RelationsConfig,
+  schemaName?: string,
+  includeCommon?: boolean,
 ) => {
+  const schema = schemaName ?? "";
   const sheetNames = Object.keys(dictYaml);
-  let result = getGassmaMain(sheetNames);
+  let result = getGassmaMain(sheetNames, schema, includeCommon);
 
-  result += getGassmaSheet(sheetNames);
-  result += getGassmaController(sheetNames);
-  result += getGassmaManyCount();
-  result += getGassmaAnyUse(dictYaml);
-  result += getGassmaCreate(sheetNames, relations);
-  result += getGassmaCreateMany(sheetNames);
-  result += getGassmaFilterCoditions(dictYaml);
-  result += getGassmaWhereUse(dictYaml, relations);
-  result += getGassmaHavingCore(dictYaml);
-  result += getGassmaHavingUse(dictYaml);
-  result += getGassmaFindData(dictYaml);
-  result += getGassmaFindManyData(sheetNames);
-  result += getGassmaUpdateData(sheetNames, relations);
-  result += getGassmaUpdateSingleData(sheetNames, relations);
-  result += getGassmaUpsertData(sheetNames);
-  result += getGassmaUpsertSingleData(sheetNames, relations);
-  result += getGassmaDeleteData(sheetNames);
-  result += getGassmaDeleteSingleData(sheetNames);
-  result += getGassmaAggregateData(sheetNames);
-  result += getGassmaGroupByData(dictYaml);
-  result += getGassmaOrderBy(dictYaml, relations);
-  result += getGassmaSelect(dictYaml);
-  result += getGassmaOmit(dictYaml);
-  result += getGassmaCountData(sheetNames);
-  result += getGassmaCreateReturn(dictYaml);
-  result += getGassmaDefaultFindResult(sheetNames);
-  result += getGassmaFindResult(sheetNames);
-  result += getGassmaAggregateBaseReturn(dictYaml);
-  result += getGassmaAggregateField(sheetNames);
-  result += getGassmaAggregateResult(sheetNames);
-  result += getGassmaGroupByBaseReturn(sheetNames);
-  result += getGassmaGroupByKeyOfBaseReturn(sheetNames);
-  result += getGassmaByField(sheetNames);
-  result += getGassmaGroupByResult(sheetNames);
+  result += getGassmaSheet(sheetNames, schema);
+  result += getGassmaController(sheetNames, schema);
+  if (includeCommon !== false) {
+    result += getGassmaManyCount();
+  }
+  result += getGassmaAnyUse(dictYaml, schema);
+  result += getGassmaCreate(sheetNames, schema, relations);
+  result += getGassmaCreateMany(sheetNames, schema);
+  result += getGassmaFilterCoditions(dictYaml, schema);
+  result += getGassmaWhereUse(dictYaml, schema, relations);
+  result += getGassmaHavingCore(dictYaml, schema);
+  result += getGassmaHavingUse(dictYaml, schema);
+  result += getGassmaFindData(dictYaml, schema);
+  result += getGassmaFindManyData(sheetNames, schema);
+  result += getGassmaUpdateData(sheetNames, schema, relations);
+  result += getGassmaUpdateSingleData(sheetNames, schema, relations);
+  result += getGassmaUpsertData(sheetNames, schema);
+  result += getGassmaUpsertSingleData(sheetNames, schema, relations);
+  result += getGassmaDeleteData(sheetNames, schema);
+  result += getGassmaDeleteSingleData(sheetNames, schema);
+  result += getGassmaAggregateData(sheetNames, schema);
+  result += getGassmaGroupByData(dictYaml, schema);
+  result += getGassmaOrderBy(dictYaml, schema, relations);
+  result += getGassmaSelect(dictYaml, schema);
+  result += getGassmaOmit(dictYaml, schema);
+  result += getGassmaCountData(sheetNames, schema);
+  result += getGassmaCreateReturn(dictYaml, schema);
+  result += getGassmaDefaultFindResult(sheetNames, schema);
+  result += getGassmaFindResult(sheetNames, schema);
+  result += getGassmaAggregateBaseReturn(dictYaml, schema);
+  result += getGassmaAggregateField(sheetNames, schema);
+  result += getGassmaAggregateResult(sheetNames, schema);
+  result += getGassmaGroupByBaseReturn(sheetNames, schema);
+  result += getGassmaGroupByKeyOfBaseReturn(sheetNames, schema);
+  result += getGassmaByField(sheetNames, schema);
+  result += getGassmaGroupByResult(sheetNames, schema);
 
   return result;
 };

--- a/src/generate/jsGenerate/generateClientDts.ts
+++ b/src/generate/jsGenerate/generateClientDts.ts
@@ -1,0 +1,6 @@
+const generateClientDts = (schemaName: string): string => {
+  return `declare function createGassma${schemaName}Client(options?: Gassma${schemaName}ClientOptions): Gassma.GassmaClient<"${schemaName}">;
+`;
+};
+
+export { generateClientDts };

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -1,15 +1,19 @@
 import type { RelationsConfig } from "../read/extractRelations";
 
-const generateClientJs = (relations: RelationsConfig): string => {
+const generateClientJs = (
+  relations: RelationsConfig,
+  schemaName: string,
+): string => {
+  const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
     Object.keys(relations).length === 0
       ? "{}"
       : JSON.stringify(relations, null, 2);
 
-  return `const relations = ${relationsJson};
+  return `const ${lowerName}Relations = ${relationsJson};
 
-function createGassmaClient(options) {
-  const mergedOptions = Object.assign({}, options, { relations: relations });
+function createGassma${schemaName}Client(options) {
+  var mergedOptions = Object.assign({}, options, { relations: ${lowerName}Relations });
   return new Gassma.GassmaClient(mergedOptions);
 }
 `;

--- a/src/generate/typeGenerate/gassmaAggregateBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaAggregateBaseReturn.ts
@@ -3,6 +3,7 @@ import { getOneGassmaAggregateBaseReturn } from "./gassmaAggregateBaseReturn/one
 
 const getGassmaAggregateBaseReturn = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const aggregateBaseReturnTypeDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -14,6 +15,7 @@ const getGassmaAggregateBaseReturn = (
         pre +
         getOneGassmaAggregateBaseReturn(
           sheetContent,
+          schemaName,
           removedSpaceCurrentSheetName,
         )
       );

--- a/src/generate/typeGenerate/gassmaAggregateBaseReturn/oneGassmaAggregateBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaAggregateBaseReturn/oneGassmaAggregateBaseReturn.ts
@@ -3,6 +3,7 @@ import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
 
 const getOneGassmaAggregateBaseReturn = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const oneAggregateBaseReturn = Object.keys(sheetContent).reduce(
@@ -19,7 +20,7 @@ const getOneGassmaAggregateBaseReturn = (
     "",
   );
 
-  return `\ndeclare type Gassma${sheetName}AggregateBaseReturn = {
+  return `\ndeclare type Gassma${schemaName}${sheetName}AggregateBaseReturn = {
 ${oneAggregateBaseReturn}};
 `;
 };

--- a/src/generate/typeGenerate/gassmaAggregateData.ts
+++ b/src/generate/typeGenerate/gassmaAggregateData.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaAggregateData } from "./gassmaAggregateData/oneGassmaAggregateData";
 
-const getGassmaAggregateData = (sheetNames: string[]) => {
+const getGassmaAggregateData = (sheetNames: string[], schemaName: string) => {
   const aggregateDstaDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaAggregateData(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaAggregateData(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return aggregateDstaDeclare;

--- a/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
+++ b/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
@@ -1,15 +1,15 @@
-const getOneGassmaAggregateData = (sheetName: string) => {
+const getOneGassmaAggregateData = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}AggregateData = {
-  where?: Gassma${sheetName}WhereUse;
-  orderBy?: Gassma${sheetName}OrderBy;
+declare type Gassma${schemaName}${sheetName}AggregateData = {
+  where?: Gassma${schemaName}${sheetName}WhereUse;
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy;
   take?: number;
   skip?: number;
-  _avg?: Gassma${sheetName}Select;
-  _count?: Gassma${sheetName}Select;
-  _max?: Gassma${sheetName}Select;
-  _min?: Gassma${sheetName}Select;
-  _sum?: Gassma${sheetName}Select;
+  _avg?: Gassma${schemaName}${sheetName}Select;
+  _count?: Gassma${schemaName}${sheetName}Select;
+  _max?: Gassma${schemaName}${sheetName}Select;
+  _min?: Gassma${schemaName}${sheetName}Select;
+  _sum?: Gassma${schemaName}${sheetName}Select;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaAggregateField.ts
+++ b/src/generate/typeGenerate/gassmaAggregateField.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaAggregateField } from "./gassmaAggregateField/oneGassmaAggregateField";
 
-const getGassmaAggregateField = (sheetNames: string[]) => {
+const getGassmaAggregateField = (sheetNames: string[], schemaName: string) => {
   const aggregateFiledDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaAggregateField(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaAggregateField(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return aggregateFiledDeclare;

--- a/src/generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField.ts
+++ b/src/generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField.ts
@@ -1,13 +1,13 @@
-const getOneGassmaAggregateField = (sheetName: string) => {
+const getOneGassmaAggregateField = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}AggregateField<T, K extends string> = T extends undefined
+declare type Gassma${schemaName}${sheetName}AggregateField<T, K extends string> = T extends undefined
   ? never
   : K extends "_count"
     ? { [P in keyof T as T[P] extends true ? P : never]: number }
     : {
         [P in keyof T as T[P] extends true
-          ? P & keyof Gassma${sheetName}AggregateBaseReturn
-          : never]: Gassma${sheetName}AggregateBaseReturn[P & keyof Gassma${sheetName}AggregateBaseReturn];
+          ? P & keyof Gassma${schemaName}${sheetName}AggregateBaseReturn
+          : never]: Gassma${schemaName}${sheetName}AggregateBaseReturn[P & keyof Gassma${schemaName}${sheetName}AggregateBaseReturn];
       };
 `;
 };

--- a/src/generate/typeGenerate/gassmaAggregateResult.ts
+++ b/src/generate/typeGenerate/gassmaAggregateResult.ts
@@ -1,12 +1,15 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaAggregateResult } from "./gassmaAggregateResult/oneGassmaAggregateResult";
 
-const getGassmaAggregateResult = (sheetNames: string[]) => {
+const getGassmaAggregateResult = (sheetNames: string[], schemaName: string) => {
   const aggregateResultDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaAggregateResult(removedSpaceCurrentSheetName);
+    return (
+      pre +
+      getOneGassmaAggregateResult(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return aggregateResultDeclare;

--- a/src/generate/typeGenerate/gassmaAggregateResult/oneGassmaAggregateResult.ts
+++ b/src/generate/typeGenerate/gassmaAggregateResult/oneGassmaAggregateResult.ts
@@ -1,11 +1,11 @@
-const getOneGassmaAggregateResult = (sheetName: string) => {
+const getOneGassmaAggregateResult = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}AggregateResult<T extends Gassma${sheetName}AggregateData> = {
+declare type Gassma${schemaName}${sheetName}AggregateResult<T extends Gassma${schemaName}${sheetName}AggregateData> = {
   [K in keyof T as K extends "_avg" | "_count" | "_max" | "_min" | "_sum"
     ? T[K] extends undefined
       ? never
       : K
-    : never]: K extends string ? Gassma${sheetName}AggregateField<T[K], K> : never;
+    : never]: K extends string ? Gassma${schemaName}${sheetName}AggregateField<T[K], K> : never;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaAnyUse.ts
+++ b/src/generate/typeGenerate/gassmaAnyUse.ts
@@ -3,6 +3,7 @@ import { getOneGassmaAnyUse } from "./gassmaAnyUse/oneGassmaAnyUse";
 
 const getGassmaAnyUse = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const anyUseTypeDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -11,7 +12,12 @@ const getGassmaAnyUse = (
         getRemovedCantUseVarChar(currentSheetName);
 
       return (
-        pre + getOneGassmaAnyUse(sheetContent, removedSpaceCurrentSheetName)
+        pre +
+        getOneGassmaAnyUse(
+          sheetContent,
+          schemaName,
+          removedSpaceCurrentSheetName,
+        )
       );
     },
     "",

--- a/src/generate/typeGenerate/gassmaAnyUse/oneGassmaAnyUse.ts
+++ b/src/generate/typeGenerate/gassmaAnyUse/oneGassmaAnyUse.ts
@@ -2,6 +2,7 @@ import { getColumnType } from "../../util/getColumnType";
 
 const getOneGassmaAnyUse = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const oneAnyUse = Object.keys(sheetContent).reduce((pre, columnName) => {
@@ -18,7 +19,7 @@ const getOneGassmaAnyUse = (
       : `"${removedQuestionMark}"`;
 
     return `${pre}  ${insertColumnName}: ${now};\n`;
-  }, `\ndeclare type Gassma${sheetName}Use = {\n`);
+  }, `\ndeclare type Gassma${schemaName}${sheetName}Use = {\n`);
 
   return `${oneAnyUse}};\n`;
 };

--- a/src/generate/typeGenerate/gassmaByField.ts
+++ b/src/generate/typeGenerate/gassmaByField.ts
@@ -1,12 +1,12 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaByField } from "./gassmaByField/oneGassmaByField";
 
-const getGassmaByField = (sheetNames: string[]) => {
+const getGassmaByField = (sheetNames: string[], schemaName: string) => {
   const byFieldDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentColumnName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaByField(removedSpaceCurrentColumnName);
+    return pre + getOneGassmaByField(schemaName, removedSpaceCurrentColumnName);
   }, "");
 
   return byFieldDeclare;

--- a/src/generate/typeGenerate/gassmaByField/oneGassmaByField.ts
+++ b/src/generate/typeGenerate/gassmaByField/oneGassmaByField.ts
@@ -1,12 +1,12 @@
-const getOneGassmaByField = (sheetName: string) => {
+const getOneGassmaByField = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}ByField<T extends Gassma${sheetName}GroupByKeyOfBaseReturn | Gassma${sheetName}GroupByKeyOfBaseReturn[]> =
-  T extends Gassma${sheetName}GroupByKeyOfBaseReturn[]
+declare type Gassma${schemaName}${sheetName}ByField<T extends Gassma${schemaName}${sheetName}GroupByKeyOfBaseReturn | Gassma${schemaName}${sheetName}GroupByKeyOfBaseReturn[]> =
+  T extends Gassma${schemaName}${sheetName}GroupByKeyOfBaseReturn[]
     ? {
-        [K in T[number]]: Gassma${sheetName}GroupByBaseReturn[K & keyof Gassma${sheetName}GroupByBaseReturn];
+        [K in T[number]]: Gassma${schemaName}${sheetName}GroupByBaseReturn[K & keyof Gassma${schemaName}${sheetName}GroupByBaseReturn];
       }
-    : T extends keyof Gassma${sheetName}GroupByBaseReturn
-      ? { [K in T]: Gassma${sheetName}GroupByBaseReturn[K] }
+    : T extends keyof Gassma${schemaName}${sheetName}GroupByBaseReturn
+      ? { [K in T]: Gassma${schemaName}${sheetName}GroupByBaseReturn[K] }
       : never;
 `;
 };

--- a/src/generate/typeGenerate/gassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaController } from "./gassmaController/oneGassmaController";
 
-const getGassmaController = (sheetNames: string[]) => {
+const getGassmaController = (sheetNames: string[], schemaName: string) => {
   const controllerTypeDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaController(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaController(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return controllerTypeDeclare;

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -1,6 +1,6 @@
-const getOneGassmaController = (sheetName: string) => {
+const getOneGassmaController = (schemaName: string, sheetName: string) => {
   return `
-declare class Gassma${sheetName}Controller {
+declare class Gassma${schemaName}${sheetName}Controller {
   constructor(sheetName: string, id?: string);
 
   readonly fields: Record<string, Gassma.FieldRef>;
@@ -9,22 +9,22 @@ declare class Gassma${sheetName}Controller {
     startColumnNumber: number,
     endColumnNumber: number
   ): void;
-  createMany(createdData: Gassma${sheetName}CreateManyData): CreateManyReturn;
-  createManyAndReturn(createdData: Gassma${sheetName}CreateManyData): Record<string, unknown>[];
-  create<T extends Gassma${sheetName}CreateData>(createdData: T): Gassma${sheetName}FindResult<T["select"]>;
-  findFirst<T extends Gassma${sheetName}FindData>(findData: T): Gassma${sheetName}FindResult<T["select"]> | null;
-  findFirstOrThrow<T extends Gassma${sheetName}FindData>(findData: T): Gassma${sheetName}FindResult<T["select"]>;
-  findMany<T extends Gassma${sheetName}FindManyData>(findData: T): Gassma${sheetName}FindResult<T["select"]>[];
-  update<T extends Gassma${sheetName}UpdateSingleData>(updateData: T): Gassma${sheetName}FindResult<T["select"]> | null;
-  updateMany(updateData: Gassma${sheetName}UpdateData): UpdateManyReturn;
-  updateManyAndReturn(updateData: Gassma${sheetName}UpdateData): Record<string, unknown>[];
-  upsert<T extends Gassma${sheetName}UpsertSingleData>(upsertData: T): Gassma${sheetName}FindResult<T["select"]>;
-  upsertMany(upsertData: Gassma${sheetName}UpsertData): UpsertManyReturn;
-  delete<T extends Gassma${sheetName}DeleteSingleData>(deleteData: T): Gassma${sheetName}FindResult<T["select"]> | null;
-  deleteMany(deleteData: Gassma${sheetName}DeleteData): DeleteManyReturn;
-  aggregate<T extends Gassma${sheetName}AggregateData>(aggregateData: T): Gassma${sheetName}AggregateResult<T>;
-  count(coutData: Gassma${sheetName}CountData): number;
-  groupBy<T extends Gassma${sheetName}GroupByData>(groupByData: T): Gassma${sheetName}GroupByResult<T>[];
+  createMany(createdData: Gassma${schemaName}${sheetName}CreateManyData): CreateManyReturn;
+  createManyAndReturn(createdData: Gassma${schemaName}${sheetName}CreateManyData): Record<string, unknown>[];
+  create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]>;
+  findFirst<T extends Gassma${schemaName}${sheetName}FindData>(findData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]> | null;
+  findFirstOrThrow<T extends Gassma${schemaName}${sheetName}FindData>(findData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]>;
+  findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]>[];
+  update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]> | null;
+  updateMany(updateData: Gassma${schemaName}${sheetName}UpdateData): UpdateManyReturn;
+  updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): Record<string, unknown>[];
+  upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]>;
+  upsertMany(upsertData: Gassma${schemaName}${sheetName}UpsertData): UpsertManyReturn;
+  delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]> | null;
+  deleteMany(deleteData: Gassma${schemaName}${sheetName}DeleteData): DeleteManyReturn;
+  aggregate<T extends Gassma${schemaName}${sheetName}AggregateData>(aggregateData: T): Gassma${schemaName}${sheetName}AggregateResult<T>;
+  count(coutData: Gassma${schemaName}${sheetName}CountData): number;
+  groupBy<T extends Gassma${schemaName}${sheetName}GroupByData>(groupByData: T): Gassma${schemaName}${sheetName}GroupByResult<T>[];
 }
 `;
 };

--- a/src/generate/typeGenerate/gassmaCountData.ts
+++ b/src/generate/typeGenerate/gassmaCountData.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaCountData } from "./gassmaCountData/oneGassmaCountData";
 
-const getGassmaCountData = (sheetNames: string[]) => {
+const getGassmaCountData = (sheetNames: string[], schemaName: string) => {
   const countDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaCountData(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaCountData(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return countDataDeclare;

--- a/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
+++ b/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
@@ -1,8 +1,8 @@
-const getOneGassmaCountData = (sheetName: string) => {
+const getOneGassmaCountData = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}CountData = {
-  where?: Gassma${sheetName}WhereUse;
-  orderBy?: Gassma${sheetName}OrderBy;
+declare type Gassma${schemaName}${sheetName}CountData = {
+  where?: Gassma${schemaName}${sheetName}WhereUse;
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy;
   take?: number;
   skip?: number;
 };

--- a/src/generate/typeGenerate/gassmaCreate.ts
+++ b/src/generate/typeGenerate/gassmaCreate.ts
@@ -2,12 +2,19 @@ import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaCreate } from "./gassmaCreate/oneGassmaCreate";
 import type { RelationsConfig } from "../read/extractRelations";
 
-const getGassmaCreate = (sheetNames: string[], relations?: RelationsConfig) => {
+const getGassmaCreate = (
+  sheetNames: string[],
+  schemaName: string,
+  relations?: RelationsConfig,
+) => {
   const createTypeDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaCreate(removedSpaceCurrentSheetName, relations);
+    return (
+      pre +
+      getOneGassmaCreate(schemaName, removedSpaceCurrentSheetName, relations)
+    );
   }, "");
 
   return createTypeDeclare;

--- a/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
+++ b/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
@@ -1,17 +1,21 @@
 import type { RelationsConfig } from "../../read/extractRelations";
 import { getNestedWriteFields } from "../util/getNestedWriteFields";
 
-const getOneGassmaCreate = (sheetName: string, relations?: RelationsConfig) => {
+const getOneGassmaCreate = (
+  schemaName: string,
+  sheetName: string,
+  relations?: RelationsConfig,
+) => {
   const nestedFields = getNestedWriteFields(sheetName, relations);
   const dataType = nestedFields
-    ? `Gassma${sheetName}Use & {\n${nestedFields}  }`
-    : `Gassma${sheetName}Use`;
+    ? `Gassma${schemaName}${sheetName}Use & {\n${nestedFields}  }`
+    : `Gassma${schemaName}${sheetName}Use`;
 
   return `
-declare type Gassma${sheetName}CreateData = {
+declare type Gassma${schemaName}${sheetName}CreateData = {
   data: ${dataType};
-  select?: Gassma${sheetName}Select;
-  omit?: Gassma${sheetName}Omit;
+  select?: Gassma${schemaName}${sheetName}Select;
+  omit?: Gassma${schemaName}${sheetName}Omit;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaCreateMany.ts
+++ b/src/generate/typeGenerate/gassmaCreateMany.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaCreateMany } from "./gassmaCreateMany/oneGassmaCreateMany";
 
-const getGassmaCreateMany = (sheetNames: string[]) => {
+const getGassmaCreateMany = (sheetNames: string[], schemaName: string) => {
   const createManyTypeDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaCreateMany(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaCreateMany(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return createManyTypeDeclare;

--- a/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany.ts
+++ b/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany.ts
@@ -1,7 +1,7 @@
-const getOneGassmaCreateMany = (sheetName: string) => {
+const getOneGassmaCreateMany = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}CreateManyData = {
-  data: Gassma${sheetName}Use[];
+declare type Gassma${schemaName}${sheetName}CreateManyData = {
+  data: Gassma${schemaName}${sheetName}Use[];
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaCreateReturn.ts
+++ b/src/generate/typeGenerate/gassmaCreateReturn.ts
@@ -3,6 +3,7 @@ import { getOneGassmaCreateReturn } from "./gassmaCreateReturn/oneGassmaCreateRe
 
 const getGassmaCreateReturn = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const createReturnTypeDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -12,7 +13,11 @@ const getGassmaCreateReturn = (
 
       return (
         pre +
-        getOneGassmaCreateReturn(sheetContent, removedSpaceCurrentSheetName)
+        getOneGassmaCreateReturn(
+          sheetContent,
+          schemaName,
+          removedSpaceCurrentSheetName,
+        )
       );
     },
     "",

--- a/src/generate/typeGenerate/gassmaCreateReturn/oneGassmaCreateReturn.ts
+++ b/src/generate/typeGenerate/gassmaCreateReturn/oneGassmaCreateReturn.ts
@@ -2,6 +2,7 @@ import { getColumnType } from "../../util/getColumnType";
 
 const getOneGassmaCreateReturn = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const oneCreateReturn = Object.keys(sheetContent).reduce(
@@ -17,7 +18,7 @@ const getOneGassmaCreateReturn = (
 
       return `${pre} "${removedQuestionMark}": ${now}${isQuestionMark ? " | null" : ""};\n`;
     },
-    `\ndeclare type Gassma${sheetName}CreateReturn = {\n`,
+    `\ndeclare type Gassma${schemaName}${sheetName}CreateReturn = {\n`,
   );
 
   return `${oneCreateReturn}};\n`;

--- a/src/generate/typeGenerate/gassmaDefaultFindResult.ts
+++ b/src/generate/typeGenerate/gassmaDefaultFindResult.ts
@@ -1,12 +1,18 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaDefaultFindResult } from "./gassmaDefaultFindResult/oneGassmaDefaultFindResult";
 
-const getGassmaDefaultFindResult = (sheetNames: string[]) => {
+const getGassmaDefaultFindResult = (
+  sheetNames: string[],
+  schemaName: string,
+) => {
   const defaultFindResult = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaDefaultFindResult(removedSpaceCurrentSheetName);
+    return (
+      pre +
+      getOneGassmaDefaultFindResult(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return defaultFindResult;

--- a/src/generate/typeGenerate/gassmaDefaultFindResult/oneGassmaDefaultFindResult.ts
+++ b/src/generate/typeGenerate/gassmaDefaultFindResult/oneGassmaDefaultFindResult.ts
@@ -1,6 +1,9 @@
-const getOneGassmaDefaultFindResult = (sheetName: string) => {
+const getOneGassmaDefaultFindResult = (
+  schemaName: string,
+  sheetName: string,
+) => {
   return `
-declare type Gassma${sheetName}DefaultFindResult = Gassma${sheetName}CreateReturn;
+declare type Gassma${schemaName}${sheetName}DefaultFindResult = Gassma${schemaName}${sheetName}CreateReturn;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaDeleteData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteData.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaDeleteData } from "./gassmaDeleteManyData/oneGassmaDeleteManyData";
 
-const getGassmaDeleteData = (sheetNames: string[]) => {
+const getGassmaDeleteData = (sheetNames: string[], schemaName: string) => {
   const deleteManyData = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaDeleteData(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaDeleteData(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return deleteManyData;

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
@@ -1,7 +1,7 @@
-const getOneGassmaDeleteData = (sheetName: string) => {
+const getOneGassmaDeleteData = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}DeleteData = {
-  where: Gassma${sheetName}WhereUse;
+declare type Gassma${schemaName}${sheetName}DeleteData = {
+  where: Gassma${schemaName}${sheetName}WhereUse;
   limit?: number;
 };
 `;

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
@@ -1,10 +1,13 @@
-const getOneGassmaDeleteSingleData = (sheetName: string) => {
+const getOneGassmaDeleteSingleData = (
+  schemaName: string,
+  sheetName: string,
+) => {
   return `
-declare type Gassma${sheetName}DeleteSingleData = {
-  where: Gassma${sheetName}WhereUse;
-  select?: Gassma${sheetName}Select;
+declare type Gassma${schemaName}${sheetName}DeleteSingleData = {
+  where: Gassma${schemaName}${sheetName}WhereUse;
+  select?: Gassma${schemaName}${sheetName}Select;
   include?: Gassma.IncludeData;
-  omit?: Gassma${sheetName}Omit;
+  omit?: Gassma${schemaName}${sheetName}Omit;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaDeleteSingleData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteSingleData.ts
@@ -1,12 +1,18 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaDeleteSingleData } from "./gassmaDeleteManyData/oneGassmaDeleteSingleData";
 
-const getGassmaDeleteSingleData = (sheetNames: string[]) => {
+const getGassmaDeleteSingleData = (
+  sheetNames: string[],
+  schemaName: string,
+) => {
   const deleteSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaDeleteSingleData(removedSpaceCurrentSheetName);
+    return (
+      pre +
+      getOneGassmaDeleteSingleData(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return deleteSingleDataDeclare;

--- a/src/generate/typeGenerate/gassmaFilterConditions.ts
+++ b/src/generate/typeGenerate/gassmaFilterConditions.ts
@@ -3,6 +3,7 @@ import { getOneSheetGassmaFilterConditions } from "./gassmaFilterConditions/oneS
 
 const getGassmaFilterCoditions = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const filterConditionsDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -14,6 +15,7 @@ const getGassmaFilterCoditions = (
         pre +
         getOneSheetGassmaFilterConditions(
           sheetContent,
+          schemaName,
           removedSpaceCurrentSheetName,
         )
       );

--- a/src/generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions.ts
+++ b/src/generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions.ts
@@ -3,6 +3,7 @@ import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
 
 const getOneSheetGassmaFilterConditions = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const oneFilterConditions = Object.keys(sheetContent).reduce(
@@ -17,7 +18,7 @@ const getOneSheetGassmaFilterConditions = (
       const isOneType = columnTypes.length === 1;
 
       const oneFilterConditionsType = `
-declare type Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions = {
+declare type Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions = {
   equals?: ${now}${isQuestionMark ? " | null" : ""} | Gassma.FieldRef;
   not?: ${now}${isQuestionMark ? " | null" : ""};
   in?: ${isOneType ? `${now}[]` : `(${now})[]`};

--- a/src/generate/typeGenerate/gassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData.ts
@@ -3,6 +3,7 @@ import { getOneGassmaFindData } from "./gassmaFindData/oneGassmaFindData";
 
 const getGassmaFindData = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const findDeclare = Object.keys(dictYaml).reduce((pre, currentSheetName) => {
     const sheetContent = dictYaml[currentSheetName];
@@ -10,7 +11,12 @@ const getGassmaFindData = (
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaFindData(sheetContent, removedSpaceCurrentSheetName)
+      pre +
+      getOneGassmaFindData(
+        sheetContent,
+        schemaName,
+        removedSpaceCurrentSheetName,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -1,5 +1,6 @@
 const getOneGassmaFindData = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const distinctArrayData = Object.keys(sheetContent).reduce(
@@ -24,16 +25,16 @@ const getOneGassmaFindData = (
     return `${pre}"${removedQuestionMark}" | `;
   }, "");
 
-  return `\ndeclare type Gassma${sheetName}FindData = {
-  where?: Gassma${sheetName}WhereUse;
-  select?: Gassma${sheetName}Select;
-  omit?: Gassma${sheetName}Omit;
-  orderBy?: Gassma${sheetName}OrderBy;
+  return `\ndeclare type Gassma${schemaName}${sheetName}FindData = {
+  where?: Gassma${schemaName}${sheetName}WhereUse;
+  select?: Gassma${schemaName}${sheetName}Select;
+  omit?: Gassma${schemaName}${sheetName}Omit;
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy;
   take?: number;
   skip?: number;
   distinct?: ${distinctData}(${distinctArrayData})[];
   include?: Gassma.IncludeData;
-  cursor?: Partial<Gassma${sheetName}Use>;
+  cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
   _count?: Gassma.CountValue;
 };\n`;
 };

--- a/src/generate/typeGenerate/gassmaFindManyData.ts
+++ b/src/generate/typeGenerate/gassmaFindManyData.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaFindManyData } from "./gassmaFindManyData/oneGassmaFindManyData";
 
-const getGassmaFindManyData = (sheetNames: string[]) => {
+const getGassmaFindManyData = (sheetNames: string[], schemaName: string) => {
   const findManyDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaFindManyData(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaFindManyData(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return findManyDataDeclare;

--- a/src/generate/typeGenerate/gassmaFindManyData/oneGassmaFindManyData.ts
+++ b/src/generate/typeGenerate/gassmaFindManyData/oneGassmaFindManyData.ts
@@ -1,6 +1,6 @@
-const getOneGassmaFindManyData = (sheetName: string) => {
+const getOneGassmaFindManyData = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}FindManyData = Gassma${sheetName}FindData;    
+declare type Gassma${schemaName}${sheetName}FindManyData = Gassma${schemaName}${sheetName}FindData;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaFindResult.ts
+++ b/src/generate/typeGenerate/gassmaFindResult.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaFindResult } from "./gassmaFindResult/oneGassmaFindResult";
 
-const getGassmaFindResult = (sheetNames: string[]) => {
+const getGassmaFindResult = (sheetNames: string[], schemaName: string) => {
   const findResult = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaFindResult(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaFindResult(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return findResult;

--- a/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -1,14 +1,14 @@
-const getOneGassmaFindResult = (sheetName: string) => {
+const getOneGassmaFindResult = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}FindResult<T> = T extends undefined
-  ? Gassma${sheetName}DefaultFindResult
-  : T extends Gassma${sheetName}Select
+declare type Gassma${schemaName}${sheetName}FindResult<T> = T extends undefined
+  ? Gassma${schemaName}${sheetName}DefaultFindResult
+  : T extends Gassma${schemaName}${sheetName}Select
     ? {
         [K in keyof T as T[K] extends true
-          ? K & keyof Gassma${sheetName}DefaultFindResult
-          : never]: Gassma${sheetName}DefaultFindResult[K & keyof Gassma${sheetName}DefaultFindResult];
+          ? K & keyof Gassma${schemaName}${sheetName}DefaultFindResult
+          : never]: Gassma${schemaName}${sheetName}DefaultFindResult[K & keyof Gassma${schemaName}${sheetName}DefaultFindResult];
       }
-    : Gassma${sheetName}DefaultFindResult;
+    : Gassma${schemaName}${sheetName}DefaultFindResult;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaGroupByBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaGroupByBaseReturn.ts
@@ -1,12 +1,18 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaGroupByBaseReturn } from "./gassmaGroupByBaseReturn/oneGassmaGroupByBaseReturn";
 
-const getGassmaGroupByBaseReturn = (sheetNames: string[]) => {
+const getGassmaGroupByBaseReturn = (
+  sheetNames: string[],
+  schemaName: string,
+) => {
   const groupByBaseReturn = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaGroupByBaseReturn(removedSpaceCurrentSheetName);
+    return (
+      pre +
+      getOneGassmaGroupByBaseReturn(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return groupByBaseReturn;

--- a/src/generate/typeGenerate/gassmaGroupByBaseReturn/oneGassmaGroupByBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaGroupByBaseReturn/oneGassmaGroupByBaseReturn.ts
@@ -1,6 +1,9 @@
-const getOneGassmaGroupByBaseReturn = (sheetName: string) => {
+const getOneGassmaGroupByBaseReturn = (
+  schemaName: string,
+  sheetName: string,
+) => {
   return `
-declare type Gassma${sheetName}GroupByBaseReturn = Gassma${sheetName}CreateReturn;
+declare type Gassma${schemaName}${sheetName}GroupByBaseReturn = Gassma${schemaName}${sheetName}CreateReturn;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaGroupByData.ts
+++ b/src/generate/typeGenerate/gassmaGroupByData.ts
@@ -3,6 +3,7 @@ import { getOneGassmaGroupByData } from "./gassmaGroupByData/oneGassmaGroupByDat
 
 const getGassmaGroupByData = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const groupByDataDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -12,7 +13,11 @@ const getGassmaGroupByData = (
 
       return (
         pre +
-        getOneGassmaGroupByData(sheetContent, removedSpaceCurrentSheetName)
+        getOneGassmaGroupByData(
+          sheetContent,
+          schemaName,
+          removedSpaceCurrentSheetName,
+        )
       );
     },
     "",

--- a/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
+++ b/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
@@ -1,5 +1,6 @@
 const getOneGassmaGroupByData = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const byArrayData = Object.keys(sheetContent).reduce(
@@ -24,9 +25,9 @@ const getOneGassmaGroupByData = (
     return `${pre}"${removedQuestionMark}" | `;
   }, "");
 
-  return `\ndeclare type Gassma${sheetName}GroupByData = Gassma${sheetName}AggregateData & {
+  return `\ndeclare type Gassma${schemaName}${sheetName}GroupByData = Gassma${schemaName}${sheetName}AggregateData & {
   by: ${byData}(${byArrayData})[];
-  having?: Gassma${sheetName}HavingUse;
+  having?: Gassma${schemaName}${sheetName}HavingUse;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaGroupByKeyOfBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaGroupByKeyOfBaseReturn.ts
@@ -1,13 +1,20 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaGroupByKeyOfBaseReturn } from "./gassmaGroupByKeyOfBaseReturn/oneGassmaGroupByKeyOfBaseReturn";
 
-const getGassmaGroupByKeyOfBaseReturn = (sheetNames: string[]) => {
+const getGassmaGroupByKeyOfBaseReturn = (
+  sheetNames: string[],
+  schemaName: string,
+) => {
   const groupByKeyOfBaseReturn = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaGroupByKeyOfBaseReturn(removedSpaceCurrentSheetName)
+      pre +
+      getOneGassmaGroupByKeyOfBaseReturn(
+        schemaName,
+        removedSpaceCurrentSheetName,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaGroupByKeyOfBaseReturn/oneGassmaGroupByKeyOfBaseReturn.ts
+++ b/src/generate/typeGenerate/gassmaGroupByKeyOfBaseReturn/oneGassmaGroupByKeyOfBaseReturn.ts
@@ -1,6 +1,9 @@
-const getOneGassmaGroupByKeyOfBaseReturn = (sheetName: string) => {
+const getOneGassmaGroupByKeyOfBaseReturn = (
+  schemaName: string,
+  sheetName: string,
+) => {
   return `
-declare type Gassma${sheetName}GroupByKeyOfBaseReturn = keyof Gassma${sheetName}GroupByBaseReturn;
+declare type Gassma${schemaName}${sheetName}GroupByKeyOfBaseReturn = keyof Gassma${schemaName}${sheetName}GroupByBaseReturn;
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaGroupByResult.ts
+++ b/src/generate/typeGenerate/gassmaGroupByResult.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaGroupByResult } from "./gassmaGroupByResult/oneGassmaGroupByResult";
 
-const getGassmaGroupByResult = (sheetNames: string[]) => {
+const getGassmaGroupByResult = (sheetNames: string[], schemaName: string) => {
   const groupByResultDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaGroupByResult(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaGroupByResult(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return groupByResultDeclare;

--- a/src/generate/typeGenerate/gassmaGroupByResult/oneGassmaGroupByResult.ts
+++ b/src/generate/typeGenerate/gassmaGroupByResult/oneGassmaGroupByResult.ts
@@ -1,11 +1,11 @@
-const getOneGassmaGroupByResult = (sheetName: string) => {
+const getOneGassmaGroupByResult = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}GroupByResult<T extends Gassma${sheetName}GroupByData> = Gassma${sheetName}ByField<T["by"]> & {
+declare type Gassma${schemaName}${sheetName}GroupByResult<T extends Gassma${schemaName}${sheetName}GroupByData> = Gassma${schemaName}${sheetName}ByField<T["by"]> & {
   [K in keyof T as K extends "_avg" | "_count" | "_max" | "_min" | "_sum"
     ? T[K] extends undefined
       ? never
       : K
-    : never]: K extends string ? Gassma${sheetName}AggregateField<T[K], K> : never;
+    : never]: K extends string ? Gassma${schemaName}${sheetName}AggregateField<T[K], K> : never;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaHavingCore.ts
+++ b/src/generate/typeGenerate/gassmaHavingCore.ts
@@ -3,6 +3,7 @@ import { getOneGassmaHavingCore } from "./gassmaHavingCore/oneGassmaHavingCore";
 
 const getGassmaHavingCore = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const havingCoreDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -11,7 +12,12 @@ const getGassmaHavingCore = (
         getRemovedCantUseVarChar(currentSheetName);
 
       return (
-        pre + getOneGassmaHavingCore(sheetContent, removedSpaceCurrentSheetName)
+        pre +
+        getOneGassmaHavingCore(
+          sheetContent,
+          schemaName,
+          removedSpaceCurrentSheetName,
+        )
       );
     },
     "",

--- a/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
+++ b/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
@@ -2,19 +2,20 @@ import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
 
 const getOneGassmaHavingCore = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const oneHavingCore = Object.keys(sheetContent).reduce((pre, columnName) => {
     const removedSpaceCurrentColumnName = getRemovedCantUseVarChar(columnName);
 
     const oneHavingCoreType = `
-declare type Gassma${sheetName}${removedSpaceCurrentColumnName}HavingCore = {
-  _avg?: Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-  _count?: Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-  _max?: Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-  _min?: Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-  _sum?: Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-} & Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+declare type Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}HavingCore = {
+  _avg?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+  _count?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+  _max?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+  _min?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+  _sum?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+} & Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
 `;
 
     return pre + oneHavingCoreType;

--- a/src/generate/typeGenerate/gassmaHavingUse.ts
+++ b/src/generate/typeGenerate/gassmaHavingUse.ts
@@ -3,6 +3,7 @@ import { getOneGassmaHavingUse } from "./gassmaHavingUse/oneGassmaHavingUse";
 
 const getGassmaHavingUse = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const havingUseDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -11,7 +12,12 @@ const getGassmaHavingUse = (
         getRemovedCantUseVarChar(currentSheetName);
 
       return (
-        pre + getOneGassmaHavingUse(sheetContent, removedSpaceCurrentSheetName)
+        pre +
+        getOneGassmaHavingUse(
+          sheetContent,
+          schemaName,
+          removedSpaceCurrentSheetName,
+        )
       );
     },
     "",

--- a/src/generate/typeGenerate/gassmaHavingUse/oneGassmaHavingUse.ts
+++ b/src/generate/typeGenerate/gassmaHavingUse/oneGassmaHavingUse.ts
@@ -3,6 +3,7 @@ import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
 
 const getOneGassmaHavingUse = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const oneHavingUse = Object.keys(sheetContent).reduce((pre, columnName) => {
@@ -15,13 +16,13 @@ const getOneGassmaHavingUse = (
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${sheetName}${removedSpaceCurrentColumnName}HavingCore;\n`;
-  }, `\ndeclare type Gassma${sheetName}HavingUse = {\n`);
+    return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}HavingCore;\n`;
+  }, `\ndeclare type Gassma${schemaName}${sheetName}HavingUse = {\n`);
 
   return `${oneHavingUse}
-  AND?: Gassma${sheetName}HavingUse[] | Gassma${sheetName}HavingUse;
-  OR?: Gassma${sheetName}HavingUse[];
-  NOT?: Gassma${sheetName}HavingUse[] | Gassma${sheetName}HavingUse;
+  AND?: Gassma${schemaName}${sheetName}HavingUse[] | Gassma${schemaName}${sheetName}HavingUse;
+  OR?: Gassma${schemaName}${sheetName}HavingUse[];
+  NOT?: Gassma${schemaName}${sheetName}HavingUse[] | Gassma${schemaName}${sheetName}HavingUse;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -2,28 +2,31 @@ import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getGassmaCommonTypes } from "./gassmaCommonTypes";
 import { getGassmaErrorClasses } from "./gassmaErrorClasses";
 
-const getGassmaGlobalOmitConfig = (sheetNames: string[]) => {
+const getGassmaGlobalOmitConfig = (
+  sheetNames: string[],
+  schemaName: string,
+) => {
   const body = sheetNames.reduce((pre, sheetName) => {
     const cleanName = getRemovedCantUseVarChar(sheetName);
-    return `${pre}  "${sheetName}"?: Gassma${cleanName}Omit;\n`;
+    return `${pre}  "${sheetName}"?: Gassma${schemaName}${cleanName}Omit;\n`;
   }, "");
 
-  return `declare type GassmaGlobalOmitConfig = {\n${body}};\n`;
+  return `declare type Gassma${schemaName}GlobalOmitConfig = {\n${body}};\n`;
 };
 
-const getGassmaClientOptions = () => {
-  return `declare type GassmaClientOptions = {
+const getGassmaClientOptions = (schemaName: string) => {
+  return `declare type Gassma${schemaName}ClientOptions = {
   id?: string;
   relations?: Gassma.RelationsConfig;
-  omit?: GassmaGlobalOmitConfig;
+  omit?: Gassma${schemaName}GlobalOmitConfig;
 };\n`;
 };
 
-const getGassmaMain = (sheetNames: string[]) => {
-  const errorClasses = getGassmaErrorClasses();
+const getGassmaCommonNamespace = () => {
   const commonTypes = getGassmaCommonTypes();
+  const errorClasses = getGassmaErrorClasses();
 
-  const mainTypeDeclare = `declare namespace Gassma {
+  return `declare namespace Gassma {
 ${commonTypes}
   class FieldRef {
     readonly modelName: string;
@@ -31,21 +34,36 @@ ${commonTypes}
     constructor(modelName: string, name: string);
   }
 
-  class GassmaClient {
-    constructor(idOrOptions?: string | GassmaClientOptions);
-
-    readonly sheets: GassmaSheet;
-  }
-
 ${errorClasses}}
+
+`;
+};
+
+const getGassmaSchemaClient = (sheetNames: string[], schemaName: string) => {
+  const clientDeclare = `declare namespace Gassma {
+  class Gassma${schemaName}Client {
+    constructor(idOrOptions?: string | Gassma${schemaName}ClientOptions);
+    readonly sheets: Gassma${schemaName}Sheet;
+  }
+}
 
 `;
 
   return (
-    mainTypeDeclare +
-    getGassmaGlobalOmitConfig(sheetNames) +
-    getGassmaClientOptions()
+    clientDeclare +
+    getGassmaGlobalOmitConfig(sheetNames, schemaName) +
+    getGassmaClientOptions(schemaName)
   );
 };
 
-export { getGassmaMain };
+const getGassmaMain = (
+  sheetNames: string[],
+  schemaName: string,
+  includeCommon?: boolean,
+) => {
+  const common = includeCommon !== false ? getGassmaCommonNamespace() : "";
+
+  return common + getGassmaSchemaClient(sheetNames, schemaName);
+};
+
+export { getGassmaMain, getGassmaCommonNamespace };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -28,6 +28,13 @@ const getGassmaCommonNamespace = () => {
 
   return `declare namespace Gassma {
 ${commonTypes}
+  interface GassmaClientMap {}
+
+  class GassmaClient<T extends keyof GassmaClientMap> {
+    constructor(idOrOptions?: string | GassmaClientMap[T]["options"]);
+    readonly sheets: GassmaClientMap[T]["sheets"];
+  }
+
   class FieldRef {
     readonly modelName: string;
     readonly name: string;
@@ -40,17 +47,19 @@ ${errorClasses}}
 };
 
 const getGassmaSchemaClient = (sheetNames: string[], schemaName: string) => {
-  const clientDeclare = `declare namespace Gassma {
-  class Gassma${schemaName}Client {
-    constructor(idOrOptions?: string | Gassma${schemaName}ClientOptions);
-    readonly sheets: Gassma${schemaName}Sheet;
+  const clientMapEntry = `declare namespace Gassma {
+  interface GassmaClientMap {
+    "${schemaName}": {
+      sheets: Gassma${schemaName}Sheet;
+      options: Gassma${schemaName}ClientOptions;
+    };
   }
 }
 
 `;
 
   return (
-    clientDeclare +
+    clientMapEntry +
     getGassmaGlobalOmitConfig(sheetNames, schemaName) +
     getGassmaClientOptions(schemaName)
   );

--- a/src/generate/typeGenerate/gassmaOmit.ts
+++ b/src/generate/typeGenerate/gassmaOmit.ts
@@ -1,13 +1,19 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaOmit } from "./gassmaOmit/oneGassmaOmit";
 
-const getGassmaOmit = (dictYaml: Record<string, Record<string, unknown[]>>) => {
+const getGassmaOmit = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
+) => {
   const omitDeclare = Object.keys(dictYaml).reduce((pre, currentSheetName) => {
     const sheetContent = dictYaml[currentSheetName];
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaOmit(sheetContent, removedSpaceCurrentSheetName);
+    return (
+      pre +
+      getOneGassmaOmit(sheetContent, schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return omitDeclare;

--- a/src/generate/typeGenerate/gassmaOmit/oneGassmaOmit.ts
+++ b/src/generate/typeGenerate/gassmaOmit/oneGassmaOmit.ts
@@ -1,5 +1,6 @@
 const getOneGassmaOmit = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const oneOmit = Object.keys(sheetContent).reduce((pre, columnName) => {
@@ -9,7 +10,7 @@ const getOneGassmaOmit = (
       : columnName;
 
     return `${pre}  "${removedQuestionMark}"?: true;\n`;
-  }, `\ndeclare type Gassma${sheetName}Omit = {\n`);
+  }, `\ndeclare type Gassma${schemaName}${sheetName}Omit = {\n`);
 
   return `${oneOmit}};\n`;
 };

--- a/src/generate/typeGenerate/gassmaOrderBy.ts
+++ b/src/generate/typeGenerate/gassmaOrderBy.ts
@@ -4,6 +4,7 @@ import type { RelationsConfig } from "../read/extractRelations";
 
 const getGassmaOrderBy = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
   relations?: RelationsConfig,
 ) => {
   const orderByDeclare = Object.keys(dictYaml).reduce(
@@ -16,6 +17,7 @@ const getGassmaOrderBy = (
         pre +
         getOneGassmaOrderBy(
           sheetContent,
+          schemaName,
           removedSpaceCurrentSheetName,
           relations,
         )

--- a/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
+++ b/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
@@ -2,6 +2,7 @@ import type { RelationsConfig } from "../../read/extractRelations";
 
 const getOneGassmaOrderBy = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
@@ -12,7 +13,7 @@ const getOneGassmaOrderBy = (
       : columnName;
 
     return `${pre}  "${removedQuestionMark}"?: "asc" | "desc" | Gassma.SortOrderInput;\n`;
-  }, `\ndeclare type Gassma${sheetName}OrderBy = {\n`);
+  }, `\ndeclare type Gassma${schemaName}${sheetName}OrderBy = {\n`);
 
   const modelRelations = relations?.[sheetName];
   const relationFields = modelRelations

--- a/src/generate/typeGenerate/gassmaSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect.ts
@@ -3,6 +3,7 @@ import { getOneGassmaSelect } from "./gassmaSelect/oneGassmaSelect";
 
 const getGassmaSelect = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
 ) => {
   const selectDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -11,7 +12,12 @@ const getGassmaSelect = (
         getRemovedCantUseVarChar(currentSheetName);
 
       return (
-        pre + getOneGassmaSelect(sheetContent, removedSpaceCurrentSheetName)
+        pre +
+        getOneGassmaSelect(
+          sheetContent,
+          schemaName,
+          removedSpaceCurrentSheetName,
+        )
       );
     },
     "",

--- a/src/generate/typeGenerate/gassmaSelect/oneGassmaSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect/oneGassmaSelect.ts
@@ -1,5 +1,6 @@
 const getOneGassmaSelect = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
 ) => {
   const oneSelct = Object.keys(sheetContent).reduce((pre, columnName) => {
@@ -9,7 +10,7 @@ const getOneGassmaSelect = (
       : columnName;
 
     return `${pre}  "${removedQuestionMark}"?: true;\n`;
-  }, `\ndeclare type Gassma${sheetName}Select = {\n`);
+  }, `\ndeclare type Gassma${schemaName}${sheetName}Select = {\n`);
 
   return `${oneSelct}};\n`;
 };

--- a/src/generate/typeGenerate/gassmaSheet.ts
+++ b/src/generate/typeGenerate/gassmaSheet.ts
@@ -1,11 +1,11 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 
-const getGassmaSheet = (sheetNames: string[]) => {
+const getGassmaSheet = (sheetNames: string[], schemaName: string) => {
   const sheetTypeDeclare = sheetNames.reduce((pre, current) => {
     const removedSpaceCurrentSheetName = getRemovedCantUseVarChar(current);
 
-    return `${pre}  "${current}": Gassma${removedSpaceCurrentSheetName}Controller;\n`;
-  }, "declare type GassmaSheet = {\n");
+    return `${pre}  "${current}": Gassma${schemaName}${removedSpaceCurrentSheetName}Controller;\n`;
+  }, `declare type Gassma${schemaName}Sheet = {\n`);
 
   return sheetTypeDeclare + "};\n";
 };

--- a/src/generate/typeGenerate/gassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData.ts
@@ -4,6 +4,7 @@ import type { RelationsConfig } from "../read/extractRelations";
 
 const getGassmaUpdateData = (
   sheetNames: string[],
+  schemaName: string,
   relations?: RelationsConfig,
 ) => {
   const updateDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
@@ -11,7 +12,12 @@ const getGassmaUpdateData = (
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaUpdateData(removedSpaceCurrentSheetName, relations)
+      pre +
+      getOneGassmaUpdateData(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        relations,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
@@ -2,18 +2,19 @@ import type { RelationsConfig } from "../../read/extractRelations";
 import { getNestedWriteFields } from "../util/getNestedWriteFields";
 
 const getOneGassmaUpdateData = (
+  schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
   const nestedFields = getNestedWriteFields(sheetName, relations);
-  const baseDataType = `{ [K in keyof Gassma${sheetName}Use]: Gassma${sheetName}Use[K] | Gassma.NumberOperation }`;
+  const baseDataType = `{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }`;
   const dataType = nestedFields
     ? `${baseDataType} & {\n${nestedFields}  }`
     : baseDataType;
 
   return `
-declare type Gassma${sheetName}UpdateData = {
-  where?: Gassma${sheetName}WhereUse;
+declare type Gassma${schemaName}${sheetName}UpdateData = {
+  where?: Gassma${schemaName}${sheetName}WhereUse;
   data: ${dataType};
   limit?: number;
 };

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
@@ -2,21 +2,22 @@ import type { RelationsConfig } from "../../read/extractRelations";
 import { getNestedWriteFields } from "../util/getNestedWriteFields";
 
 const getOneGassmaUpdateSingleData = (
+  schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
   const nestedFields = getNestedWriteFields(sheetName, relations);
-  const baseDataType = `{ [K in keyof Gassma${sheetName}Use]: Gassma${sheetName}Use[K] | Gassma.NumberOperation }`;
+  const baseDataType = `{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }`;
   const dataType = nestedFields
     ? `${baseDataType} & {\n${nestedFields}  }`
     : baseDataType;
 
   return `
-declare type Gassma${sheetName}UpdateSingleData = {
-  where: Gassma${sheetName}WhereUse;
+declare type Gassma${schemaName}${sheetName}UpdateSingleData = {
+  where: Gassma${schemaName}${sheetName}WhereUse;
   data: ${dataType};
-  select?: Gassma${sheetName}Select;
-  omit?: Gassma${sheetName}Omit;
+  select?: Gassma${schemaName}${sheetName}Select;
+  omit?: Gassma${schemaName}${sheetName}Omit;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateSingleData.ts
@@ -4,6 +4,7 @@ import type { RelationsConfig } from "../read/extractRelations";
 
 const getGassmaUpdateSingleData = (
   sheetNames: string[],
+  schemaName: string,
   relations?: RelationsConfig,
 ) => {
   const updateSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
@@ -12,7 +13,11 @@ const getGassmaUpdateSingleData = (
 
     return (
       pre +
-      getOneGassmaUpdateSingleData(removedSpaceCurrentSheetName, relations)
+      getOneGassmaUpdateSingleData(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        relations,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaUpsertData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData.ts
@@ -1,12 +1,14 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaUpsertData } from "./gassmaUpsertData/oneGassmaUpsertData";
 
-const getGassmaUpsertData = (sheetNames: string[]) => {
+const getGassmaUpsertData = (sheetNames: string[], schemaName: string) => {
   const upsertDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
-    return pre + getOneGassmaUpsertData(removedSpaceCurrentSheetName);
+    return (
+      pre + getOneGassmaUpsertData(schemaName, removedSpaceCurrentSheetName)
+    );
   }, "");
 
   return upsertDataDeclare;

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertData.ts
@@ -1,9 +1,9 @@
-const getOneGassmaUpsertData = (sheetName: string) => {
+const getOneGassmaUpsertData = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${sheetName}UpsertData = {
-  where: Gassma${sheetName}WhereUse;
-  update: Gassma${sheetName}Use;
-  data: Gassma${sheetName}Use;
+declare type Gassma${schemaName}${sheetName}UpsertData = {
+  where: Gassma${schemaName}${sheetName}WhereUse;
+  update: Gassma${schemaName}${sheetName}Use;
+  data: Gassma${schemaName}${sheetName}Use;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
@@ -2,28 +2,29 @@ import type { RelationsConfig } from "../../read/extractRelations";
 import { getNestedWriteFields } from "../util/getNestedWriteFields";
 
 const getOneGassmaUpsertSingleData = (
+  schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
   const nestedFields = getNestedWriteFields(sheetName, relations);
 
   const createType = nestedFields
-    ? `Gassma${sheetName}Use & {\n${nestedFields}  }`
-    : `Gassma${sheetName}Use`;
+    ? `Gassma${schemaName}${sheetName}Use & {\n${nestedFields}  }`
+    : `Gassma${schemaName}${sheetName}Use`;
 
-  const baseUpdateType = `{ [K in keyof Gassma${sheetName}Use]: Gassma${sheetName}Use[K] | Gassma.NumberOperation }`;
+  const baseUpdateType = `{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }`;
   const updateType = nestedFields
     ? `${baseUpdateType} & {\n${nestedFields}  }`
     : baseUpdateType;
 
   return `
-declare type Gassma${sheetName}UpsertSingleData = {
-  where: Gassma${sheetName}WhereUse;
+declare type Gassma${schemaName}${sheetName}UpsertSingleData = {
+  where: Gassma${schemaName}${sheetName}WhereUse;
   create: ${createType};
   update: ${updateType};
-  select?: Gassma${sheetName}Select;
+  select?: Gassma${schemaName}${sheetName}Select;
   include?: Gassma.IncludeData;
-  omit?: Gassma${sheetName}Omit;
+  omit?: Gassma${schemaName}${sheetName}Omit;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertSingleData.ts
@@ -4,6 +4,7 @@ import type { RelationsConfig } from "../read/extractRelations";
 
 const getGassmaUpsertSingleData = (
   sheetNames: string[],
+  schemaName: string,
   relations?: RelationsConfig,
 ) => {
   const upsertSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
@@ -12,7 +13,11 @@ const getGassmaUpsertSingleData = (
 
     return (
       pre +
-      getOneGassmaUpsertSingleData(removedSpaceCurrentSheetName, relations)
+      getOneGassmaUpsertSingleData(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        relations,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse.ts
@@ -4,6 +4,7 @@ import type { RelationsConfig } from "../read/extractRelations";
 
 const getGassmaWhereUse = (
   dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
   relations?: RelationsConfig,
 ) => {
   const whereUseDeclare = Object.keys(dictYaml).reduce(
@@ -16,6 +17,7 @@ const getGassmaWhereUse = (
         pre +
         getOneGassmaWhereUse(
           sheetContent,
+          schemaName,
           removedSpaceCurrentSheetName,
           relations,
         )

--- a/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
@@ -25,6 +25,7 @@ const getRelationFields = (
 
 const getOneGassmaWhereUse = (
   sheetContent: Record<string, unknown[]>,
+  schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
@@ -38,15 +39,15 @@ const getOneGassmaWhereUse = (
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${sheetName}${removedSpaceCurrentColumnName}FilterConditions;\n`;
-  }, `\ndeclare type Gassma${sheetName}WhereUse = {\n`);
+    return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;\n`;
+  }, `\ndeclare type Gassma${schemaName}${sheetName}WhereUse = {\n`);
 
   const relationFields = getRelationFields(sheetName, relations);
 
   return `${oneWhereUse}${relationFields}
-  AND?: Gassma${sheetName}WhereUse[] | Gassma${sheetName}WhereUse;
-  OR?: Gassma${sheetName}WhereUse[];
-  NOT?: Gassma${sheetName}WhereUse[] | Gassma${sheetName}WhereUse;
+  AND?: Gassma${schemaName}${sheetName}WhereUse[] | Gassma${schemaName}${sheetName}WhereUse;
+  OR?: Gassma${schemaName}${sheetName}WhereUse[];
+  NOT?: Gassma${schemaName}${sheetName}WhereUse[] | Gassma${schemaName}${sheetName}WhereUse;
 };
 `;
 };


### PR DESCRIPTION
## Summary
- 全型生成関数に `schemaName` パラメータを追加（84ファイル変更）
- 型名を `Gassma${SheetName}Xxx` → `Gassma${SchemaName}${SheetName}Xxx` に変更
- `GassmaClient<T>` 型引数パターンに変更（`GassmaClientMap` interface declaration merging）
- 共通型（FieldRef, エラークラス等）は `Gassma` namespace 内で共有、同一 output 先では1回だけ出力
- `generate.ts` で `.prisma` ファイル名から schemaName を自動取得（`hoge.prisma` → `Hoge`）
- `generateClientJs` に schemaName 対応追加（`createGassmaHogeClient` / `hogeRelations`）
- `generateClientDts` 新規作成（クライアント JS の型宣言を `.d.ts` として生成）
- per-schema ファイル出力（`hogeClient.js`, `hogeClient.d.ts`）

## 使用例
```typescript
// hoge.prisma → new Gassma.GassmaClient<"Hoge">(options)
// fuga.prisma → new Gassma.GassmaClient<"Fuga">(options)
// 両方に User モデルがあっても GassmaHogeUserUse / GassmaFugaUserUse で衝突しない

// ヘルパー関数（リレーション自動注入済み）
const client = createGassmaHogeClient(); // → Gassma.GassmaClient<"Hoge">
const client2 = createGassmaFugaClient(); // → Gassma.GassmaClient<"Fuga">
```

## Test plan
- [x] 全184テスト通過
- [x] 単一スキーマの型チェックテスト通過
- [x] 複数スキーマ（同名 User モデル）の型チェックテスト通過（衝突なし）
- [x] クライアント `.d.ts` を含むマルチスキーマ型チェック通過
- [x] biome チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)