### PR TITLE
fix: Include型/_count/NestedWrite操作の不足を修正

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaInclude.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaInclude.test.ts
@@ -42,8 +42,25 @@ describe("getOneGassmaInclude", () => {
     const result = getOneGassmaInclude("", "User", relations);
 
     expect(result).toContain(
-      '"posts"?: true | { select?: GassmaPostSelect; omit?: GassmaPostOmit; where?: GassmaPostWhereUse; orderBy?: GassmaPostOrderBy; take?: number; skip?: number; _count?: GassmaPostCountValue };',
+      '"posts"?: true | { select?: GassmaPostSelect; omit?: GassmaPostOmit; where?: GassmaPostWhereUse; orderBy?: GassmaPostOrderBy; take?: number; skip?: number; include?: GassmaPostInclude; _count?: GassmaPostCountValue };',
     );
+  });
+
+  it("should include _count at top level", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+
+    const result = getOneGassmaInclude("", "User", relations);
+
+    expect(result).toContain('"_count"?: GassmaUserCountValue');
   });
 
   it("should return empty type when no relations", () => {

--- a/src/__test__/generate/typeGenerate/gassmaOrderBy.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaOrderBy.test.ts
@@ -41,7 +41,9 @@ describe("getOneGassmaOrderBy", () => {
 
     const result = getOneGassmaOrderBy(sheetContent, "", "User", relations);
 
-    expect(result).toContain('"posts"?: GassmaPostOrderBy;');
+    expect(result).toContain(
+      '"posts"?: GassmaPostOrderBy | { _count: "asc" | "desc" };',
+    );
   });
 
   it("should add _count with relation name keys", () => {

--- a/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
+++ b/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
@@ -13,11 +13,13 @@ const getOneGassmaInclude = (
   const fields = Object.keys(modelRelations).reduce((pre, relationName) => {
     const targetModel = modelRelations[relationName].to;
     const target = `Gassma${schemaName}${targetModel}`;
-    const optionsType = `{ select?: ${target}Select; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; _count?: ${target}CountValue }`;
+    const optionsType = `{ select?: ${target}Select; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; include?: ${target}Include; _count?: ${target}CountValue }`;
     return `${pre}  "${relationName}"?: true | ${optionsType};\n`;
   }, "");
 
-  return `\ndeclare type Gassma${schemaName}${sheetName}Include = {\n${fields}};\n`;
+  const countField = `  "_count"?: Gassma${schemaName}${sheetName}CountValue;\n`;
+
+  return `\ndeclare type Gassma${schemaName}${sheetName}Include = {\n${fields}${countField}};\n`;
 };
 
 export { getOneGassmaInclude };

--- a/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
+++ b/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
@@ -19,7 +19,7 @@ const getOneGassmaOrderBy = (
   const relationFields = modelRelations
     ? Object.keys(modelRelations).reduce((pre, relationName) => {
         const targetModel = modelRelations[relationName].to;
-        return `${pre}  "${relationName}"?: Gassma${schemaName}${targetModel}OrderBy;\n`;
+        return `${pre}  "${relationName}"?: Gassma${schemaName}${targetModel}OrderBy | { _count: "asc" | "desc" };\n`;
       }, "")
     : "";
 

--- a/src/generate/typeGenerate/util/getNestedWriteFields.ts
+++ b/src/generate/typeGenerate/util/getNestedWriteFields.ts
@@ -27,7 +27,32 @@ const getNestedWriteFields = (
       ? `{ where: ${target}WhereUse; create: ${target}Use } | { where: ${target}WhereUse; create: ${target}Use }[]`
       : `{ where: ${target}WhereUse; create: ${target}Use }`;
 
-    return `${pre}    "${relationName}"?: { create?: ${createType}; connect?: ${connectType}; connectOrCreate?: ${connectOrCreateType} };\n`;
+    const ops = [
+      `create?: ${createType}`,
+      `connect?: ${connectType}`,
+      `connectOrCreate?: ${connectOrCreateType}`,
+    ];
+
+    if (rel.type === "oneToMany") {
+      ops.push(
+        `update?: { where: ${target}WhereUse; data: Partial<${target}Use> } | { where: ${target}WhereUse; data: Partial<${target}Use> }[]`,
+      );
+      ops.push(`delete?: boolean | ${target}WhereUse | ${target}WhereUse[]`);
+      ops.push(`deleteMany?: ${target}WhereUse | ${target}WhereUse[]`);
+      ops.push(
+        `disconnect?: boolean | ${target}WhereUse | ${target}WhereUse[]`,
+      );
+      ops.push(`set?: ${target}WhereUse[]`);
+    } else if (rel.type === "oneToOne") {
+      ops.push(`update?: Partial<${target}Use>`);
+      ops.push("delete?: true");
+      ops.push("disconnect?: true");
+    } else if (rel.type === "manyToMany") {
+      ops.push(`disconnect?: ${target}WhereUse | ${target}WhereUse[]`);
+      ops.push(`set?: ${target}WhereUse[]`);
+    }
+
+    return `${pre}    "${relationName}"?: { ${ops.join("; ")} };\n`;
   }, "");
 
   return fields;


### PR DESCRIPTION
## 概要

PR #46 で生成した厳密な型に不足があり、gassma-test で型エラーが発生していた問題を修正。

### 修正内容

- **Include型**: ネストされた `include` オプションと `_count` をトップレベルに追加
- **OrderBy型**: リレーションフィールドに `{ _count: "asc" | "desc" }` ユニオンを追加
- **NestedWrite型**: リレーション種別ごとに `update`/`delete`/`deleteMany`/`disconnect`/`set` を追加
  - oneToMany: 全操作対応
  - oneToOne: update/delete/disconnect 追加
  - manyToMany: disconnect/set 追加

## テスト

- 全196テスト通過
- typecheck テスト通過
- gassma-test の型エラーすべて解消