### PR TITLE
feat: @updatedAt サポート追加 + DefaultsConfig/UpdatedAtConfig 型精緻化

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -1,5 +1,6 @@
 import { generateClientJs } from "../../../generate/jsGenerate/generateClientJs";
 import type { DefaultsConfig } from "../../../generate/read/extractDefaults";
+import type { UpdatedAtConfig } from "../../../generate/read/extractUpdatedAt";
 
 describe("generateClientJs", () => {
   it("should generate GassmaClient class with embedded relations", () => {
@@ -133,5 +134,44 @@ describe("generateClientJs", () => {
 
     expect(result).not.toContain("Defaults");
     expect(result).not.toContain("defaults");
+  });
+
+  it("should embed updatedAt config", () => {
+    const updatedAt: UpdatedAtConfig = {
+      User: ["updatedAt"],
+      Post: ["updatedAt", "modifiedAt"],
+    };
+
+    const result = generateClientJs({}, "Test", undefined, updatedAt);
+
+    expect(result).toContain("testUpdatedAt =");
+    expect(result).toContain("updatedAt: testUpdatedAt");
+    expect(result).toContain('"User"');
+    expect(result).toContain('"updatedAt"');
+    expect(result).toContain('"Post"');
+    expect(result).toContain('"modifiedAt"');
+  });
+
+  it("should not embed updatedAt when config is empty", () => {
+    const result = generateClientJs({}, "Test", undefined, {});
+
+    expect(result).not.toContain("UpdatedAt");
+    expect(result).not.toContain("updatedAt");
+  });
+
+  it("should embed both defaults and updatedAt", () => {
+    const defaults: DefaultsConfig = {
+      User: { isActive: { kind: "static", value: true } },
+    };
+    const updatedAt: UpdatedAtConfig = {
+      User: ["updatedAt"],
+    };
+
+    const result = generateClientJs({}, "Test", defaults, updatedAt);
+
+    expect(result).toContain("testDefaults");
+    expect(result).toContain("testUpdatedAt");
+    expect(result).toContain("defaults: testDefaults");
+    expect(result).toContain("updatedAt: testUpdatedAt");
   });
 });

--- a/src/__test__/generate/read/extractUpdatedAt.test.ts
+++ b/src/__test__/generate/read/extractUpdatedAt.test.ts
@@ -1,0 +1,75 @@
+import { extractUpdatedAt } from "../../../generate/read/extractUpdatedAt";
+
+describe("extractUpdatedAt", () => {
+  it("should extract @updatedAt fields", () => {
+    const schema = `
+model User {
+  id        Int      @id
+  name      String
+  updatedAt DateTime @updatedAt
+}
+`;
+    const result = extractUpdatedAt(schema);
+    expect(result).toEqual({
+      User: ["updatedAt"],
+    });
+  });
+
+  it("should extract multiple @updatedAt fields from one model", () => {
+    const schema = `
+model Post {
+  id         Int      @id
+  updatedAt  DateTime @updatedAt
+  modifiedAt DateTime @updatedAt
+}
+`;
+    const result = extractUpdatedAt(schema);
+    expect(result).toEqual({
+      Post: ["updatedAt", "modifiedAt"],
+    });
+  });
+
+  it("should extract from multiple models", () => {
+    const schema = `
+model User {
+  id        Int      @id
+  updatedAt DateTime @updatedAt
+}
+
+model Post {
+  id        Int      @id
+  updatedAt DateTime @updatedAt
+}
+`;
+    const result = extractUpdatedAt(schema);
+    expect(result).toEqual({
+      User: ["updatedAt"],
+      Post: ["updatedAt"],
+    });
+  });
+
+  it("should return empty object when no @updatedAt fields", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractUpdatedAt(schema);
+    expect(result).toEqual({});
+  });
+
+  it("should not confuse @updatedAt with @default(now())", () => {
+    const schema = `
+model User {
+  id        Int      @id
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+`;
+    const result = extractUpdatedAt(schema);
+    expect(result).toEqual({
+      User: ["updatedAt"],
+    });
+  });
+});

--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -278,6 +278,21 @@ model User {
     expect(result.User.name).toEqual(["string"]);
   });
 
