### PR TITLE
feat: @default() の CLI 対応（JS/型生成）

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -1,4 +1,5 @@
 import { generateClientJs } from "../../../generate/jsGenerate/generateClientJs";
+import type { DefaultsConfig } from "../../../generate/read/extractDefaults";
 
 describe("generateClientJs", () => {
   it("should generate GassmaClient class with embedded relations", () => {
@@ -93,5 +94,44 @@ describe("generateClientJs", () => {
     expect(result).toContain(
       "Object.assign({}, options, { relations: fugaRelations })",
     );
+  });
+
+  it("should embed defaults with static values", () => {
+    const defaults: DefaultsConfig = {
+      User: { isActive: { kind: "static", value: true } },
+      Post: { viewCount: { kind: "static", value: 0 } },
+    };
+
+    const result = generateClientJs({}, "Test", defaults);
+
+    expect(result).toContain("testDefaults =");
+    expect(result).toContain("defaults: testDefaults");
+  });
+
+  it("should embed now() as () => new Date()", () => {
+    const defaults: DefaultsConfig = {
+      User: { createdAt: { kind: "function", name: "now" } },
+    };
+
+    const result = generateClientJs({}, "Test", defaults);
+
+    expect(result).toContain("() => new Date()");
+  });
+
+  it("should embed uuid() as () => Utilities.getUuid()", () => {
+    const defaults: DefaultsConfig = {
+      User: { id: { kind: "function", name: "uuid" } },
+    };
+
+    const result = generateClientJs({}, "Test", defaults);
+
+    expect(result).toContain("() => Utilities.getUuid()");
+  });
+
+  it("should not embed defaults when config is empty", () => {
+    const result = generateClientJs({}, "Test", {});
+
+    expect(result).not.toContain("Defaults");
+    expect(result).not.toContain("defaults");
   });
 });

--- a/src/__test__/generate/read/extractDefaults.test.ts
+++ b/src/__test__/generate/read/extractDefaults.test.ts
@@ -1,0 +1,137 @@
+import { extractDefaults } from "../../../generate/read/extractDefaults";
+
+describe("extractDefaults", () => {
+  it("should extract static boolean default", () => {
+    const schema = `
+model User {
+  id       Int     @id
+  isActive Boolean @default(true)
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      User: { isActive: { kind: "static", value: true } },
+    });
+  });
+
+  it("should extract static number default", () => {
+    const schema = `
+model Post {
+  id        Int @id
+  viewCount Int @default(0)
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      Post: { viewCount: { kind: "static", value: 0 } },
+    });
+  });
+
+  it("should extract now() function default", () => {
+    const schema = `
+model User {
+  id        Int      @id
+  createdAt DateTime @default(now())
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      User: { createdAt: { kind: "function", name: "now" } },
+    });
+  });
+
+  it("should extract uuid() function default", () => {
+    const schema = `
+model User {
+  id   String @id @default(uuid())
+  name String
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      User: { id: { kind: "function", name: "uuid" } },
+    });
+  });
+
+  it("should skip autoincrement()", () => {
+    const schema = `
+model User {
+  id   Int    @id @default(autoincrement())
+  name String
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({});
+  });
+
+  it("should extract multiple defaults from one model", () => {
+    const schema = `
+model Post {
+  id        Int      @id @default(autoincrement())
+  published Boolean  @default(false)
+  viewCount Int      @default(0)
+  createdAt DateTime @default(now())
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      Post: {
+        published: { kind: "static", value: false },
+        viewCount: { kind: "static", value: 0 },
+        createdAt: { kind: "function", name: "now" },
+      },
+    });
+  });
+
+  it("should extract defaults from multiple models", () => {
+    const schema = `
+model User {
+  id        Int      @id
+  isActive  Boolean  @default(true)
+}
+
+model Post {
+  id        Int      @id
+  published Boolean  @default(false)
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      User: { isActive: { kind: "static", value: true } },
+      Post: { published: { kind: "static", value: false } },
+    });
+  });
+
+  it("should return empty object when no defaults exist", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({});
+  });
+
+  it("should extract static string default", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  role String @default("USER")
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      User: { role: { kind: "static", value: "USER" } },
+    });
+  });
+});

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -4,6 +4,7 @@ import { generater } from "./generator";
 import { generateClientDts } from "./jsGenerate/generateClientDts";
 import { generateClientJs } from "./jsGenerate/generateClientJs";
 import { extractOutputPath } from "./read/extractOutputPath";
+import { extractDefaults } from "./read/extractDefaults";
 import { extractRelations } from "./read/extractRelations";
 import { prismaReader } from "./read/prismaReader";
 import { writer } from "./writer";
@@ -47,6 +48,7 @@ function generate(customDir?: string) {
 
     const parsed = prismaReader(schemaText);
     const relations = extractRelations(schemaText);
+    const defaults = extractDefaults(schemaText);
     const baseName = path.basename(file, ".prisma");
     const schemaName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
     const includeCommon = !commonWritten.has(outputPath);
@@ -58,7 +60,7 @@ function generate(customDir?: string) {
       includeCommon,
     );
     writer(resultString, baseName, outputPath);
-    const clientJs = generateClientJs(relations, schemaName);
+    const clientJs = generateClientJs(relations, schemaName, defaults);
     jsWriter(clientJs, `${baseName}Client`, outputPath);
     const clientDts = generateClientDts(schemaName);
     writer(clientDts, `${baseName}Client`, outputPath);

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -1,8 +1,31 @@
 import type { RelationsConfig } from "../read/extractRelations";
+import type { DefaultsConfig } from "../read/extractDefaults";
+
+const FUNCTION_MAP: Record<string, string> = {
+  now: "() => new Date()",
+  uuid: "() => Utilities.getUuid()",
+};
+
+const serializeDefaults = (defaults: DefaultsConfig): string => {
+  const entries = Object.keys(defaults).map((modelName) => {
+    const fields = defaults[modelName];
+    const fieldEntries = Object.keys(fields).map((fieldName) => {
+      const info = fields[fieldName];
+      if (info.kind === "static") {
+        return `      "${fieldName}": ${JSON.stringify(info.value)}`;
+      }
+      const funcStr = FUNCTION_MAP[info.name] ?? `() => null`;
+      return `      "${fieldName}": ${funcStr}`;
+    });
+    return `    "${modelName}": {\n${fieldEntries.join(",\n")}\n    }`;
+  });
+  return `{\n${entries.join(",\n")}\n  }`;
+};
 
 const generateClientJs = (
   relations: RelationsConfig,
   schemaName: string,
+  defaults?: DefaultsConfig,
 ): string => {
   const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
@@ -10,11 +33,21 @@ const generateClientJs = (
       ? "{}"
       : JSON.stringify(relations, null, 2);
 
+  const hasDefaults = defaults && Object.keys(defaults).length > 0;
+
+  const defaultsDecl = hasDefaults
+    ? `const ${lowerName}Defaults = ${serializeDefaults(defaults)};\n\n`
+    : "";
+
+  const mergeExpr = hasDefaults
+    ? `Object.assign({}, options, { relations: ${lowerName}Relations, defaults: ${lowerName}Defaults })`
+    : `Object.assign({}, options, { relations: ${lowerName}Relations })`;
+
   return `const ${lowerName}Relations = ${relationsJson};
 
-class GassmaClient {
+${defaultsDecl}class GassmaClient {
   constructor(options) {
-    const mergedOptions = Object.assign({}, options, { relations: ${lowerName}Relations });
+    const mergedOptions = ${mergeExpr};
     const client = new Gassma.GassmaClient(mergedOptions);
     this.sheets = client.sheets;
   }

--- a/src/generate/read/extractDefaults.ts
+++ b/src/generate/read/extractDefaults.ts
@@ -1,0 +1,68 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import { findDefaultFieldAttribute } from "@loancrate/prisma-schema-parser/dist/attributes";
+
+type StaticDefault = {
+  kind: "static";
+  value: string | number | boolean;
+};
+
+type FunctionDefault = {
+  kind: "function";
+  name: string;
+};
+
+type DefaultInfo = StaticDefault | FunctionDefault;
+
+type DefaultsConfig = {
+  [modelName: string]: {
+    [fieldName: string]: DefaultInfo;
+  };
+};
+
+const SKIP_FUNCTIONS = ["autoincrement"];
+
+const extractDefaults = (schemaText: string): DefaultsConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: DefaultsConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+
+    const modelDefaults: Record<string, DefaultInfo> = {};
+
+    decl.members.forEach((member) => {
+      if (member.kind !== "field") return;
+
+      const defaultAttr = findDefaultFieldAttribute(member);
+      if (!defaultAttr) return;
+
+      const expr = defaultAttr.expression;
+
+      if (expr.kind === "literal") {
+        modelDefaults[member.name.value] = {
+          kind: "static",
+          value: expr.value,
+        };
+        return;
+      }
+
+      if (expr.kind === "functionCall") {
+        const funcName = expr.path.value[0];
+        if (SKIP_FUNCTIONS.indexOf(funcName) !== -1) return;
+        modelDefaults[member.name.value] = {
+          kind: "function",
+          name: funcName,
+        };
+      }
+    });
+
+    if (Object.keys(modelDefaults).length > 0) {
+      result[decl.name.value] = modelDefaults;
+    }
+  });
+
+  return result;
+};
+
+export { extractDefaults };
+export type { DefaultsConfig, DefaultInfo, StaticDefault, FunctionDefault };

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -17,6 +17,12 @@ const getGassmaCommonTypes = () => {
   type FalseKeys<T> = { [K in keyof T]: T[K] extends false ? K : never }[keyof T];
   type ResolveOmitKeys<GO, QO> = Exclude<TrueKeys<GO>, FalseKeys<QO>> | TrueKeys<QO>;
 
+  type DefaultsConfig = {
+    [sheetName: string]: {
+      [columnName: string]: unknown | (() => unknown);
+    };
+  };
+
   type ManyReturn = {
     count: number;
   };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -19,6 +19,7 @@ const getGassmaClientOptions = (schemaName: string) => {
   id?: string;
   relations?: Gassma.RelationsConfig;
   omit?: O;
+  defaults?: Gassma.DefaultsConfig;
 };\n`;
 };
 


### PR DESCRIPTION
## 概要

gassma 本体の PR #105 で追加された `defaults` オプションに対応。`.prisma` の `@default()` を読み取り、生成する JS に defaults オブジェクトを埋め込む。

## 対応する `@default` の種類

| `@default()` | 生成される JS |
|---|---|
| `@default(true)` / `@default(false)` | `true` / `false` |
| `@default(0)` (数値) | `0` |
| `@default("USER")` (文字列) | `"USER"` |
| `@default(now())` | `() => new Date()` |
| `@default(uuid())` | `() => Utilities.getUuid()` |
| `@default(autoincrement())` | スキップ（別タスク） |

## 変更内容

- `extractDefaults.ts`: 新規。Prisma AST から `@default` を抽出。静的値と関数を区別
- `generateClientJs.ts`: `defaults` 引数を追加。関数値は `() => new Date()` のような JS コードとして埋め込み
- `gassmaCommonTypes.ts`: `DefaultsConfig` 型を追加
- `gassmaMain.ts`: `GassmaClientOptions` に `defaults?: Gassma.DefaultsConfig` を追加
- `generate.ts`: `extractDefaults` を呼び出して `generateClientJs` に渡す

## テスト

- extractDefaults: 9件、generateClientJs: 4件追加（全226テスト Green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)