### PR TITLE
feat: enum 型生成サポート

### DIFF
--- a/src/__test__/generate/read/extractEnums.test.ts
+++ b/src/__test__/generate/read/extractEnums.test.ts
@@ -1,0 +1,61 @@
+import { extractEnums } from "../../../generate/read/extractEnums";
+
+describe("extractEnums", () => {
+  it("should extract enum values", () => {
+    const schema = `
+enum Role {
+  ADMIN
+  USER
+  MODERATOR
+}
+
+model User {
+  id   Int  @id
+  role Role
+}
+`;
+    const result = extractEnums(schema);
+
+    expect(result).toEqual({
+      Role: ["ADMIN", "USER", "MODERATOR"],
+    });
+  });
+
+  it("should extract multiple enums", () => {
+    const schema = `
+enum Role {
+  ADMIN
+  USER
+}
+
+enum Status {
+  ACTIVE
+  INACTIVE
+}
+
+model User {
+  id     Int    @id
+  role   Role
+  status Status
+}
+`;
+    const result = extractEnums(schema);
+
+    expect(result).toEqual({
+      Role: ["ADMIN", "USER"],
+      Status: ["ACTIVE", "INACTIVE"],
+    });
+  });
+
+  it("should return empty object when no enums exist", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractEnums(schema);
+
+    expect(result).toEqual({});
+  });
+});

--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -189,6 +189,41 @@ model User {
     expect(result.User.id).toEqual(["number", "string", "boolean"]);
   });
 
+  it("should convert enum fields to literal union types", () => {
+    const schema = `
+enum Role {
+  ADMIN
+  USER
+  MODERATOR
+}
+
+model User {
+  id   Int  @id
+  role Role
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User.role).toEqual(["ADMIN", "USER", "MODERATOR"]);
+  });
+
+  it("should handle optional enum fields", () => {
+    const schema = `
+enum Status {
+  ACTIVE
+  INACTIVE
+}
+
+model User {
+  id     Int     @id
+  status Status?
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User["status?"]).toEqual(["ACTIVE", "INACTIVE"]);
+  });
+
   it("should replace base type with @gassma.replaceType", () => {
     const schema = `
 model User {

--- a/src/generate/read/extractEnums.ts
+++ b/src/generate/read/extractEnums.ts
@@ -1,0 +1,23 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+
+type EnumsConfig = Record<string, string[]>;
+
+const extractEnums = (schemaText: string): EnumsConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: EnumsConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "enum") return;
+
+    const values = decl.members
+      .filter((member) => member.kind === "enumValue")
+      .map((member) => member.name.value);
+
+    result[decl.name.value] = values;
+  });
+
+  return result;
+};
+
+export { extractEnums };
+export type { EnumsConfig };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -2,6 +2,7 @@ import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
 import { mapPrismaType } from "./mapPrismaType";
 import { isScalarField } from "./isScalarField";
 import { extractAddTypes, extractReplaceTypes } from "./extractAddTypes";
+import { extractEnums } from "./extractEnums";
 
 function prismaReader(
   schemaText: string,
@@ -9,6 +10,7 @@ function prismaReader(
   const ast = parsePrismaSchema(schemaText);
   const addTypes = extractAddTypes(schemaText);
   const replaceTypes = extractReplaceTypes(schemaText);
+  const enums = extractEnums(schemaText);
   const result: Record<string, Record<string, unknown[]>> = {};
 
   ast.declarations.forEach((decl) => {
@@ -28,18 +30,26 @@ function prismaReader(
           : member.type;
       if (baseType.kind === "unsupported" || baseType.kind === "list") return;
 
-      const tsType = mapPrismaType(baseType.name.value);
+      const typeName = baseType.name.value;
       const fieldName = isOptional
         ? `${member.name.value}?`
         : member.name.value;
 
+      const enumValues = enums[typeName];
+      if (enumValues) {
+        fields[fieldName] = enumValues;
+        return;
+      }
+
       const replace = replaceTypes[modelName]?.[member.name.value];
       if (replace) {
         fields[fieldName] = replace;
-      } else {
-        const extra = addTypes[modelName]?.[member.name.value] ?? [];
-        fields[fieldName] = [tsType, ...extra];
+        return;
       }
+
+      const tsType = mapPrismaType(typeName);
+      const extra = addTypes[modelName]?.[member.name.value] ?? [];
+      fields[fieldName] = [tsType, ...extra];
     });
 
     result[modelName] = fields;


### PR DESCRIPTION
## 概要

- Prisma スキーマの `enum` 定義からリテラルユニオン型を自動生成
- `/// @gassma.replaceType` と同等の効果を enum 定義から自動で適用

## 使用例

```prisma
enum Role {
  ADMIN
  USER
  MODERATOR
}

model User {
  id   Int  @id
  role Role
}
```

生成結果:
```typescript
"role": "ADMIN" | "USER" | "MODERATOR"
```

## 変更内容

- `extractEnums.ts`: 新規。Prisma AST から enum 宣言を抽出し `Record<string, string[]>` を返す
- `prismaReader.ts`: フィールドの型が enum の場合、enum 値をリテラルとして使用（`mapPrismaType` をスキップ）
- テスト: extractEnums に3件、prismaReader に2件追加（全213テスト Green）

## 優先順位

enum > replaceType > addType の順に適用。enum がある場合は replaceType/addType は無視される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)