### PR TITLE
fix: remove onDelete/onUpdate from fields-side relation config

### DIFF
--- a/src/__test__/generate/read/extractRelations.test.ts
+++ b/src/__test__/generate/read/extractRelations.test.ts
@@ -100,8 +100,8 @@ model Post {
 `;
     const result = extractRelations(schema);
 
-    expect(result.Post.author.onDelete).toBe("Cascade");
-    expect(result.Post.author.onUpdate).toBe("SetNull");
+    expect(result.Post.author.onDelete).toBeUndefined();
+    expect(result.Post.author.onUpdate).toBeUndefined();
 
     expect(result.User.posts.onDelete).toBe("Cascade");
     expect(result.User.posts.onUpdate).toBe("SetNull");

--- a/src/generate/read/extractRelations.ts
+++ b/src/generate/read/extractRelations.ts
@@ -87,8 +87,6 @@ const buildRelationsConfig = (
       to: rel.toModel,
       field: rel.localField,
       reference: rel.foreignField,
-      ...(rel.onDelete ? { onDelete: rel.onDelete } : {}),
-      ...(rel.onUpdate ? { onUpdate: rel.onUpdate } : {}),
     };
 
     const inverseModel = models.find((m) => m.name.value === rel.toModel);


### PR DESCRIPTION
## 概要
- fields-side（manyToOne / child-oneToOne）の relation config から onDelete/onUpdate を除去

## 問題
onDelete が fields-side（子側）と inverse-side（親側）の両方に存在すると、`resolveOnDelete` で循環 cascade が発生する。

例: User 削除 → Profile Cascade 削除 → Profile.user の Cascade で User 削除 → 無限ループ（Maximum call stack size exceeded）

## 修正
- fields-side には onDelete/onUpdate を含めない
- inverse-side（oneToMany / parent-oneToOne）にのみ onDelete/onUpdate を持たせる（PR #42 で追加済み）
- resolveOnDelete は親側のリレーションのみ処理するため、正しい方向にだけ cascade/restrict が発動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)