### PR TITLE
feat: @default()付きフィールドをUse型でオプショナルに

### DIFF
--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -251,6 +251,33 @@ model User {
     expect(result.User.status).toEqual(["active", "inactive"]);
   });
 
+  it("should make fields with @default() optional (except autoincrement)", () => {
+    const schema = `
+model User {
+  id        Int      @id @default(autoincrement())
+  name      String
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+}
+`;
+    const result = prismaReader(schema);
+
+    // autoincrement() は除外 → 必須のまま
+    expect(result.User.id).toEqual(["number"]);
+    expect(result.User["id?"]).toBeUndefined();
+
+    // @default(true) → オプショナル
+    expect(result.User["isActive?"]).toEqual(["boolean"]);
+    expect(result.User.isActive).toBeUndefined();
+
+    // @default(now()) → オプショナル
+    expect(result.User["createdAt?"]).toEqual(["Date"]);
+    expect(result.User.createdAt).toBeUndefined();
+
+    // @default なし → 必須のまま
+    expect(result.User.name).toEqual(["string"]);
+  });
+
   it("should ignore relation fields (list types referencing other models)", () => {
     const schema = `
 model User {

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -1,4 +1,5 @@
 import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import { findDefaultFieldAttribute } from "@loancrate/prisma-schema-parser/dist/attributes";
 import { mapPrismaType } from "./mapPrismaType";
 import { isScalarField } from "./isScalarField";
 import { extractAddTypes, extractReplaceTypes } from "./extractAddTypes";
@@ -24,6 +25,7 @@ function prismaReader(
       if (!isScalarField(member, ast)) return;
 
       const isOptional = member.type.kind === "optional";
+      const hasNonAutoDefault = hasNonAutoincrementDefault(member);
       const baseType =
         member.type.kind === "optional" || member.type.kind === "required"
           ? member.type.type
@@ -31,9 +33,10 @@ function prismaReader(
       if (baseType.kind === "unsupported" || baseType.kind === "list") return;
 
       const typeName = baseType.name.value;
-      const fieldName = isOptional
-        ? `${member.name.value}?`
-        : member.name.value;
+      const fieldName =
+        isOptional || hasNonAutoDefault
+          ? `${member.name.value}?`
+          : member.name.value;
 
       const enumValues = enums[typeName];
       if (enumValues) {
@@ -56,6 +59,20 @@ function prismaReader(
   });
 
   return result;
+}
+
+const SKIP_DEFAULT_FUNCTIONS = ["autoincrement"];
+
+function hasNonAutoincrementDefault(
+  member: Parameters<typeof findDefaultFieldAttribute>[0],
+): boolean {
+  const attr = findDefaultFieldAttribute(member);
+  if (!attr) return false;
+  if (attr.expression.kind === "functionCall") {
+    const funcName = attr.expression.path.value[0];
+    return SKIP_DEFAULT_FUNCTIONS.indexOf(funcName) === -1;
+  }
+  return true;
 }
 
 export { prismaReader };


### PR DESCRIPTION
## 概要
- `@default()`が付いたフィールドをCreate入力型（`Use`型）でオプショナル（`?`）にする
- `@default(autoincrement())`は除外（必須のまま）

## 変更内容
- `prismaReader.ts`: `findDefaultFieldAttribute`でデフォルト属性を検出し、`autoincrement()`以外はフィールド名に`?`を付与
- `prismaReader.test.ts`: `@default(true)`, `@default(now())`, `@default(autoincrement())`の各ケースのテスト追加

## 生成型の変化例
```typescript
// Before
"isActive": boolean;
"createdAt": Date;

// After
"isActive"?: boolean;
"createdAt"?: Date;
```

## テスト
- 全227テスト通過
- gassma-testでGAS統合テスト確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)