### PR TITLE
fix: use const/class in generated client JS

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -30,7 +30,7 @@ describe("generateClientJs", () => {
     expect(result).toContain('"Post"');
     expect(result).toContain('"author"');
     expect(result).toContain('"manyToOne"');
-    expect(result).toContain("function GassmaClient");
+    expect(result).toContain("class GassmaClient");
     expect(result).toContain("exports.GassmaClient = GassmaClient");
   });
 
@@ -38,7 +38,7 @@ describe("generateClientJs", () => {
     const result = generateClientJs({}, "Hoge");
 
     expect(result).toContain("hogeRelations = {}");
-    expect(result).toContain("function GassmaClient");
+    expect(result).toContain("class GassmaClient");
   });
 
   it("should include onDelete and onUpdate when present", () => {

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -10,16 +10,15 @@ const generateClientJs = (
       ? "{}"
       : JSON.stringify(relations, null, 2);
 
-  return `var ${lowerName}Relations = ${relationsJson};
+  return `const ${lowerName}Relations = ${relationsJson};
 
-var GassmaClient = (function () {
-  function GassmaClient(options) {
-    var mergedOptions = Object.assign({}, options, { relations: ${lowerName}Relations });
-    var client = new Gassma.GassmaClient(mergedOptions);
+class GassmaClient {
+  constructor(options) {
+    const mergedOptions = Object.assign({}, options, { relations: ${lowerName}Relations });
+    const client = new Gassma.GassmaClient(mergedOptions);
     this.sheets = client.sheets;
   }
-  return GassmaClient;
-})();
+}
 
 exports.GassmaClient = GassmaClient;
 `;


### PR DESCRIPTION
## Summary
- 生成されるクライアント JS で `var` / IIFE パターンを使用していたのを `const` / `class` に修正
- GAS V8 ランタイムは ES6+ をサポートしているため不要な古い書き方だった

## Test plan
- [x] 全 185 テスト通過
- [x] `tsc --noEmit` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)