### PR TITLE
fix: make update/upsert data fields partial

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
@@ -2,10 +2,11 @@ import { getOneGassmaUpdateData } from "../../../generate/typeGenerate/gassmaUpd
 import type { RelationsConfig } from "../../../generate/read/extractRelations";
 
 describe("getOneGassmaUpdateData", () => {
-  it("should generate UpdateData with NumberOperation support", () => {
+  it("should generate UpdateData with Partial NumberOperation support", () => {
     const result = getOneGassmaUpdateData("", "User");
 
     expect(result).toContain("declare type GassmaUserUpdateData");
+    expect(result).toContain("Partial<");
     expect(result).toContain(
       "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
     );

--- a/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
@@ -14,9 +14,10 @@ describe("getOneGassmaUpdateSingleData", () => {
     expect(result).toContain("where: GassmaUserWhereUse;");
   });
 
-  it("should include data with NumberOperation", () => {
+  it("should include data with Partial NumberOperation", () => {
     const result = getOneGassmaUpdateSingleData("", "User");
 
+    expect(result).toContain("Partial<");
     expect(result).toContain(
       "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
     );

--- a/src/__test__/generate/typeGenerate/gassmaUpsertData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpsertData.test.ts
@@ -1,0 +1,30 @@
+import { getOneGassmaUpsertData } from "../../../generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertData";
+
+describe("getOneGassmaUpsertData", () => {
+  it("should generate UpsertData type", () => {
+    const result = getOneGassmaUpsertData("", "User");
+
+    expect(result).toContain("declare type GassmaUserUpsertData");
+  });
+
+  it("should include where property", () => {
+    const result = getOneGassmaUpsertData("", "User");
+
+    expect(result).toContain("where: GassmaUserWhereUse;");
+  });
+
+  it("should include data (create) as required fields", () => {
+    const result = getOneGassmaUpsertData("", "User");
+
+    expect(result).toContain("data: GassmaUserUse;");
+  });
+
+  it("should include update with Partial NumberOperation", () => {
+    const result = getOneGassmaUpsertData("", "User");
+
+    expect(result).toContain("Partial<");
+    expect(result).toContain(
+      "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
+    );
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
@@ -20,9 +20,10 @@ describe("getOneGassmaUpsertSingleData", () => {
     expect(result).toContain("create: GassmaUserUse");
   });
 
-  it("should include update with NumberOperation", () => {
+  it("should include update with Partial NumberOperation", () => {
     const result = getOneGassmaUpsertSingleData("", "User");
 
+    expect(result).toContain("Partial<");
     expect(result).toContain(
       "[K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation",
     );

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
@@ -7,7 +7,7 @@ const getOneGassmaUpdateData = (
   relations?: RelationsConfig,
 ) => {
   const nestedFields = getNestedWriteFields(sheetName, relations);
-  const baseDataType = `{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }`;
+  const baseDataType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>`;
   const dataType = nestedFields
     ? `${baseDataType} & {\n${nestedFields}  }`
     : baseDataType;

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
@@ -7,7 +7,7 @@ const getOneGassmaUpdateSingleData = (
   relations?: RelationsConfig,
 ) => {
   const nestedFields = getNestedWriteFields(sheetName, relations);
-  const baseDataType = `{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }`;
+  const baseDataType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>`;
   const dataType = nestedFields
     ? `${baseDataType} & {\n${nestedFields}  }`
     : baseDataType;

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertData.ts
@@ -2,7 +2,7 @@ const getOneGassmaUpsertData = (schemaName: string, sheetName: string) => {
   return `
 declare type Gassma${schemaName}${sheetName}UpsertData = {
   where: Gassma${schemaName}${sheetName}WhereUse;
-  update: Gassma${schemaName}${sheetName}Use;
+  update: Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>;
   data: Gassma${schemaName}${sheetName}Use;
 };
 `;

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
@@ -12,7 +12,7 @@ const getOneGassmaUpsertSingleData = (
     ? `Gassma${schemaName}${sheetName}Use & {\n${nestedFields}  }`
     : `Gassma${schemaName}${sheetName}Use`;
 
-  const baseUpdateType = `{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }`;
+  const baseUpdateType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>`;
   const updateType = nestedFields
     ? `${baseUpdateType} & {\n${nestedFields}  }`
     : baseUpdateType;


### PR DESCRIPTION
## 概要
- update/upsert の data フィールドを `Partial` に変更
- create は全フィールド必須で正しいが、update/upsert は部分更新が可能なので Partial であるべき

## 変更ファイル
- `oneGassmaUpdateData.ts` - updateMany の data を Partial に
- `oneGassmaUpdateSingleData.ts` - update の data を Partial に
- `oneGassmaUpsertSingleData.ts` - upsert の update を Partial に
- 対応するテストファイル3件

## テスト
- 全188テスト通過
- ビルド成功