### PR TITLE
feat: reflect global omit in return types at type level

### DIFF
--- a/src/__test__/generate/generator.test.ts
+++ b/src/__test__/generate/generator.test.ts
@@ -21,9 +21,15 @@ describe("generater", () => {
   });
 
   it("should include GassmaSheet type", () => {
-    expect(result).toContain("declare type GassmaSheet = {");
-    expect(result).toContain('"User": GassmaUserController;');
-    expect(result).toContain('"Post": GassmaPostController;');
+    expect(result).toContain(
+      "declare type GassmaSheet<O extends GassmaGlobalOmitConfig = {}> = {",
+    );
+    expect(result).toContain(
+      '"User": GassmaUserController<O extends { "User": infer UO } ? UO extends GassmaUserOmit ? UO : {} : {}>;',
+    );
+    expect(result).toContain(
+      '"Post": GassmaPostController<O extends { "Post": infer UO } ? UO extends GassmaPostOmit ? UO : {} : {}>;',
+    );
   });
 
   it("should include Controller for each sheet", () => {

--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -4,7 +4,9 @@ describe("getOneGassmaController", () => {
   const result = getOneGassmaController("", "User");
 
   it("should generate controller class declaration", () => {
-    expect(result).toContain("declare class GassmaUserController");
+    expect(result).toContain(
+      "declare class GassmaUserController<GO extends GassmaUserOmit = {}>",
+    );
   });
 
   it("should include constructor", () => {
@@ -33,13 +35,13 @@ describe("getOneGassmaController", () => {
 
   it("should have generic delete method with model-specific type", () => {
     expect(result).toContain(
-      'delete<T extends GassmaUserDeleteSingleData>(deleteData: T): GassmaUserFindResult<T["select"]> | null',
+      'delete<T extends GassmaUserDeleteSingleData>(deleteData: T): GassmaUserFindResult<T["select"], T["omit"], GO> | null',
     );
   });
 
   it("should have generic upsert method with model-specific type", () => {
     expect(result).toContain(
-      'upsert<T extends GassmaUserUpsertSingleData>(upsertData: T): GassmaUserFindResult<T["select"]>',
+      'upsert<T extends GassmaUserUpsertSingleData>(upsertData: T): GassmaUserFindResult<T["select"], T["omit"], GO>',
     );
   });
 
@@ -61,13 +63,13 @@ describe("getOneGassmaController", () => {
 
   it("should have generic create method with FindResult return", () => {
     expect(result).toContain(
-      'create<T extends GassmaUserCreateData>(createdData: T): GassmaUserFindResult<T["select"]>',
+      'create<T extends GassmaUserCreateData>(createdData: T): GassmaUserFindResult<T["select"], T["omit"], GO>',
     );
   });
 
   it("should have generic update method with model-specific type", () => {
     expect(result).toContain(
-      'update<T extends GassmaUserUpdateSingleData>(updateData: T): GassmaUserFindResult<T["select"]> | null',
+      'update<T extends GassmaUserUpdateSingleData>(updateData: T): GassmaUserFindResult<T["select"], T["omit"], GO> | null',
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -27,7 +27,7 @@ describe("getGassmaMain", () => {
     expect(result).toContain("declare type GassmaTestClientOptions");
     expect(result).toContain("id?: string");
     expect(result).toContain("relations?: Gassma.RelationsConfig");
-    expect(result).toContain("omit?: GassmaTestGlobalOmitConfig");
+    expect(result).toContain("omit?: O");
   });
 
   it("should generate GassmaGlobalOmitConfig with model-specific omit", () => {

--- a/src/__test__/generate/typeGenerate/gassmaSheet.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaSheet.test.ts
@@ -4,21 +4,31 @@ describe("getGassmaSheet", () => {
   it("should generate controller type mapping for sheet names", () => {
     const result = getGassmaSheet(["User", "Post"], "");
 
-    expect(result).toContain("declare type GassmaSheet = {");
-    expect(result).toContain('"User": GassmaUserController;');
-    expect(result).toContain('"Post": GassmaPostController;');
+    expect(result).toContain(
+      "declare type GassmaSheet<O extends GassmaGlobalOmitConfig = {}> = {",
+    );
+    expect(result).toContain(
+      '"User": GassmaUserController<O extends { "User": infer UO } ? UO extends GassmaUserOmit ? UO : {} : {}>;',
+    );
+    expect(result).toContain(
+      '"Post": GassmaPostController<O extends { "Post": infer UO } ? UO extends GassmaPostOmit ? UO : {} : {}>;',
+    );
     expect(result).toContain("};");
   });
 
   it("should remove symbols only from variable name part", () => {
     const result = getGassmaSheet(["my-sheet"], "");
 
-    expect(result).toContain('"my-sheet": GassmamysheetController;');
+    expect(result).toContain(
+      '"my-sheet": GassmamysheetController<O extends { "my-sheet": infer UO } ? UO extends GassmamysheetOmit ? UO : {} : {}>;',
+    );
   });
 
   it("should generate empty object type for empty array", () => {
     const result = getGassmaSheet([], "");
 
-    expect(result).toBe("declare type GassmaSheet = {\n};\n");
+    expect(result).toBe(
+      "declare type GassmaSheet<O extends GassmaGlobalOmitConfig = {}> = {\n};\n",
+    );
   });
 });

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -57,6 +57,23 @@ const generateFromPrisma = (
   return generater(parsed, relations, schemaName, includeCommon);
 };
 
+const writeTsconfigWithTs = (tsconfigPath: string) => {
+  fs.writeFileSync(
+    tsconfigPath,
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        skipLibCheck: false,
+        lib: ["ES2021"],
+        module: "ES2020",
+        moduleResolution: "node",
+      },
+      include: ["*.d.ts", "*.ts"],
+    }),
+  );
+};
+
 describe("generated .d.ts type check", () => {
   it("should pass tsc --noEmit without type errors", () => {
     const prismaPath = path.join(__dirname, "fixture.prisma");
@@ -68,6 +85,76 @@ describe("generated .d.ts type check", () => {
     try {
       fs.writeFileSync(path.join(tmpDir, "generated.d.ts"), generated);
       writeTsconfig(tsconfigPath);
+
+      const result = runTsc(tmpDir, tsconfigPath);
+      expect(result).toBe("");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should reflect global omit in return types", () => {
+    const prismaPath = path.join(__dirname, "fixture.prisma");
+    const generated = generateFromPrisma(prismaPath);
+    const clientDts = generateClientDts("");
+
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "gassma-typecheck-omit-"),
+    );
+    const tsconfigPath = path.join(tmpDir, "tsconfig.json");
+
+    const usageTs = `
+/// <reference path="./generated.d.ts" />
+import { GassmaClient } from "./client";
+
+// グローバルomitなし: 全フィールドアクセス可能
+declare const client: GassmaClient;
+const r1 = client.sheets.User.findFirst({ where: { id: 1 } });
+if (r1) {
+  const email: string = r1.email;
+  const name: string | null = r1.name;
+}
+
+// グローバルomitあり: email が返り値から除外される
+declare const clientOmit: GassmaClient<{ User: { email: true } }>;
+const r2 = clientOmit.sheets.User.findFirst({ where: { id: 1 } });
+if (r2) {
+  const name: string | null = r2.name;
+  // @ts-expect-error email はグローバルomitで除外
+  r2.email;
+}
+
+// omit: { email: false } でグローバルomitを解除
+const r3 = clientOmit.sheets.User.findFirst({ where: { id: 1 }, omit: { email: false } });
+if (r3) {
+  const email: string = r3.email;
+}
+
+// select はグローバルomitを上書き
+const r4 = clientOmit.sheets.User.findFirst({ where: { id: 1 }, select: { email: true } });
+if (r4) {
+  const email: string = r4.email;
+}
+
+// クエリomitも返り値に反映
+const r5 = client.sheets.User.findFirst({ where: { id: 1 }, omit: { name: true } });
+if (r5) {
+  const email: string = r5.email;
+  // @ts-expect-error name はクエリomitで除外
+  r5.name;
+}
+
+// findMany でも同様
+const r6 = clientOmit.sheets.User.findMany({ where: {} });
+// @ts-expect-error email はグローバルomitで除外
+r6[0]?.email;
+`;
+
+    try {
+      fs.writeFileSync(path.join(tmpDir, "generated.d.ts"), generated);
+      fs.writeFileSync(path.join(tmpDir, "client.d.ts"), clientDts);
+      fs.writeFileSync(path.join(tmpDir, "usage.ts"), usageTs);
+      writeTsconfigWithTs(tsconfigPath);
 
       const result = runTsc(tmpDir, tsconfigPath);
       expect(result).toBe("");

--- a/src/generate/jsGenerate/generateClientDts.ts
+++ b/src/generate/jsGenerate/generateClientDts.ts
@@ -1,7 +1,7 @@
 const generateClientDts = (schemaName: string): string => {
-  return `export declare class GassmaClient {
-  constructor(options?: Gassma${schemaName}ClientOptions);
-  readonly sheets: Gassma${schemaName}Sheet;
+  return `export declare class GassmaClient<O extends Gassma${schemaName}GlobalOmitConfig = {}> {
+  constructor(options?: Gassma${schemaName}ClientOptions<O>);
+  readonly sheets: Gassma${schemaName}Sheet<O>;
 }
 `;
 };

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -47,6 +47,10 @@ const getGassmaCommonTypes = () => {
     isNot?: Record<string, unknown>;
   };
 
+  type TrueKeys<T> = { [K in keyof T]: T[K] extends true ? K : never }[keyof T];
+  type FalseKeys<T> = { [K in keyof T]: T[K] extends false ? K : never }[keyof T];
+  type ResolveOmitKeys<GO, QO> = Exclude<TrueKeys<GO>, FalseKeys<QO>> | TrueKeys<QO>;
+
   type ManyReturn = {
     count: number;
   };

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -1,6 +1,7 @@
 const getOneGassmaController = (schemaName: string, sheetName: string) => {
+  const fr = `Gassma${schemaName}${sheetName}FindResult`;
   return `
-declare class Gassma${schemaName}${sheetName}Controller {
+declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma${schemaName}${sheetName}Omit = {}> {
   constructor(sheetName: string, id?: string);
 
   readonly fields: Record<string, Gassma.FieldRef>;
@@ -11,16 +12,16 @@ declare class Gassma${schemaName}${sheetName}Controller {
   ): void;
   createMany(createdData: Gassma${schemaName}${sheetName}CreateManyData): CreateManyReturn;
   createManyAndReturn(createdData: Gassma${schemaName}${sheetName}CreateManyData): Record<string, unknown>[];
-  create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]>;
-  findFirst<T extends Gassma${schemaName}${sheetName}FindData>(findData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]> | null;
-  findFirstOrThrow<T extends Gassma${schemaName}${sheetName}FindData>(findData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]>;
-  findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]>[];
-  update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]> | null;
+  create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): ${fr}<T["select"], T["omit"], GO>;
+  findFirst<T extends Gassma${schemaName}${sheetName}FindData>(findData: T): ${fr}<T["select"], T["omit"], GO> | null;
+  findFirstOrThrow<T extends Gassma${schemaName}${sheetName}FindData>(findData: T): ${fr}<T["select"], T["omit"], GO>;
+  findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): ${fr}<T["select"], T["omit"], GO>[];
+  update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): ${fr}<T["select"], T["omit"], GO> | null;
   updateMany(updateData: Gassma${schemaName}${sheetName}UpdateData): UpdateManyReturn;
   updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): Record<string, unknown>[];
-  upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]>;
+  upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): ${fr}<T["select"], T["omit"], GO>;
   upsertMany(upsertData: Gassma${schemaName}${sheetName}UpsertData): UpsertManyReturn;
-  delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): Gassma${schemaName}${sheetName}FindResult<T["select"]> | null;
+  delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): ${fr}<T["select"], T["omit"], GO> | null;
   deleteMany(deleteData: Gassma${schemaName}${sheetName}DeleteData): DeleteManyReturn;
   aggregate<T extends Gassma${schemaName}${sheetName}AggregateData>(aggregateData: T): Gassma${schemaName}${sheetName}AggregateResult<T>;
   count(coutData: Gassma${schemaName}${sheetName}CountData): number;

--- a/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -1,14 +1,16 @@
 const getOneGassmaFindResult = (schemaName: string, sheetName: string) => {
   return `
-declare type Gassma${schemaName}${sheetName}FindResult<T> = T extends undefined
-  ? Gassma${schemaName}${sheetName}DefaultFindResult
-  : T extends Gassma${schemaName}${sheetName}Select
-    ? {
-        [K in keyof T as T[K] extends true
-          ? K & keyof Gassma${schemaName}${sheetName}DefaultFindResult
-          : never]: Gassma${schemaName}${sheetName}DefaultFindResult[K & keyof Gassma${schemaName}${sheetName}DefaultFindResult];
-      }
-    : Gassma${schemaName}${sheetName}DefaultFindResult;
+declare type Gassma${schemaName}${sheetName}FindResult<S, QO = undefined, GO = {}> = S extends Gassma${schemaName}${sheetName}Select
+  ? {
+      [K in keyof S as S[K] extends true
+        ? K & keyof Gassma${schemaName}${sheetName}DefaultFindResult
+        : never]: Gassma${schemaName}${sheetName}DefaultFindResult[K & keyof Gassma${schemaName}${sheetName}DefaultFindResult];
+    }
+  : {
+      [K in keyof Gassma${schemaName}${sheetName}DefaultFindResult as
+        K extends Gassma.ResolveOmitKeys<GO, QO> ? never : K
+      ]: Gassma${schemaName}${sheetName}DefaultFindResult[K];
+    };
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -15,10 +15,10 @@ const getGassmaGlobalOmitConfig = (
 };
 
 const getGassmaClientOptions = (schemaName: string) => {
-  return `declare type Gassma${schemaName}ClientOptions = {
+  return `declare type Gassma${schemaName}ClientOptions<O extends Gassma${schemaName}GlobalOmitConfig = {}> = {
   id?: string;
   relations?: Gassma.RelationsConfig;
-  omit?: Gassma${schemaName}GlobalOmitConfig;
+  omit?: O;
 };\n`;
 };
 
@@ -52,6 +52,7 @@ const getGassmaSchemaClient = (sheetNames: string[], schemaName: string) => {
     "${schemaName}": {
       sheets: Gassma${schemaName}Sheet;
       options: Gassma${schemaName}ClientOptions;
+      globalOmitConfig: Gassma${schemaName}GlobalOmitConfig;
     };
   }
 }

--- a/src/generate/typeGenerate/gassmaOmit/oneGassmaOmit.ts
+++ b/src/generate/typeGenerate/gassmaOmit/oneGassmaOmit.ts
@@ -9,7 +9,7 @@ const getOneGassmaOmit = (
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: true;\n`;
+    return `${pre}  "${removedQuestionMark}"?: true | false;\n`;
   }, `\ndeclare type Gassma${schemaName}${sheetName}Omit = {\n`);
 
   return `${oneOmit}};\n`;

--- a/src/generate/typeGenerate/gassmaSheet.ts
+++ b/src/generate/typeGenerate/gassmaSheet.ts
@@ -2,10 +2,10 @@ import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 
 const getGassmaSheet = (sheetNames: string[], schemaName: string) => {
   const sheetTypeDeclare = sheetNames.reduce((pre, current) => {
-    const removedSpaceCurrentSheetName = getRemovedCantUseVarChar(current);
+    const clean = getRemovedCantUseVarChar(current);
 
-    return `${pre}  "${current}": Gassma${schemaName}${removedSpaceCurrentSheetName}Controller;\n`;
-  }, `declare type Gassma${schemaName}Sheet = {\n`);
+    return `${pre}  "${current}": Gassma${schemaName}${clean}Controller<O extends { "${current}": infer UO } ? UO extends Gassma${schemaName}${clean}Omit ? UO : {} : {}>;\n`;
+  }, `declare type Gassma${schemaName}Sheet<O extends Gassma${schemaName}GlobalOmitConfig = {}> = {\n`);
 
   return sheetTypeDeclare + "};\n";
 };


### PR DESCRIPTION
## Summary
- GassmaClient, Sheet, Controllerをジェネリック化してグローバルomit設定を型レベルで追跡
- FindResultにselect/クエリomit/グローバルomitの3パラメータを追加
- Omit型の値を`true`固定から`true | false`に変更（`omit: { field: false }`でグローバルomit解除可能に）
- `ResolveOmitKeys`/`TrueKeys`/`FalseKeys`ヘルパー型をGassma namespaceに追加

## Test plan
- [x] 全193テスト通過
- [x] typecheckテストでグローバルomitの型レベル検証（`@ts-expect-error`による除外確認、`omit: { field: false }`による解除確認、selectによる上書き確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)