### PR TITLE
fix: handle self-referencing relations in findInverseField

### DIFF
--- a/src/__test__/generate/read/extractRelations.test.ts
+++ b/src/__test__/generate/read/extractRelations.test.ts
@@ -208,6 +208,32 @@ model Apple {
     });
   });
 
+  it("should extract self-referencing oneToMany relation", () => {
+    const schema = `
+model Category {
+  id       Int        @id @default(autoincrement())
+  name     String
+  parentId Int?
+  parent   Category?  @relation("CategoryTree", fields: [parentId], references: [id])
+  children Category[] @relation("CategoryTree")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Category.parent).toEqual({
+      type: "manyToOne",
+      to: "Category",
+      field: "parentId",
+      reference: "id",
+    });
+    expect(result.Category.children).toEqual({
+      type: "oneToMany",
+      to: "Category",
+      field: "id",
+      reference: "parentId",
+    });
+  });
+
   it("should extract manyToMany relation with through table", () => {
     const schema = `
 model Post {

--- a/src/generate/read/relationHelpers.ts
+++ b/src/generate/read/relationHelpers.ts
@@ -74,7 +74,13 @@ const findInverseField = (
     if (baseType.name.value !== targetModelName) return false;
 
     if (relationName) {
-      return getRelationName(m) === relationName;
+      if (getRelationName(m) !== relationName) return false;
+      const relAttr = findFirstAttribute(m.attributes, "relation");
+      if (relAttr) {
+        const relFields = getFieldReferences(relAttr.args, "fields");
+        if (relFields) return false;
+      }
+      return true;
     }
 
     const attr = findFirstAttribute(m.attributes, "relation");


### PR DESCRIPTION
## 概要
- 自己参照リレーション（例: Category の parent/children）で `findInverseField` が fields-side のフィールドを逆引きとして誤って返すバグを修正
- `relationName` マッチ時にも `fields` を持つフィールドを除外するようにした

## 問題
```prisma
model Category {
  parent   Category?  @relation("CategoryTree", fields: [parentId], references: [id])
  children Category[] @relation("CategoryTree")
}
```
このような自己参照リレーションで `children` が `manyToMany` として誤検出され、存在しない `_CategoryToCategory` 中間テーブルを参照してエラーになっていた。

## 原因
`findInverseField` が `relationName` 指定時に `fields` を持つフィールド（fields-side）を除外していなかったため、自己参照時に `parent` 自身が逆引きフィールドとして返されていた。

## テスト
- 自己参照 oneToMany リレーションのテストケースを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)