### PR TITLE
chore: exclude __test__ from build output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["src"],
+  "exclude": ["src/__test__"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 


### PR DESCRIPTION
## Summary
- `tsconfig.json` に `"exclude": ["src/__test__"]` を追加
- `npm run build` 時に `dist/` にテストファイルが含まれないようにした

## Test plan
- [x] `dist/` にテストディレクトリが含まれないことを確認
- [x] 全 185 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)