### PR TITLE
fix: @gassma.addType のクォート付き値が二重クォートされるバグ修正

### DIFF
--- a/src/__test__/generate/read/extractAddTypes.test.ts
+++ b/src/__test__/generate/read/extractAddTypes.test.ts
@@ -80,6 +80,34 @@ model Post {
     });
   });
 
+  it("should strip quotes from addType values", () => {
+    const schema = `
+model Order {
+  /// @gassma.addType "pending", "shipped", "delivered"
+  status String
+}
+`;
+    const result = extractAddTypes(schema);
+
+    expect(result).toEqual({
+      Order: { status: ["pending", "shipped", "delivered"] },
+    });
+  });
+
+  it("should handle mixed quoted and unquoted addType values", () => {
+    const schema = `
+model Post {
+  /// @gassma.addType number, "draft"
+  content String
+}
+`;
+    const result = extractAddTypes(schema);
+
+    expect(result).toEqual({
+      Post: { content: ["number", "draft"] },
+    });
+  });
+
   it("should ignore regular comments", () => {
     const schema = `
 model User {

--- a/src/generate/read/extractAddTypes.ts
+++ b/src/generate/read/extractAddTypes.ts
@@ -38,7 +38,9 @@ const processModel = (
       if (!comment.text.startsWith(GASSMA_ADD_TYPE_PREFIX)) return;
 
       const typesString = comment.text.slice(GASSMA_ADD_TYPE_PREFIX.length);
-      const types = typesString.split(",").map((t) => t.trim());
+      const types = typesString
+        .split(",")
+        .map((t) => t.trim().replace(/^"|"$/g, ""));
 
       if (!result[model.name.value]) result[model.name.value] = {};
       result[model.name.value][nextMember.name.value] = types;


### PR DESCRIPTION
## Summary
- `/// @gassma.addType "pending", "shipped"` のようにクォート付きで書くと、生成される型が `""pending""` と二重クォートされていたバグを修正
- `extractAddTypes` のパース時にクォートを除去するようにした

## Test plan
- [x] クォート付き addType 値のテスト追加
- [x] クォート混在（`number, "draft"`）のテスト追加
- [x] 全 187 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)