### PR TITLE
feat: select と omit の同時指定を型レベルで禁止

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
@@ -64,7 +64,14 @@ describe("getOneGassmaCreate", () => {
   it("should include omit property", () => {
     const result = getOneGassmaCreate("", "User");
 
-    expect(result).toContain("omit?: GassmaUserOmit;");
+    expect(result).toContain("omit?: GassmaUserOmit");
+  });
+
+  it("should make select and omit mutually exclusive", () => {
+    const result = getOneGassmaCreate("", "User");
+
+    expect(result).toContain("select?: GassmaUserSelect; omit?: never");
+    expect(result).toContain("select?: never; omit?: GassmaUserOmit");
   });
 
   it("should not add relation fields when no relations for model", () => {

--- a/src/__test__/generate/typeGenerate/gassmaDeleteSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteSingleData.test.ts
@@ -28,6 +28,13 @@ describe("getOneGassmaDeleteSingleData", () => {
   it("should include omit property", () => {
     const result = getOneGassmaDeleteSingleData("", "User");
 
-    expect(result).toContain("omit?: GassmaUserOmit;");
+    expect(result).toContain("omit?: GassmaUserOmit");
+  });
+
+  it("should make select and omit mutually exclusive", () => {
+    const result = getOneGassmaDeleteSingleData("", "User");
+
+    expect(result).toContain("select?: GassmaUserSelect; omit?: never");
+    expect(result).toContain("select?: never; omit?: GassmaUserOmit");
   });
 });

--- a/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindData.test.ts
@@ -17,6 +17,13 @@ describe("getOneGassmaFindData", () => {
     expect(result).toContain("orderBy?: GassmaUserOrderBy");
   });
 
+  it("should make select and omit mutually exclusive", () => {
+    const result = getOneGassmaFindData(sheetContent, "", "User");
+
+    expect(result).toContain("select?: GassmaUserSelect; omit?: never");
+    expect(result).toContain("select?: never; omit?: GassmaUserOmit");
+  });
+
   it("should include take, skip, and distinct", () => {
     const result = getOneGassmaFindData(sheetContent, "", "User");
 

--- a/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
@@ -32,7 +32,14 @@ describe("getOneGassmaUpdateSingleData", () => {
   it("should include omit property", () => {
     const result = getOneGassmaUpdateSingleData("", "User");
 
-    expect(result).toContain("omit?: GassmaUserOmit;");
+    expect(result).toContain("omit?: GassmaUserOmit");
+  });
+
+  it("should make select and omit mutually exclusive", () => {
+    const result = getOneGassmaUpdateSingleData("", "User");
+
+    expect(result).toContain("select?: GassmaUserSelect; omit?: never");
+    expect(result).toContain("select?: never; omit?: GassmaUserOmit");
   });
 
   it("should add nested write operations for relations", () => {

--- a/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
@@ -44,7 +44,14 @@ describe("getOneGassmaUpsertSingleData", () => {
   it("should include omit property", () => {
     const result = getOneGassmaUpsertSingleData("", "User");
 
-    expect(result).toContain("omit?: GassmaUserOmit;");
+    expect(result).toContain("omit?: GassmaUserOmit");
+  });
+
+  it("should make select and omit mutually exclusive", () => {
+    const result = getOneGassmaUpsertSingleData("", "User");
+
+    expect(result).toContain("select?: GassmaUserSelect; omit?: never");
+    expect(result).toContain("select?: never; omit?: GassmaUserOmit");
   });
 
   it("should add nested write operations for relations in create and update", () => {

--- a/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
+++ b/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
@@ -11,12 +11,13 @@ const getOneGassmaCreate = (
     ? `Gassma${schemaName}${sheetName}Use & {\n${nestedFields}  }`
     : `Gassma${schemaName}${sheetName}Use`;
 
+  const s = `Gassma${schemaName}${sheetName}Select`;
+  const o = `Gassma${schemaName}${sheetName}Omit`;
+
   return `
 declare type Gassma${schemaName}${sheetName}CreateData = {
   data: ${dataType};
-  select?: Gassma${schemaName}${sheetName}Select;
-  omit?: Gassma${schemaName}${sheetName}Omit;
-};
+} & ({ select?: ${s}; omit?: never } | { select?: never; omit?: ${o} });
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
@@ -2,13 +2,14 @@ const getOneGassmaDeleteSingleData = (
   schemaName: string,
   sheetName: string,
 ) => {
+  const s = `Gassma${schemaName}${sheetName}Select`;
+  const o = `Gassma${schemaName}${sheetName}Omit`;
+
   return `
 declare type Gassma${schemaName}${sheetName}DeleteSingleData = {
   where: Gassma${schemaName}${sheetName}WhereUse;
-  select?: Gassma${schemaName}${sheetName}Select;
   include?: Gassma${schemaName}${sheetName}Include;
-  omit?: Gassma${schemaName}${sheetName}Omit;
-};
+} & ({ select?: ${s}; omit?: never } | { select?: never; omit?: ${o} });
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -25,10 +25,11 @@ const getOneGassmaFindData = (
     return `${pre}"${removedQuestionMark}" | `;
   }, "");
 
+  const s = `Gassma${schemaName}${sheetName}Select`;
+  const o = `Gassma${schemaName}${sheetName}Omit`;
+
   return `\ndeclare type Gassma${schemaName}${sheetName}FindData = {
   where?: Gassma${schemaName}${sheetName}WhereUse;
-  select?: Gassma${schemaName}${sheetName}Select;
-  omit?: Gassma${schemaName}${sheetName}Omit;
   orderBy?: Gassma${schemaName}${sheetName}OrderBy;
   take?: number;
   skip?: number;
@@ -36,7 +37,7 @@ const getOneGassmaFindData = (
   include?: Gassma${schemaName}${sheetName}Include;
   cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
   _count?: Gassma${schemaName}${sheetName}CountValue;
-};\n`;
+} & ({ select?: ${s}; omit?: never } | { select?: never; omit?: ${o} });\n`;
 };
 
 export { getOneGassmaFindData };

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
@@ -12,13 +12,14 @@ const getOneGassmaUpdateSingleData = (
     ? `${baseDataType} & {\n${nestedFields}  }`
     : baseDataType;
 
+  const s = `Gassma${schemaName}${sheetName}Select`;
+  const o = `Gassma${schemaName}${sheetName}Omit`;
+
   return `
 declare type Gassma${schemaName}${sheetName}UpdateSingleData = {
   where: Gassma${schemaName}${sheetName}WhereUse;
   data: ${dataType};
-  select?: Gassma${schemaName}${sheetName}Select;
-  omit?: Gassma${schemaName}${sheetName}Omit;
-};
+} & ({ select?: ${s}; omit?: never } | { select?: never; omit?: ${o} });
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
@@ -17,15 +17,16 @@ const getOneGassmaUpsertSingleData = (
     ? `${baseUpdateType} & {\n${nestedFields}  }`
     : baseUpdateType;
 
+  const s = `Gassma${schemaName}${sheetName}Select`;
+  const o = `Gassma${schemaName}${sheetName}Omit`;
+
   return `
 declare type Gassma${schemaName}${sheetName}UpsertSingleData = {
   where: Gassma${schemaName}${sheetName}WhereUse;
   create: ${createType};
   update: ${updateType};
-  select?: Gassma${schemaName}${sheetName}Select;
   include?: Gassma${schemaName}${sheetName}Include;
-  omit?: Gassma${schemaName}${sheetName}Omit;
-};
+} & ({ select?: ${s}; omit?: never } | { select?: never; omit?: ${o} });
 `;
 };
 


### PR DESCRIPTION
## 概要

- select と omit の同時指定を型レベルで禁止（従来はランタイムエラーのみ）
- ユニオン型のインターセクションで排他制約を実現: `& ({ select?: Select; omit?: never } | { select?: never; omit?: Omit })`

## 対象型

- `FindData` / `FindManyData`
- `CreateData`
- `UpdateSingleData`
- `DeleteSingleData`
- `UpsertSingleData`

## テスト

- 5つのテストファイルに排他制約テストを追加（全201テスト Green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)