+  it("should make @updatedAt fields optional", () => {
+    const schema = `
+model User {
+  id        Int      @id
+  name      String
+  updatedAt DateTime @updatedAt
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User["updatedAt?"]).toEqual(["Date"]);
+    expect(result.User.updatedAt).toBeUndefined();
+    expect(result.User.name).toEqual(["string"]);
+  });
+
   it("should ignore relation fields (list types referencing other models)", () => {
     const schema = `
 model User {

--- a/src/__test__/generate/typeGenerate/gassmaDefaultsType.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDefaultsType.test.ts
@@ -1,0 +1,108 @@
+import { getGassmaDefaultsType } from "../../../generate/typeGenerate/gassmaDefaultsType";
+import type { DefaultsConfig } from "../../../generate/read/extractDefaults";
+
+describe("getGassmaDefaultsType", () => {
+  it("should generate schema-specific defaults config with correct field types", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        name: ["string"],
+        "isActive?": ["boolean"],
+        "createdAt?": ["Date"],
+      },
+    };
+    const defaults: DefaultsConfig = {
+      User: {
+        isActive: { kind: "static", value: true },
+        createdAt: { kind: "function", name: "now" },
+      },
+    };
+    const result = getGassmaDefaultsType(dictYaml, defaults, "Test");
+
+    expect(result).toContain("declare type GassmaTestDefaultsConfig");
+    expect(result).toContain('"User"?:');
+    expect(result).toContain('"isActive"?: boolean | (() => boolean)');
+    expect(result).toContain('"createdAt"?: Date | (() => Date)');
+  });
+
+  it("should not include models without defaults", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        "isActive?": ["boolean"],
+      },
+      Tag: {
+        id: ["number"],
+        name: ["string"],
+      },
+    };
+    const defaults: DefaultsConfig = {
+      User: {
+        isActive: { kind: "static", value: true },
+      },
+    };
+    const result = getGassmaDefaultsType(dictYaml, defaults, "Test");
+
+    expect(result).toContain('"User"?:');
+    expect(result).not.toContain('"Tag"');
+  });
+
+  it("should handle multiple models with defaults", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        "isActive?": ["boolean"],
+      },
+      Post: {
+        id: ["number"],
+        "published?": ["boolean"],
+        "viewCount?": ["number"],
+      },
+    };
+    const defaults: DefaultsConfig = {
+      User: {
+        isActive: { kind: "static", value: true },
+      },
+      Post: {
+        published: { kind: "static", value: false },
+        viewCount: { kind: "static", value: 0 },
+      },
+    };
+    const result = getGassmaDefaultsType(dictYaml, defaults, "Test");
+
+    expect(result).toContain('"User"?:');
+    expect(result).toContain('"Post"?:');
+    expect(result).toContain('"isActive"?: boolean | (() => boolean)');
+    expect(result).toContain('"published"?: boolean | (() => boolean)');
+    expect(result).toContain('"viewCount"?: number | (() => number)');
+  });
+
+  it("should return empty config when no defaults exist", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: { id: ["number"] },
+    };
+    const defaults: DefaultsConfig = {};
+    const result = getGassmaDefaultsType(dictYaml, defaults, "Test");
+
+    expect(result).toContain("declare type GassmaTestDefaultsConfig = {}");
+  });
+
+  it("should handle union types in field", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      Post: {
+        id: ["number"],
+        "content?": ["string", "number"],
+      },
+    };
+    const defaults: DefaultsConfig = {
+      Post: {
+        content: { kind: "static", value: "" },
+      },
+    };
+    const result = getGassmaDefaultsType(dictYaml, defaults, "Test");
+
+    expect(result).toContain(
+      '"content"?: string | number | (() => string | number)',
+    );
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaUpdatedAtType.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaUpdatedAtType.test.ts
@@ -1,0 +1,96 @@
+import { getGassmaUpdatedAtType } from "../../../generate/typeGenerate/gassmaUpdatedAtType";
+
+describe("getGassmaUpdatedAtType", () => {
+  it("should generate schema-specific updatedAt config with column name literals", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      Post: {
+        id: ["number"],
+        title: ["string"],
+        "updatedAt?": ["Date"],
+      },
+    };
+    const result = getGassmaUpdatedAtType(dictYaml, ["Post"], "Test");
+
+    expect(result).toContain("declare type GassmaTestUpdatedAtConfig");
+    expect(result).toContain('"Post"?:');
+  });
+
+  it("should include all column names as literal union for the model", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      Post: {
+        id: ["number"],
+        title: ["string"],
+        "content?": ["string"],
+        "updatedAt?": ["Date"],
+      },
+    };
+    const result = getGassmaUpdatedAtType(dictYaml, ["Post"], "Test");
+
+    expect(result).toContain('"id"');
+    expect(result).toContain('"title"');
+    expect(result).toContain('"content"');
+    expect(result).toContain('"updatedAt"');
+  });
+
+  it("should support string | string[] format", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      Post: {
+        id: ["number"],
+        title: ["string"],
+      },
+    };
+    const result = getGassmaUpdatedAtType(dictYaml, ["Post"], "Test");
+
+    // string | string[] の形式
+    const columnUnion = '"id" | "title"';
+    expect(result).toContain(`${columnUnion} | (${columnUnion})[]`);
+  });
+
+  it("should only include models that have updatedAt fields", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        name: ["string"],
+      },
+      Post: {
+        id: ["number"],
+        title: ["string"],
+        "updatedAt?": ["Date"],
+      },
+    };
+    const result = getGassmaUpdatedAtType(dictYaml, ["Post"], "Test");
+
+    expect(result).not.toContain('"User"');
+    expect(result).toContain('"Post"?:');
+  });
+
+  it("should handle multiple models with updatedAt", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      Post: {
+        id: ["number"],
+        title: ["string"],
+      },
+      Product: {
+        id: ["number"],
+        name: ["string"],
+      },
+    };
+    const result = getGassmaUpdatedAtType(
+      dictYaml,
+      ["Post", "Product"],
+      "Test",
+    );
+
+    expect(result).toContain('"Post"?:');
+    expect(result).toContain('"Product"?:');
+  });
+
+  it("should return empty config when no models have updatedAt", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: { id: ["number"] },
+    };
+    const result = getGassmaUpdatedAtType(dictYaml, [], "Test");
+
+    expect(result).toContain("declare type GassmaTestUpdatedAtConfig = {}");
+  });
+});

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -6,6 +6,7 @@ import { generateClientJs } from "./jsGenerate/generateClientJs";
 import { extractOutputPath } from "./read/extractOutputPath";
 import { extractDefaults } from "./read/extractDefaults";
 import { extractRelations } from "./read/extractRelations";
