### PR TITLE
feat: Prisma風クライアントJS/d.ts生成

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -1,24 +1,29 @@
 import { generateClientDts } from "../../../generate/jsGenerate/generateClientDts";
 
 describe("generateClientDts", () => {
-  it("should declare createGassmaXxxClient function with schema type parameter", () => {
+  it("should export GassmaClient class", () => {
     const result = generateClientDts("Hoge");
 
-    expect(result).toContain("function createGassmaHogeClient");
-    expect(result).toContain('Gassma.GassmaClient<"Hoge">');
+    expect(result).toContain("export declare class GassmaClient");
   });
 
-  it("should accept optional GassmaClientOptions parameter", () => {
+  it("should have constructor with optional GassmaClientOptions", () => {
     const result = generateClientDts("Hoge");
 
     expect(result).toContain("options?: GassmaHogeClientOptions");
   });
 
+  it("should have readonly sheets property with schema-specific type", () => {
+    const result = generateClientDts("Hoge");
+
+    expect(result).toContain("readonly sheets: GassmaHogeSheet");
+  });
+
   it("should work with different schema names", () => {
     const result = generateClientDts("Fuga");
 
-    expect(result).toContain("function createGassmaFugaClient");
-    expect(result).toContain('Gassma.GassmaClient<"Fuga">');
+    expect(result).toContain("export declare class GassmaClient");
     expect(result).toContain("options?: GassmaFugaClientOptions");
+    expect(result).toContain("readonly sheets: GassmaFugaSheet");
   });
 });

--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -1,7 +1,7 @@
 import { generateClientJs } from "../../../generate/jsGenerate/generateClientJs";
 
 describe("generateClientJs", () => {
-  it("should generate JS with embedded relations config and schema name", () => {
+  it("should generate GassmaClient class with embedded relations", () => {
     const relations = {
       User: {
         posts: {
@@ -23,21 +23,22 @@ describe("generateClientJs", () => {
 
     const result = generateClientJs(relations, "Hoge");
 
-    expect(result).toContain("const hogeRelations =");
+    expect(result).toContain("hogeRelations =");
     expect(result).toContain('"User"');
     expect(result).toContain('"posts"');
     expect(result).toContain('"oneToMany"');
     expect(result).toContain('"Post"');
     expect(result).toContain('"author"');
     expect(result).toContain('"manyToOne"');
-    expect(result).toContain("function createGassmaHogeClient");
+    expect(result).toContain("function GassmaClient");
+    expect(result).toContain("exports.GassmaClient = GassmaClient");
   });
 
-  it("should generate JS with empty relations when none exist", () => {
+  it("should generate GassmaClient with empty relations when none exist", () => {
     const result = generateClientJs({}, "Hoge");
 
-    expect(result).toContain("const hogeRelations = {}");
-    expect(result).toContain("function createGassmaHogeClient");
+    expect(result).toContain("hogeRelations = {}");
+    expect(result).toContain("function GassmaClient");
   });
 
   it("should include onDelete and onUpdate when present", () => {
@@ -85,11 +86,12 @@ describe("generateClientJs", () => {
     expect(result).toContain('"tagId"');
   });
 
-  it("should pass schemaName to function name", () => {
+  it("should merge relations into options in constructor", () => {
     const result = generateClientJs({}, "Fuga");
 
-    expect(result).toContain("const fugaRelations =");
-    expect(result).toContain("function createGassmaFugaClient");
-    expect(result).toContain("new Gassma.GassmaClient(mergedOptions)");
+    expect(result).toContain("fugaRelations =");
+    expect(result).toContain(
+      "Object.assign({}, options, { relations: fugaRelations })",
+    );
   });
 });

--- a/src/generate/jsGenerate/generateClientDts.ts
+++ b/src/generate/jsGenerate/generateClientDts.ts
@@ -1,5 +1,8 @@
 const generateClientDts = (schemaName: string): string => {
-  return `declare function createGassma${schemaName}Client(options?: Gassma${schemaName}ClientOptions): Gassma.GassmaClient<"${schemaName}">;
+  return `export declare class GassmaClient {
+  constructor(options?: Gassma${schemaName}ClientOptions);
+  readonly sheets: Gassma${schemaName}Sheet;
+}
 `;
 };
 

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -10,12 +10,18 @@ const generateClientJs = (
       ? "{}"
       : JSON.stringify(relations, null, 2);
 
-  return `const ${lowerName}Relations = ${relationsJson};
+  return `var ${lowerName}Relations = ${relationsJson};
 
-function createGassma${schemaName}Client(options) {
-  var mergedOptions = Object.assign({}, options, { relations: ${lowerName}Relations });
-  return new Gassma.GassmaClient(mergedOptions);
-}
+var GassmaClient = (function () {
+  function GassmaClient(options) {
+    var mergedOptions = Object.assign({}, options, { relations: ${lowerName}Relations });
+    var client = new Gassma.GassmaClient(mergedOptions);
+    this.sheets = client.sheets;
+  }
+  return GassmaClient;
+})();
+
+exports.GassmaClient = GassmaClient;
 `;
 };
 


### PR DESCRIPTION
## Summary
- `createGassmaXxxClient()` 関数を廃止し、Prisma風の `GassmaClient` クラス export に変更
- `hogeClient.js`: `exports.GassmaClient` でモジュールとしてexport
- `hogeClient.d.ts`: `export declare class GassmaClient` で型安全なimportを提供
- per-schema ファイル出力（`hogeClient.js` + `hogeClient.d.ts`）
- リレーション定義を自動注入済みの `GassmaClient` をexport

## 使用例
```typescript
// Prisma
import { PrismaClient } from '@prisma/client'
const prisma = new PrismaClient()

// gassma（同じパターン）
import { GassmaClient } from './generated/gassma/hogeClient'
const gassma = new GassmaClient()
gassma.sheets.User.findMany({})
```

## Test plan
- [x] generateClientJs テスト（GassmaClient class export パターン）
- [x] generateClientDts テスト（export declare class の型宣言）
- [x] typecheck テスト（マルチスキーマ型チェック通過）
- [x] 全 185 テスト通過
- [x] `tsc --noEmit` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)