### PR TITLE
feat: @gassma.replaceType ディレクティブ追加

### DIFF
--- a/src/__test__/generate/read/extractAddTypes.test.ts
+++ b/src/__test__/generate/read/extractAddTypes.test.ts
@@ -1,4 +1,7 @@
-import { extractAddTypes } from "../../../generate/read/extractAddTypes";
+import {
+  extractAddTypes,
+  extractReplaceTypes,
+} from "../../../generate/read/extractAddTypes";
 
 describe("extractAddTypes", () => {
   it("should extract addType for a field", () => {
@@ -118,5 +121,83 @@ model User {
     const result = extractAddTypes(schema);
 
     expect(result).toEqual({});
+  });
+});
+
+describe("extractReplaceTypes", () => {
+  it("should extract replaceType for a field", () => {
+    const schema = `
+model User {
+  /// @gassma.replaceType "admin", "user"
+  role String
+}
+`;
+    const result = extractReplaceTypes(schema);
+
+    expect(result).toEqual({
+      User: { role: ["admin", "user"] },
+    });
+  });
+
+  it("should extract single replaceType value", () => {
+    const schema = `
+model Order {
+  /// @gassma.replaceType "pending", "shipped", "delivered"
+  status String
+}
+`;
+    const result = extractReplaceTypes(schema);
+
+    expect(result).toEqual({
+      Order: { status: ["pending", "shipped", "delivered"] },
+    });
+  });
+
+  it("should return empty object when no replaceType comments exist", () => {
+    const schema = `
+model User {
+  id Int @id
+  name String
+}
+`;
+    const result = extractReplaceTypes(schema);
+
+    expect(result).toEqual({});
+  });
+
+  it("should handle multiple models with replaceType", () => {
+    const schema = `
+model User {
+  /// @gassma.replaceType "admin", "user"
+  role String
+}
+
+model Order {
+  /// @gassma.replaceType "pending", "shipped"
+  status String
+}
+`;
+    const result = extractReplaceTypes(schema);
+
+    expect(result).toEqual({
+      User: { role: ["admin", "user"] },
+      Order: { status: ["pending", "shipped"] },
+    });
+  });
+
+  it("should not interfere with addType", () => {
+    const schema = `
+model User {
+  /// @gassma.addType boolean
+  id Int @id
+  /// @gassma.replaceType "admin", "user"
+  role String
+}
+`;
+    const addResult = extractAddTypes(schema);
+    const replaceResult = extractReplaceTypes(schema);
+
+    expect(addResult).toEqual({ User: { id: ["boolean"] } });
+    expect(replaceResult).toEqual({ User: { role: ["admin", "user"] } });
   });
 });

--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -189,6 +189,33 @@ model User {
     expect(result.User.id).toEqual(["number", "string", "boolean"]);
   });
 
+  it("should replace base type with @gassma.replaceType", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  /// @gassma.replaceType "admin", "user", "moderator"
+  role String
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User.role).toEqual(["admin", "user", "moderator"]);
+  });
+
+  it("should not include base type when using replaceType", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  /// @gassma.replaceType "active", "inactive"
+  status String
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User.status).not.toContain("string");
+    expect(result.User.status).toEqual(["active", "inactive"]);
+  });
+
   it("should ignore relation fields (list types referencing other models)", () => {
     const schema = `
 model User {

--- a/src/generate/read/extractAddTypes.ts
+++ b/src/generate/read/extractAddTypes.ts
@@ -8,22 +8,33 @@ type AddTypesConfig = {
 };
 
 const GASSMA_ADD_TYPE_PREFIX = "@gassma.addType ";
+const GASSMA_REPLACE_TYPE_PREFIX = "@gassma.replaceType ";
 
-const extractAddTypes = (schemaText: string): AddTypesConfig => {
+const extractAddTypes = (schemaText: string): AddTypesConfig =>
+  extractByPrefix(schemaText, GASSMA_ADD_TYPE_PREFIX);
+
+const extractByPrefix = (
+  schemaText: string,
+  prefix: string,
+): AddTypesConfig => {
   const ast = parsePrismaSchema(schemaText);
   const result: AddTypesConfig = {};
 
   ast.declarations.forEach((decl) => {
     if (decl.kind !== "model") return;
-    processModel(decl, result);
+    processModel(decl, result, prefix);
   });
 
   return result;
 };
 
+const extractReplaceTypes = (schemaText: string): AddTypesConfig =>
+  extractByPrefix(schemaText, GASSMA_REPLACE_TYPE_PREFIX);
+
 const processModel = (
   model: ModelDeclaration,
   result: AddTypesConfig,
+  prefix: string,
 ): void => {
   const members = model.members;
 
@@ -35,9 +46,9 @@ const processModel = (
 
     member.comments.forEach((comment) => {
       if (comment.kind !== "docComment") return;
-      if (!comment.text.startsWith(GASSMA_ADD_TYPE_PREFIX)) return;
+      if (!comment.text.startsWith(prefix)) return;
 
-      const typesString = comment.text.slice(GASSMA_ADD_TYPE_PREFIX.length);
+      const typesString = comment.text.slice(prefix.length);
       const types = typesString
         .split(",")
         .map((t) => t.trim().replace(/^"|"$/g, ""));
@@ -48,5 +59,5 @@ const processModel = (
   });
 };
 
-export { extractAddTypes };
+export { extractAddTypes, extractReplaceTypes };
 export type { AddTypesConfig };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -1,13 +1,14 @@
 import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
 import { mapPrismaType } from "./mapPrismaType";
 import { isScalarField } from "./isScalarField";
-import { extractAddTypes } from "./extractAddTypes";
+import { extractAddTypes, extractReplaceTypes } from "./extractAddTypes";
 
 function prismaReader(
   schemaText: string,
 ): Record<string, Record<string, unknown[]>> {
   const ast = parsePrismaSchema(schemaText);
   const addTypes = extractAddTypes(schemaText);
+  const replaceTypes = extractReplaceTypes(schemaText);
   const result: Record<string, Record<string, unknown[]>> = {};
 
   ast.declarations.forEach((decl) => {
@@ -32,8 +33,13 @@ function prismaReader(
         ? `${member.name.value}?`
         : member.name.value;
 
-      const extra = addTypes[modelName]?.[member.name.value] ?? [];
-      fields[fieldName] = [tsType, ...extra];
+      const replace = replaceTypes[modelName]?.[member.name.value];
+      if (replace) {
+        fields[fieldName] = replace;
+      } else {
+        const extra = addTypes[modelName]?.[member.name.value] ?? [];
+        fields[fieldName] = [tsType, ...extra];
+      }
     });
 
     result[modelName] = fields;


### PR DESCRIPTION
## 概要

- `/// @gassma.replaceType` ディレクティブを追加
- `addType` は基底型とのユニオン（`string | "admin" | "user"` → 事実上 `string`）
- `replaceType` は基底型を置換し、指定した型のみ生成（`"admin" | "user"`）

## 使用例

```prisma
/// @gassma.replaceType "admin", "user", "moderator"
role String
```

生成結果:
```typescript
"role": "admin" | "user" | "moderator"  // string を含まない
```

## 変更内容

- `extractAddTypes.ts`: `extractByPrefix` ヘルパーにリファクタリング、`extractReplaceTypes` を追加
- `prismaReader.ts`: `replaceType` がある場合は基底型を含めず extra のみを使用
- テスト: extractAddTypes に5件、prismaReader に2件追加（全208テスト Green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)