### PR TITLE
fix: propagate onDelete/onUpdate to inverse relation config

### DIFF
--- a/src/__test__/generate/read/extractRelations.test.ts
+++ b/src/__test__/generate/read/extractRelations.test.ts
@@ -102,6 +102,9 @@ model Post {
 
     expect(result.Post.author.onDelete).toBe("Cascade");
     expect(result.Post.author.onUpdate).toBe("SetNull");
+
+    expect(result.User.posts.onDelete).toBe("Cascade");
+    expect(result.User.posts.onUpdate).toBe("SetNull");
   });
 
   it("should handle multiple relations on the same model", () => {

--- a/src/generate/read/extractRelations.ts
+++ b/src/generate/read/extractRelations.ts
@@ -109,6 +109,8 @@ const buildRelationsConfig = (
       to: rel.modelName,
       field: rel.foreignField,
       reference: rel.localField,
+      ...(rel.onDelete ? { onDelete: rel.onDelete } : {}),
+      ...(rel.onUpdate ? { onUpdate: rel.onUpdate } : {}),
     };
   });
 


### PR DESCRIPTION
## 概要
- inverse リレーション構築時に `onDelete`/`onUpdate` が伝播されていなかったバグを修正
- 例: `Post.author` に `onDelete: Cascade` があっても、`User.posts` 側に伝播されていなかった

## 影響
親モデル削除時に Cascade/SetNull/Restrict が発動しなかった。
例えば User を削除しても、User.posts の onDelete が undefined のため Profile/Post/Comment の Cascade 削除が動かなかった。

## テスト
- 既存テスト `should extract onDelete and onUpdate actions` に inverse side の検証を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)