+import { extractUpdatedAt } from "./read/extractUpdatedAt";
 import { prismaReader } from "./read/prismaReader";
 import { writer } from "./writer";
 import { jsWriter } from "./jsWriter";
@@ -49,6 +50,7 @@ function generate(customDir?: string) {
     const parsed = prismaReader(schemaText);
     const relations = extractRelations(schemaText);
     const defaults = extractDefaults(schemaText);
+    const updatedAt = extractUpdatedAt(schemaText);
     const baseName = path.basename(file, ".prisma");
     const schemaName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
     const includeCommon = !commonWritten.has(outputPath);
@@ -60,7 +62,12 @@ function generate(customDir?: string) {
       includeCommon,
     );
     writer(resultString, baseName, outputPath);
-    const clientJs = generateClientJs(relations, schemaName, defaults);
+    const clientJs = generateClientJs(
+      relations,
+      schemaName,
+      defaults,
+      updatedAt,
+    );
     jsWriter(clientJs, `${baseName}Client`, outputPath);
     const clientDts = generateClientDts(schemaName);
     writer(clientDts, `${baseName}Client`, outputPath);

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -60,6 +60,8 @@ function generate(customDir?: string) {
       relations,
       schemaName,
       includeCommon,
+      defaults,
+      Object.keys(updatedAt),
     );
     writer(resultString, baseName, outputPath);
     const clientJs = generateClientJs(

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -35,6 +35,7 @@ import { getGassmaUpdateSingleData } from "./typeGenerate/gassmaUpdateSingleData
 import { getGassmaUpsertData } from "./typeGenerate/gassmaUpsertData";
 import { getGassmaUpsertSingleData } from "./typeGenerate/gassmaUpsertSingleData";
 import { getGassmaWhereUse } from "./typeGenerate/gassmaWhereUse";
+import type { DefaultsConfig } from "./read/extractDefaults";
 import type { RelationsConfig } from "./read/extractRelations";
 
 const generater = (
@@ -42,10 +43,16 @@ const generater = (
   relations?: RelationsConfig,
   schemaName?: string,
   includeCommon?: boolean,
+  defaults?: DefaultsConfig,
+  updatedAtModels?: string[],
 ) => {
   const schema = schemaName ?? "";
   const sheetNames = Object.keys(dictYaml);
-  let result = getGassmaMain(sheetNames, schema, includeCommon);
+  let result = getGassmaMain(sheetNames, schema, includeCommon, {
+    dictYaml,
+    defaults: defaults ?? {},
+    updatedAtModels: updatedAtModels ?? [],
+  });
 
   result += getGassmaSheet(sheetNames, schema);
   result += getGassmaController(sheetNames, schema);

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -1,5 +1,6 @@
 import type { RelationsConfig } from "../read/extractRelations";
 import type { DefaultsConfig } from "../read/extractDefaults";
+import type { UpdatedAtConfig } from "../read/extractUpdatedAt";
 
 const FUNCTION_MAP: Record<string, string> = {
   now: "() => new Date()",
@@ -22,10 +23,20 @@ const serializeDefaults = (defaults: DefaultsConfig): string => {
   return `{\n${entries.join(",\n")}\n  }`;
 };
 
+const serializeUpdatedAt = (updatedAt: UpdatedAtConfig): string => {
+  const entries = Object.keys(updatedAt).map((modelName) => {
+    const fields = updatedAt[modelName];
+    const values = fields.map((f) => `"${f}"`).join(", ");
+    return `    "${modelName}": [${values}]`;
+  });
+  return `{\n${entries.join(",\n")}\n  }`;
+};
+
 const generateClientJs = (
   relations: RelationsConfig,
   schemaName: string,
   defaults?: DefaultsConfig,
+  updatedAt?: UpdatedAtConfig,
 ): string => {
   const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
@@ -34,18 +45,24 @@ const generateClientJs = (
       : JSON.stringify(relations, null, 2);
 
   const hasDefaults = defaults && Object.keys(defaults).length > 0;
+  const hasUpdatedAt = updatedAt && Object.keys(updatedAt).length > 0;
 
   const defaultsDecl = hasDefaults
     ? `const ${lowerName}Defaults = ${serializeDefaults(defaults)};\n\n`
     : "";
 
-  const mergeExpr = hasDefaults
-    ? `Object.assign({}, options, { relations: ${lowerName}Relations, defaults: ${lowerName}Defaults })`
-    : `Object.assign({}, options, { relations: ${lowerName}Relations })`;
+  const updatedAtDecl = hasUpdatedAt
+    ? `const ${lowerName}UpdatedAt = ${serializeUpdatedAt(updatedAt)};\n\n`
+    : "";
+
+  const mergeProps = [`relations: ${lowerName}Relations`];
+  if (hasDefaults) mergeProps.push(`defaults: ${lowerName}Defaults`);
+  if (hasUpdatedAt) mergeProps.push(`updatedAt: ${lowerName}UpdatedAt`);
+  const mergeExpr = `Object.assign({}, options, { ${mergeProps.join(", ")} })`;
 
   return `const ${lowerName}Relations = ${relationsJson};
 
-${defaultsDecl}class GassmaClient {
+${defaultsDecl}${updatedAtDecl}class GassmaClient {
   constructor(options) {
     const mergedOptions = ${mergeExpr};
     const client = new Gassma.GassmaClient(mergedOptions);

--- a/src/generate/read/extractUpdatedAt.ts
+++ b/src/generate/read/extractUpdatedAt.ts
@@ -1,0 +1,36 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+
+type UpdatedAtConfig = {
+  [modelName: string]: string[];
+};
+
+const extractUpdatedAt = (schemaText: string): UpdatedAtConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: UpdatedAtConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+
+    const fields: string[] = [];
+
+    decl.members.forEach((member) => {
+      if (member.kind !== "field") return;
+      const hasUpdatedAt = (member.attributes ?? []).some(
+        (attr) =>
+          attr.kind === "fieldAttribute" && attr.path.value[0] === "updatedAt",
+      );
+      if (hasUpdatedAt) {
+        fields.push(member.name.value);
+      }
+    });
+
+    if (fields.length > 0) {
+      result[decl.name.value] = fields;
+    }
+  });
+
+  return result;
+};
+
+export { extractUpdatedAt };
+export type { UpdatedAtConfig };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -26,6 +26,7 @@ function prismaReader(
 
       const isOptional = member.type.kind === "optional";
       const hasNonAutoDefault = hasNonAutoincrementDefault(member);
+      const isUpdatedAt = hasUpdatedAtAttribute(member);
       const baseType =
         member.type.kind === "optional" || member.type.kind === "required"
           ? member.type.type
@@ -34,7 +35,7 @@ function prismaReader(
 
       const typeName = baseType.name.value;
       const fieldName =
-        isOptional || hasNonAutoDefault
+        isOptional || hasNonAutoDefault || isUpdatedAt
           ? `${member.name.value}?`
           : member.name.value;
 
@@ -73,6 +74,15 @@ function hasNonAutoincrementDefault(
     return SKIP_DEFAULT_FUNCTIONS.indexOf(funcName) === -1;
   }
   return true;
+}
+
+function hasUpdatedAtAttribute(
+  member: Parameters<typeof findDefaultFieldAttribute>[0],
+): boolean {
+  return (member.attributes ?? []).some(
+    (attr) =>
+      attr.kind === "fieldAttribute" && attr.path.value[0] === "updatedAt",
+  );
 }
 
 export { prismaReader };

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -23,6 +23,10 @@ const getGassmaCommonTypes = () => {
     };
   };
 
+  type UpdatedAtConfig = {
+    [sheetName: string]: string | string[];
+  };
+
   type ManyReturn = {
     count: number;
   };

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -17,16 +17,6 @@ const getGassmaCommonTypes = () => {
   type FalseKeys<T> = { [K in keyof T]: T[K] extends false ? K : never }[keyof T];
   type ResolveOmitKeys<GO, QO> = Exclude<TrueKeys<GO>, FalseKeys<QO>> | TrueKeys<QO>;
 
-  type DefaultsConfig = {
-    [sheetName: string]: {
-      [columnName: string]: unknown | (() => unknown);
-    };
-  };
-
-  type UpdatedAtConfig = {
-    [sheetName: string]: string | string[];
-  };
-
   type ManyReturn = {
     count: number;
   };

--- a/src/generate/typeGenerate/gassmaDefaultsType.ts
+++ b/src/generate/typeGenerate/gassmaDefaultsType.ts
@@ -1,0 +1,41 @@
+import type { DefaultsConfig } from "../read/extractDefaults";
+import { getColumnType } from "../util/getColumnType";
+
+const findFieldType = (
+  fields: Record<string, unknown[]>,
+  fieldName: string,
+): string | undefined => {
+  const optionalKey = `${fieldName}?`;
+  const types = fields[fieldName] ?? fields[optionalKey];
+  if (!types) return undefined;
+  return getColumnType(types);
+};
+
+const getGassmaDefaultsType = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  defaults: DefaultsConfig,
+  schemaName: string,
+): string => {
+  const modelNames = Object.keys(defaults);
+  if (modelNames.length === 0) {
+    return `declare type Gassma${schemaName}DefaultsConfig = {};\n`;
+  }
+
+  const body = modelNames.reduce((pre, modelName) => {
+    const modelDefaults = defaults[modelName];
+    const fields = dictYaml[modelName];
+    if (!fields) return pre;
+
+    const fieldEntries = Object.keys(modelDefaults).reduce((acc, fieldName) => {
+      const tsType = findFieldType(fields, fieldName);
+      if (!tsType) return acc;
+      return `${acc}    "${fieldName}"?: ${tsType} | (() => ${tsType});\n`;
+    }, "");
+
+    return `${pre}  "${modelName}"?: {\n${fieldEntries}  };\n`;
+  }, "");
+
+  return `declare type Gassma${schemaName}DefaultsConfig = {\n${body}};\n`;
+};
+
+export { getGassmaDefaultsType };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -1,6 +1,9 @@
+import type { DefaultsConfig } from "../read/extractDefaults";
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getGassmaCommonTypes } from "./gassmaCommonTypes";
+import { getGassmaDefaultsType } from "./gassmaDefaultsType";
 import { getGassmaErrorClasses } from "./gassmaErrorClasses";
+import { getGassmaUpdatedAtType } from "./gassmaUpdatedAtType";
 
 const getGassmaGlobalOmitConfig = (
   sheetNames: string[],
@@ -19,9 +22,9 @@ const getGassmaClientOptions = (schemaName: string) => {
   id?: string;
   relations?: Gassma.RelationsConfig;
   omit?: O;
-  defaults?: Gassma.DefaultsConfig;
-  updatedAt?: Gassma.UpdatedAtConfig;
-};\n`;
+  defaults?: Gassma${schemaName}DefaultsConfig;
+  updatedAt?: Gassma${schemaName}UpdatedAtConfig;
+};\n\n`;
 };
 
 const getGassmaCommonNamespace = () => {
@@ -48,7 +51,17 @@ ${errorClasses}}
 `;
 };
 
-const getGassmaSchemaClient = (sheetNames: string[], schemaName: string) => {
+type GassmaMainOptions = {
+  dictYaml: Record<string, Record<string, unknown[]>>;
+  defaults: DefaultsConfig;
+  updatedAtModels: string[];
+};
+
+const getGassmaSchemaClient = (
+  sheetNames: string[],
+  schemaName: string,
+  options: GassmaMainOptions,
+) => {
   const clientMapEntry = `declare namespace Gassma {
   interface GassmaClientMap {
     "${schemaName}": {
@@ -64,6 +77,15 @@ const getGassmaSchemaClient = (sheetNames: string[], schemaName: string) => {
   return (
     clientMapEntry +
     getGassmaGlobalOmitConfig(sheetNames, schemaName) +
+    "\n" +
+    getGassmaDefaultsType(options.dictYaml, options.defaults, schemaName) +
+    "\n" +
+    getGassmaUpdatedAtType(
+      options.dictYaml,
+      options.updatedAtModels,
+      schemaName,
+    ) +
+    "\n" +
     getGassmaClientOptions(schemaName)
   );
 };
@@ -72,10 +94,16 @@ const getGassmaMain = (
   sheetNames: string[],
   schemaName: string,
   includeCommon?: boolean,
+  options?: GassmaMainOptions,
 ) => {
   const common = includeCommon !== false ? getGassmaCommonNamespace() : "";
+  const mainOptions = options ?? {
+    dictYaml: {},
+    defaults: {},
+    updatedAtModels: [],
+  };
 
-  return common + getGassmaSchemaClient(sheetNames, schemaName);
+  return common + getGassmaSchemaClient(sheetNames, schemaName, mainOptions);
 };
 
 export { getGassmaMain, getGassmaCommonNamespace };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -20,6 +20,7 @@ const getGassmaClientOptions = (schemaName: string) => {
   relations?: Gassma.RelationsConfig;
   omit?: O;
   defaults?: Gassma.DefaultsConfig;
+  updatedAt?: Gassma.UpdatedAtConfig;
 };\n`;
 };
 

--- a/src/generate/typeGenerate/gassmaUpdatedAtType.ts
+++ b/src/generate/typeGenerate/gassmaUpdatedAtType.ts
@@ -1,0 +1,28 @@
+const stripOptional = (key: string) =>
+  key.endsWith("?") ? key.slice(0, -1) : key;
+
+const getGassmaUpdatedAtType = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  updatedAtModels: string[],
+  schemaName: string,
+): string => {
+  if (updatedAtModels.length === 0) {
+    return `declare type Gassma${schemaName}UpdatedAtConfig = {};\n`;
+  }
+
+  const body = updatedAtModels.reduce((pre, modelName) => {
+    const fields = dictYaml[modelName];
+    if (!fields) return pre;
+
+    const columnNames = Object.keys(fields).map(
+      (key) => `"${stripOptional(key)}"`,
+    );
+    const union = columnNames.join(" | ");
+
+    return `${pre}  "${modelName}"?: ${union} | (${union})[];\n`;
+  }, "");
+
+  return `declare type Gassma${schemaName}UpdatedAtConfig = {\n${body}};\n`;
+};
+
+export { getGassmaUpdatedAtType };


### PR DESCRIPTION
## 概要
- Prisma の `@updatedAt` に対応するCLI型生成・JS生成を追加（gassma本体の PR #106 に対応）
- `DefaultsConfig` と `UpdatedAtConfig` を汎用型からスキーマ固有の正確な型に変更

## 変更内容

### @updatedAt サポート
- `extractUpdatedAt.ts` (新規): Prisma ASTから `@updatedAt` フィールドを抽出
- `generateClientJs.ts`: `updatedAt` 設定を生成JSに埋め込み
- `gassmaMain.ts`: `GassmaClientOptions` に `updatedAt` プロパティ追加
- `prismaReader.ts`: `@updatedAt` フィールドをオプショナルに
- `generate.ts`: `extractUpdatedAt` 呼び出し統合

### DefaultsConfig/UpdatedAtConfig 型精緻化
- 共通 namespace の `Gassma.DefaultsConfig` / `Gassma.UpdatedAtConfig` を削除
- `gassmaDefaultsType.ts` (新規): スキーマ固有の `DefaultsConfig` を生成（フィールド名・値の型が正確）
- `gassmaUpdatedAtType.ts` (新規): スキーマ固有の `UpdatedAtConfig` を生成（カラム名リテラルユニオン）
- declare type 間に空行を追加

### 生成例
```typescript
declare type GassmaTestDefaultsConfig = {
  "User"?: {
    "isActive"?: boolean | (() => boolean);
    "createdAt"?: Date | (() => Date);
  };
};

declare type GassmaTestUpdatedAtConfig = {
  "Post"?: "id" | "title" | ... | ("id" | "title" | ...)[];
};
```

## テスト
- 全247テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)