### PR TITLE
feat: アバウトな型をモデル固有の厳密な型に置換

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -7,16 +7,6 @@ describe("getGassmaCommonTypes", () => {
     expect(result).toContain("type RelationsConfig =");
   });
 
-  it("should generate IncludeData type", () => {
-    expect(result).toContain("type IncludeData =");
-  });
-
-  it("should generate CountValue related types", () => {
-    expect(result).toContain("type CountSelectItem =");
-    expect(result).toContain("type CountSelect =");
-    expect(result).toContain("type CountValue =");
-  });
-
   it("should generate NumberOperation type", () => {
     expect(result).toContain("type NumberOperation =");
     expect(result).toContain("increment?: number");
@@ -25,36 +15,10 @@ describe("getGassmaCommonTypes", () => {
     expect(result).toContain("divide?: number");
   });
 
-  it("should generate NestedWriteOperation type", () => {
-    expect(result).toContain("type NestedWriteOperation =");
-    expect(result).toContain("create?: unknown");
-    expect(result).toContain("connect?: unknown");
-    expect(result).toContain("connectOrCreate?: unknown");
-    expect(result).toContain("disconnect?: unknown");
-    expect(result).toContain("set?: unknown");
-  });
-
   it("should generate SortOrderInput type", () => {
     expect(result).toContain("type SortOrderInput =");
     expect(result).toContain('sort: "asc" | "desc"');
     expect(result).toContain('nulls?: "first" | "last"');
-  });
-
-  it("should generate RelationOrderBy type", () => {
-    expect(result).toContain("type RelationOrderBy =");
-  });
-
-  it("should generate RelationListFilter type", () => {
-    expect(result).toContain("type RelationListFilter =");
-    expect(result).toContain("some?:");
-    expect(result).toContain("every?:");
-    expect(result).toContain("none?:");
-  });
-
-  it("should generate RelationSingleFilter type", () => {
-    expect(result).toContain("type RelationSingleFilter =");
-    expect(result).toContain("is?:");
-    expect(result).toContain("isNot?:");
   });
 
   it("should generate ManyReturn types", () => {
@@ -64,5 +28,15 @@ describe("getGassmaCommonTypes", () => {
     expect(result).toContain("type UpdateManyReturn = ManyReturn");
     expect(result).toContain("type DeleteManyReturn = ManyReturn");
     expect(result).toContain("type UpsertManyReturn = ManyReturn");
+  });
+
+  it("should not contain removed generic types", () => {
+    expect(result).not.toContain("type IncludeData");
+    expect(result).not.toContain("type CountSelectItem");
+    expect(result).not.toContain("type CountValue");
+    expect(result).not.toContain("type NestedWriteOperation");
+    expect(result).not.toContain("type RelationOrderBy");
+    expect(result).not.toContain("type RelationListFilter");
+    expect(result).not.toContain("type RelationSingleFilter");
   });
 });

--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -47,13 +47,13 @@ describe("getOneGassmaController", () => {
 
   it("should include createManyAndReturn method", () => {
     expect(result).toContain(
-      "createManyAndReturn(createdData: GassmaUserCreateManyData): Record<string, unknown>[]",
+      "createManyAndReturn(createdData: GassmaUserCreateManyData): GassmaUserDefaultFindResult[]",
     );
   });
 
   it("should include updateManyAndReturn method", () => {
     expect(result).toContain(
-      "updateManyAndReturn(updateData: GassmaUserUpdateData): Record<string, unknown>[]",
+      "updateManyAndReturn(updateData: GassmaUserUpdateData): GassmaUserDefaultFindResult[]",
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaCountValue.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCountValue.test.ts
@@ -1,0 +1,56 @@
+import { getOneGassmaCountValue } from "../../../generate/typeGenerate/gassmaCountValue/oneGassmaCountValue";
+import type { RelationsConfig } from "../../../generate/read/extractRelations";
+
+describe("getOneGassmaCountValue", () => {
+  it("should generate CountValue type with relation names in select", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+        comments: {
+          type: "oneToMany",
+          to: "Comment",
+          field: "id",
+          reference: "userId",
+        },
+      },
+    };
+
+    const result = getOneGassmaCountValue("", "User", relations);
+
+    expect(result).toContain("declare type GassmaUserCountValue");
+    expect(result).toContain('"posts"?: true | { where?: GassmaPostWhereUse }');
+    expect(result).toContain(
+      '"comments"?: true | { where?: GassmaCommentWhereUse }',
+    );
+  });
+
+  it("should return true-only type when no relations", () => {
+    const relations: RelationsConfig = {};
+
+    const result = getOneGassmaCountValue("", "User", relations);
+
+    expect(result).toContain("declare type GassmaUserCountValue = true;");
+  });
+
+  it("should work with schemaName prefix", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+
+    const result = getOneGassmaCountValue("Test", "User", relations);
+
+    expect(result).toContain("declare type GassmaTestUserCountValue");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
@@ -9,7 +9,7 @@ describe("getOneGassmaCreate", () => {
     expect(result).toContain("data: GassmaUserUse");
   });
 
-  it("should add nested write operations for relations", () => {
+  it("should add nested write operations with target model types for oneToMany", () => {
     const relations: RelationsConfig = {
       User: {
         posts: {
@@ -23,20 +23,19 @@ describe("getOneGassmaCreate", () => {
 
     const result = getOneGassmaCreate("", "User", relations);
 
+    expect(result).toContain('"posts"?:');
+    expect(result).toContain("create?: GassmaPostUse | GassmaPostUse[]");
     expect(result).toContain(
-      'data: GassmaUserUse & {\n    "posts"?: Gassma.NestedWriteOperation;\n  }',
+      "connect?: GassmaPostWhereUse | GassmaPostWhereUse[]",
+    );
+    expect(result).toContain(
+      "connectOrCreate?: { where: GassmaPostWhereUse; create: GassmaPostUse }",
     );
   });
 
-  it("should add multiple relation fields", () => {
+  it("should add nested write operations with target model types for oneToOne", () => {
     const relations: RelationsConfig = {
       User: {
-        posts: {
-          type: "oneToMany",
-          to: "Post",
-          field: "id",
-          reference: "authorId",
-        },
         profile: {
           type: "oneToOne",
           to: "Profile",
@@ -48,8 +47,12 @@ describe("getOneGassmaCreate", () => {
 
     const result = getOneGassmaCreate("", "User", relations);
 
-    expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
-    expect(result).toContain('"profile"?: Gassma.NestedWriteOperation');
+    expect(result).toContain('"profile"?:');
+    expect(result).toContain("create?: GassmaProfileUse");
+    expect(result).toContain("connect?: GassmaProfileWhereUse");
+    expect(result).toContain(
+      "connectOrCreate?: { where: GassmaProfileWhereUse; create: GassmaProfileUse }",
+    );
   });
 
   it("should include select property", () => {

--- a/src/__test__/generate/typeGenerate/gassmaDeleteSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteSingleData.test.ts
@@ -22,7 +22,7 @@ describe("getOneGassmaDeleteSingleData", () => {
   it("should include include property", () => {
     const result = getOneGassmaDeleteSingleData("", "User");
 
-    expect(result).toContain("include?: Gassma.IncludeData;");
+    expect(result).toContain("include?: GassmaUserInclude;");
   });
 
   it("should include omit property", () => {

--- a/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
@@ -25,10 +25,10 @@ describe("getOneGassmaFindData", () => {
     expect(result).toContain("distinct?:");
   });
 
-  it("should include include property", () => {
+  it("should include model-specific include property", () => {
     const result = getOneGassmaFindData(sheetContent, "", "User");
 
-    expect(result).toContain("include?: Gassma.IncludeData");
+    expect(result).toContain("include?: GassmaUserInclude");
   });
 
   it("should include cursor property", () => {
@@ -37,9 +37,9 @@ describe("getOneGassmaFindData", () => {
     expect(result).toContain("cursor?: Partial<GassmaUserUse>;");
   });
 
-  it("should include _count property", () => {
+  it("should include model-specific _count property", () => {
     const result = getOneGassmaFindData(sheetContent, "", "User");
 
-    expect(result).toContain("_count?: Gassma.CountValue;");
+    expect(result).toContain("_count?: GassmaUserCountValue;");
   });
 });

--- a/src/__test__/generate/typeGenerate/gassmaInclude.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaInclude.test.ts
@@ -1,0 +1,75 @@
+import { getOneGassmaInclude } from "../../../generate/typeGenerate/gassmaInclude/oneGassmaInclude";
+import type { RelationsConfig } from "../../../generate/read/extractRelations";
+
+describe("getOneGassmaInclude", () => {
+  it("should generate Include type with relation names as keys", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+        profile: {
+          type: "oneToOne",
+          to: "Profile",
+          field: "id",
+          reference: "userId",
+        },
+      },
+    };
+
+    const result = getOneGassmaInclude("", "User", relations);
+
+    expect(result).toContain("declare type GassmaUserInclude");
+    expect(result).toContain('"posts"?:');
+    expect(result).toContain('"profile"?:');
+  });
+
+  it("should use true or include options as value type", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+
+    const result = getOneGassmaInclude("", "User", relations);
+
+    expect(result).toContain(
+      '"posts"?: true | { select?: GassmaPostSelect; omit?: GassmaPostOmit; where?: GassmaPostWhereUse; orderBy?: GassmaPostOrderBy; take?: number; skip?: number; _count?: GassmaPostCountValue };',
+    );
+  });
+
+  it("should return empty type when no relations", () => {
+    const relations: RelationsConfig = {};
+
+    const result = getOneGassmaInclude("", "User", relations);
+
+    expect(result).toContain("declare type GassmaUserInclude = {};");
+  });
+
+  it("should work with schemaName prefix", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+
+    const result = getOneGassmaInclude("Test", "User", relations);
+
+    expect(result).toContain("declare type GassmaTestUserInclude");
+    expect(result).toContain("GassmaTestPostSelect");
+    expect(result).toContain("GassmaTestPostWhereUse");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -58,10 +58,7 @@ describe("getGassmaMain", () => {
     expect(result).toContain("type RelationsConfig =");
     expect(result).toContain("type NumberOperation =");
     expect(result).toContain("type ManyReturn =");
-    expect(result).toContain("type NestedWriteOperation =");
     expect(result).toContain("type SortOrderInput =");
-    expect(result).toContain("type IncludeData =");
-    expect(result).toContain("type CountValue =");
   });
 
   it("should exclude common types when includeCommon is false", () => {

--- a/src/__test__/generate/typeGenerate/gassmaOrderBy.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaOrderBy.test.ts
@@ -27,7 +27,7 @@ describe("getOneGassmaOrderBy", () => {
     expect(result).not.toContain('"email?"');
   });
 
-  it("should add relation fields for ordering", () => {
+  it("should add relation fields with target model OrderBy type", () => {
     const relations: RelationsConfig = {
       User: {
         posts: {
@@ -41,10 +41,10 @@ describe("getOneGassmaOrderBy", () => {
 
     const result = getOneGassmaOrderBy(sheetContent, "", "User", relations);
 
-    expect(result).toContain('"posts"?: Gassma.RelationOrderBy;');
+    expect(result).toContain('"posts"?: GassmaPostOrderBy;');
   });
 
-  it("should add _count for relation count ordering", () => {
+  it("should add _count with relation name keys", () => {
     const relations: RelationsConfig = {
       User: {
         posts: {
@@ -53,12 +53,20 @@ describe("getOneGassmaOrderBy", () => {
           field: "id",
           reference: "authorId",
         },
+        profile: {
+          type: "oneToOne",
+          to: "Profile",
+          field: "id",
+          reference: "userId",
+        },
       },
     };
 
     const result = getOneGassmaOrderBy(sheetContent, "", "User", relations);
 
-    expect(result).toContain('"_count"?: Gassma.RelationOrderBy;');
+    expect(result).toContain(
+      '"_count"?: { "posts"?: "asc" | "desc"; "profile"?: "asc" | "desc" };',
+    );
   });
 
   it("should not add relation fields when no relations for model", () => {

--- a/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
@@ -26,7 +26,11 @@ describe("getOneGassmaUpdateData", () => {
 
     const result = getOneGassmaUpdateData("", "User", relations);
 
-    expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
+    expect(result).toContain('"posts"?:');
+    expect(result).toContain("create?: GassmaPostUse | GassmaPostUse[]");
+    expect(result).toContain(
+      "connect?: GassmaPostWhereUse | GassmaPostWhereUse[]",
+    );
   });
 
   it("should include limit property", () => {

--- a/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
@@ -49,6 +49,10 @@ describe("getOneGassmaUpdateSingleData", () => {
 
     const result = getOneGassmaUpdateSingleData("", "User", relations);
 
-    expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
+    expect(result).toContain('"posts"?:');
+    expect(result).toContain("create?: GassmaPostUse | GassmaPostUse[]");
+    expect(result).toContain(
+      "connect?: GassmaPostWhereUse | GassmaPostWhereUse[]",
+    );
   });
 });

--- a/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
@@ -38,7 +38,7 @@ describe("getOneGassmaUpsertSingleData", () => {
   it("should include include property", () => {
     const result = getOneGassmaUpsertSingleData("", "User");
 
-    expect(result).toContain("include?: Gassma.IncludeData;");
+    expect(result).toContain("include?: GassmaUserInclude;");
   });
 
   it("should include omit property", () => {
@@ -61,6 +61,10 @@ describe("getOneGassmaUpsertSingleData", () => {
 
     const result = getOneGassmaUpsertSingleData("", "User", relations);
 
-    expect(result).toContain('"posts"?: Gassma.NestedWriteOperation');
+    expect(result).toContain('"posts"?:');
+    expect(result).toContain("create?: GassmaPostUse | GassmaPostUse[]");
+    expect(result).toContain(
+      "connect?: GassmaPostWhereUse | GassmaPostWhereUse[]",
+    );
   });
 });

--- a/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
@@ -32,7 +32,9 @@ describe("getOneGassmaWhereUse", () => {
 
     const result = getOneGassmaWhereUse(sheetContent, "", "User", relations);
 
-    expect(result).toContain('"posts"?: Gassma.RelationListFilter');
+    expect(result).toContain(
+      '"posts"?: { some?: GassmaPostWhereUse; every?: GassmaPostWhereUse; none?: GassmaPostWhereUse }',
+    );
   });
 
   it("should add manyToOne relation filter with is/isNot", () => {
@@ -49,7 +51,9 @@ describe("getOneGassmaWhereUse", () => {
 
     const result = getOneGassmaWhereUse(sheetContent, "", "Post", relations);
 
-    expect(result).toContain('"author"?: Gassma.RelationSingleFilter');
+    expect(result).toContain(
+      '"author"?: { is?: GassmaUserWhereUse; isNot?: GassmaUserWhereUse }',
+    );
   });
 
   it("should add oneToOne relation filter with is/isNot", () => {
@@ -66,7 +70,9 @@ describe("getOneGassmaWhereUse", () => {
 
     const result = getOneGassmaWhereUse(sheetContent, "", "User", relations);
 
-    expect(result).toContain('"profile"?: Gassma.RelationSingleFilter');
+    expect(result).toContain(
+      '"profile"?: { is?: GassmaProfileWhereUse; isNot?: GassmaProfileWhereUse }',
+    );
   });
 
   it("should add manyToMany relation filter with some/every/none", () => {
@@ -83,7 +89,9 @@ describe("getOneGassmaWhereUse", () => {
 
     const result = getOneGassmaWhereUse(sheetContent, "", "Post", relations);
 
-    expect(result).toContain('"tags"?: Gassma.RelationListFilter');
+    expect(result).toContain(
+      '"tags"?: { some?: GassmaTagWhereUse; every?: GassmaTagWhereUse; none?: GassmaTagWhereUse }',
+    );
   });
 
   it("should not add relation fields when no relations for model", () => {

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -25,6 +25,8 @@ import { getGassmaHavingUse } from "./typeGenerate/gassmaHavingUse";
 import { getGassmaMain } from "./typeGenerate/gassmaMain";
 import { getGassmaManyCount } from "./typeGenerate/gassmaManyCount";
 import { getGassmaOmit } from "./typeGenerate/gassmaOmit";
+import { getGassmaInclude } from "./typeGenerate/gassmaInclude";
+import { getGassmaCountValue } from "./typeGenerate/gassmaCountValue";
 import { getGassmaOrderBy } from "./typeGenerate/gassmaOrderBy";
 import { getGassmaSelect } from "./typeGenerate/gassmaSelect";
 import { getGassmaSheet } from "./typeGenerate/gassmaSheet";
@@ -67,6 +69,8 @@ const generater = (
   result += getGassmaDeleteSingleData(sheetNames, schema);
   result += getGassmaAggregateData(sheetNames, schema);
   result += getGassmaGroupByData(dictYaml, schema);
+  result += getGassmaInclude(sheetNames, schema, relations);
+  result += getGassmaCountValue(sheetNames, schema, relations);
   result += getGassmaOrderBy(dictYaml, schema, relations);
   result += getGassmaSelect(dictYaml, schema);
   result += getGassmaOmit(dictYaml, schema);

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -1,14 +1,6 @@
 const getGassmaCommonTypes = () => {
   return `  type RelationsConfig = Record<string, Record<string, unknown>>;
 
-  type IncludeData = {
-    [relationName: string]: unknown;
-  };
-
-  type CountSelectItem = true | { where?: Record<string, unknown> };
-  type CountSelect = { select: { [relationName: string]: CountSelectItem } };
-  type CountValue = true | CountSelect;
-
   type NumberOperation = {
     increment?: number;
     decrement?: number;
@@ -16,35 +8,9 @@ const getGassmaCommonTypes = () => {
     divide?: number;
   };
 
-  type NestedWriteOperation = {
-    create?: unknown;
-    connect?: unknown;
-    connectOrCreate?: unknown;
-    update?: unknown;
-    delete?: unknown;
-    deleteMany?: unknown;
-    disconnect?: unknown;
-    set?: unknown;
-  };
-
   type SortOrderInput = {
     sort: "asc" | "desc";
     nulls?: "first" | "last";
-  };
-
-  type RelationOrderBy = {
-    [key: string]: "asc" | "desc";
-  };
-
-  type RelationListFilter = {
-    some?: Record<string, unknown>;
-    every?: Record<string, unknown>;
-    none?: Record<string, unknown>;
-  };
-
-  type RelationSingleFilter = {
-    is?: Record<string, unknown>;
-    isNot?: Record<string, unknown>;
   };
 
   type TrueKeys<T> = { [K in keyof T]: T[K] extends true ? K : never }[keyof T];

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -11,14 +11,14 @@ declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma${schem
     endColumnNumber: number
   ): void;
   createMany(createdData: Gassma${schemaName}${sheetName}CreateManyData): CreateManyReturn;
-  createManyAndReturn(createdData: Gassma${schemaName}${sheetName}CreateManyData): Record<string, unknown>[];
+  createManyAndReturn(createdData: Gassma${schemaName}${sheetName}CreateManyData): Gassma${schemaName}${sheetName}DefaultFindResult[];
   create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): ${fr}<T["select"], T["omit"], GO>;
   findFirst<T extends Gassma${schemaName}${sheetName}FindData>(findData: T): ${fr}<T["select"], T["omit"], GO> | null;
   findFirstOrThrow<T extends Gassma${schemaName}${sheetName}FindData>(findData: T): ${fr}<T["select"], T["omit"], GO>;
   findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): ${fr}<T["select"], T["omit"], GO>[];
   update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): ${fr}<T["select"], T["omit"], GO> | null;
   updateMany(updateData: Gassma${schemaName}${sheetName}UpdateData): UpdateManyReturn;
-  updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): Record<string, unknown>[];
+  updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): Gassma${schemaName}${sheetName}DefaultFindResult[];
   upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): ${fr}<T["select"], T["omit"], GO>;
   upsertMany(upsertData: Gassma${schemaName}${sheetName}UpsertData): UpsertManyReturn;
   delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): ${fr}<T["select"], T["omit"], GO> | null;

--- a/src/generate/typeGenerate/gassmaCountValue.ts
+++ b/src/generate/typeGenerate/gassmaCountValue.ts
@@ -1,0 +1,25 @@
+import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getOneGassmaCountValue } from "./gassmaCountValue/oneGassmaCountValue";
+import type { RelationsConfig } from "../read/extractRelations";
+
+const getGassmaCountValue = (
+  sheetNames: string[],
+  schemaName: string,
+  relations?: RelationsConfig,
+) => {
+  return sheetNames.reduce((pre, currentSheetName) => {
+    const removedSpaceCurrentSheetName =
+      getRemovedCantUseVarChar(currentSheetName);
+
+    return (
+      pre +
+      getOneGassmaCountValue(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        relations,
+      )
+    );
+  }, "");
+};
+
+export { getGassmaCountValue };

--- a/src/generate/typeGenerate/gassmaCountValue/oneGassmaCountValue.ts
+++ b/src/generate/typeGenerate/gassmaCountValue/oneGassmaCountValue.ts
@@ -1,0 +1,21 @@
+import type { RelationsConfig } from "../../read/extractRelations";
+
+const getOneGassmaCountValue = (
+  schemaName: string,
+  sheetName: string,
+  relations?: RelationsConfig,
+): string => {
+  const modelRelations = relations?.[sheetName];
+  if (!modelRelations || Object.keys(modelRelations).length === 0) {
+    return `\ndeclare type Gassma${schemaName}${sheetName}CountValue = true;\n`;
+  }
+
+  const fields = Object.keys(modelRelations).reduce((pre, relationName) => {
+    const targetModel = modelRelations[relationName].to;
+    return `${pre}    "${relationName}"?: true | { where?: Gassma${schemaName}${targetModel}WhereUse };\n`;
+  }, "");
+
+  return `\ndeclare type Gassma${schemaName}${sheetName}CountValue = true | { select: {\n${fields}  } };\n`;
+};
+
+export { getOneGassmaCountValue };

--- a/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
+++ b/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
@@ -6,7 +6,7 @@ const getOneGassmaCreate = (
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
-  const nestedFields = getNestedWriteFields(sheetName, relations);
+  const nestedFields = getNestedWriteFields(schemaName, sheetName, relations);
   const dataType = nestedFields
     ? `Gassma${schemaName}${sheetName}Use & {\n${nestedFields}  }`
     : `Gassma${schemaName}${sheetName}Use`;

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
@@ -6,7 +6,7 @@ const getOneGassmaDeleteSingleData = (
 declare type Gassma${schemaName}${sheetName}DeleteSingleData = {
   where: Gassma${schemaName}${sheetName}WhereUse;
   select?: Gassma${schemaName}${sheetName}Select;
-  include?: Gassma.IncludeData;
+  include?: Gassma${schemaName}${sheetName}Include;
   omit?: Gassma${schemaName}${sheetName}Omit;
 };
 `;

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -33,9 +33,9 @@ const getOneGassmaFindData = (
   take?: number;
   skip?: number;
   distinct?: ${distinctData}(${distinctArrayData})[];
-  include?: Gassma.IncludeData;
+  include?: Gassma${schemaName}${sheetName}Include;
   cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
-  _count?: Gassma.CountValue;
+  _count?: Gassma${schemaName}${sheetName}CountValue;
 };\n`;
 };
 

--- a/src/generate/typeGenerate/gassmaInclude.ts
+++ b/src/generate/typeGenerate/gassmaInclude.ts
@@ -1,0 +1,21 @@
+import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getOneGassmaInclude } from "./gassmaInclude/oneGassmaInclude";
+import type { RelationsConfig } from "../read/extractRelations";
+
+const getGassmaInclude = (
+  sheetNames: string[],
+  schemaName: string,
+  relations?: RelationsConfig,
+) => {
+  return sheetNames.reduce((pre, currentSheetName) => {
+    const removedSpaceCurrentSheetName =
+      getRemovedCantUseVarChar(currentSheetName);
+
+    return (
+      pre +
+      getOneGassmaInclude(schemaName, removedSpaceCurrentSheetName, relations)
+    );
+  }, "");
+};
+
+export { getGassmaInclude };

--- a/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
+++ b/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
@@ -1,0 +1,23 @@
+import type { RelationsConfig } from "../../read/extractRelations";
+
+const getOneGassmaInclude = (
+  schemaName: string,
+  sheetName: string,
+  relations?: RelationsConfig,
+): string => {
+  const modelRelations = relations?.[sheetName];
+  if (!modelRelations || Object.keys(modelRelations).length === 0) {
+    return `\ndeclare type Gassma${schemaName}${sheetName}Include = {};\n`;
+  }
+
+  const fields = Object.keys(modelRelations).reduce((pre, relationName) => {
+    const targetModel = modelRelations[relationName].to;
+    const target = `Gassma${schemaName}${targetModel}`;
+    const optionsType = `{ select?: ${target}Select; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; _count?: ${target}CountValue }`;
+    return `${pre}  "${relationName}"?: true | ${optionsType};\n`;
+  }, "");
+
+  return `\ndeclare type Gassma${schemaName}${sheetName}Include = {\n${fields}};\n`;
+};
+
+export { getOneGassmaInclude };

--- a/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
+++ b/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
@@ -18,13 +18,16 @@ const getOneGassmaOrderBy = (
   const modelRelations = relations?.[sheetName];
   const relationFields = modelRelations
     ? Object.keys(modelRelations).reduce((pre, relationName) => {
-        return `${pre}  "${relationName}"?: Gassma.RelationOrderBy;\n`;
+        const targetModel = modelRelations[relationName].to;
+        return `${pre}  "${relationName}"?: Gassma${schemaName}${targetModel}OrderBy;\n`;
       }, "")
     : "";
 
   const countField =
     modelRelations && Object.keys(modelRelations).length > 0
-      ? '  "_count"?: Gassma.RelationOrderBy;\n'
+      ? `  "_count"?: { ${Object.keys(modelRelations)
+          .map((name) => `"${name}"?: "asc" | "desc"`)
+          .join("; ")} };\n`
       : "";
 
   return `${scalarFields}${relationFields}${countField}};\n`;

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
@@ -6,7 +6,7 @@ const getOneGassmaUpdateData = (
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
-  const nestedFields = getNestedWriteFields(sheetName, relations);
+  const nestedFields = getNestedWriteFields(schemaName, sheetName, relations);
   const baseDataType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>`;
   const dataType = nestedFields
     ? `${baseDataType} & {\n${nestedFields}  }`

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
@@ -6,7 +6,7 @@ const getOneGassmaUpdateSingleData = (
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
-  const nestedFields = getNestedWriteFields(sheetName, relations);
+  const nestedFields = getNestedWriteFields(schemaName, sheetName, relations);
   const baseDataType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>`;
   const dataType = nestedFields
     ? `${baseDataType} & {\n${nestedFields}  }`

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
@@ -6,7 +6,7 @@ const getOneGassmaUpsertSingleData = (
   sheetName: string,
   relations?: RelationsConfig,
 ) => {
-  const nestedFields = getNestedWriteFields(sheetName, relations);
+  const nestedFields = getNestedWriteFields(schemaName, sheetName, relations);
 
   const createType = nestedFields
     ? `Gassma${schemaName}${sheetName}Use & {\n${nestedFields}  }`
@@ -23,7 +23,7 @@ declare type Gassma${schemaName}${sheetName}UpsertSingleData = {
   create: ${createType};
   update: ${updateType};
   select?: Gassma${schemaName}${sheetName}Select;
-  include?: Gassma.IncludeData;
+  include?: Gassma${schemaName}${sheetName}Include;
   omit?: Gassma${schemaName}${sheetName}Omit;
 };
 `;

--- a/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
@@ -6,6 +6,7 @@ const isListRelation = (type: string): boolean =>
   type === "oneToMany" || type === "manyToMany";
 
 const getRelationFields = (
+  schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
 ): string => {
@@ -15,9 +16,10 @@ const getRelationFields = (
 
   return Object.keys(modelRelations).reduce((pre, relationName) => {
     const rel = modelRelations[relationName];
+    const targetWhere = `Gassma${schemaName}${rel.to}WhereUse`;
     const filterType = isListRelation(rel.type)
-      ? "Gassma.RelationListFilter"
-      : "Gassma.RelationSingleFilter";
+      ? `{ some?: ${targetWhere}; every?: ${targetWhere}; none?: ${targetWhere} }`
+      : `{ is?: ${targetWhere}; isNot?: ${targetWhere} }`;
 
     return `${pre}  "${relationName}"?: ${filterType};\n`;
   }, "");
@@ -42,7 +44,7 @@ const getOneGassmaWhereUse = (
     return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;\n`;
   }, `\ndeclare type Gassma${schemaName}${sheetName}WhereUse = {\n`);
 
-  const relationFields = getRelationFields(sheetName, relations);
+  const relationFields = getRelationFields(schemaName, sheetName, relations);
 
   return `${oneWhereUse}${relationFields}
   AND?: Gassma${schemaName}${sheetName}WhereUse[] | Gassma${schemaName}${sheetName}WhereUse;

--- a/src/generate/typeGenerate/util/getNestedWriteFields.ts
+++ b/src/generate/typeGenerate/util/getNestedWriteFields.ts
@@ -1,6 +1,10 @@
 import type { RelationsConfig } from "../../read/extractRelations";
 
+const isListRelation = (type: string): boolean =>
+  type === "oneToMany" || type === "manyToMany";
+
 const getNestedWriteFields = (
+  schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
 ): string => {
@@ -9,7 +13,21 @@ const getNestedWriteFields = (
   if (!modelRelations) return "";
 
   const fields = Object.keys(modelRelations).reduce((pre, relationName) => {
-    return `${pre}    "${relationName}"?: Gassma.NestedWriteOperation;\n`;
+    const rel = modelRelations[relationName];
+    const target = `Gassma${schemaName}${rel.to}`;
+    const isList = isListRelation(rel.type);
+
+    const createType = isList
+      ? `${target}Use | ${target}Use[]`
+      : `${target}Use`;
+    const connectType = isList
+      ? `${target}WhereUse | ${target}WhereUse[]`
+      : `${target}WhereUse`;
+    const connectOrCreateType = isList
+      ? `{ where: ${target}WhereUse; create: ${target}Use } | { where: ${target}WhereUse; create: ${target}Use }[]`
+      : `{ where: ${target}WhereUse; create: ${target}Use }`;
+
+    return `${pre}    "${relationName}"?: { create?: ${createType}; connect?: ${connectType}; connectOrCreate?: ${connectOrCreateType} };\n`;
   }, "");
 
   return fields;


### PR DESCRIPTION
## 概要

共通 namespace にあった汎用的な型（`[key: string]` や `unknown`）を、モデル固有の厳密な型に置き換えました。

### 変更内容

- `createManyAndReturn` / `updateManyAndReturn` の返り値を `Record<string, unknown>[]` → `DefaultFindResult[]` に変更
- `RelationOrderBy` をリレーション先モデルの OrderBy 型参照に置換
- `_count` の OrderBy を具体的なリレーション名に限定
- `IncludeData` をモデルごとの Include 型に置換（リレーション名・オプション型を厳密化）
- `CountValue` をモデルごとの CountValue 型に置換（リレーション名・where型を厳密化）
- `RelationListFilter` / `RelationSingleFilter` をリレーション先の WhereUse にインライン化
- `NestedWriteOperation` をリレーション先の Use / WhereUse 型にインライン化
- `CountSelectItem` をリレーション先の WhereUse にインライン化
- 不要になった共通型（IncludeData, RelationOrderBy, RelationListFilter 等）を namespace から削除

## テスト

- 全195テスト通過
- typecheck テスト（tsc --noEmit）通過
- ビルド成功