### PR TITLE
feat: 型精緻化 + IgnoreConfig 追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaIgnoreType.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaIgnoreType.test.ts
@@ -1,0 +1,57 @@
+import { getGassmaIgnoreType } from "../../../generate/typeGenerate/gassmaIgnoreType";
+
+describe("getGassmaIgnoreType", () => {
+  it("should generate schema-specific ignore config with all models", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        name: ["string"],
+        "email?": ["string"],
+      },
+      Post: {
+        id: ["number"],
+        title: ["string"],
+      },
+    };
+    const result = getGassmaIgnoreType(dictYaml, "Test");
+
+    expect(result).toContain("declare type GassmaTestIgnoreConfig");
+    expect(result).toContain('"User"?:');
+    expect(result).toContain('"Post"?:');
+  });
+
+  it("should include all column names as literal union", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        name: ["string"],
+        "email?": ["string"],
+      },
+    };
+    const result = getGassmaIgnoreType(dictYaml, "Test");
+
+    expect(result).toContain('"id"');
+    expect(result).toContain('"name"');
+    expect(result).toContain('"email"');
+  });
+
+  it("should support string | string[] format", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        name: ["string"],
+      },
+    };
+    const result = getGassmaIgnoreType(dictYaml, "Test");
+
+    const columnUnion = '"id" | "name"';
+    expect(result).toContain(`${columnUnion} | (${columnUnion})[]`);
+  });
+
+  it("should handle empty dictYaml", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {};
+    const result = getGassmaIgnoreType(dictYaml, "Test");
+
+    expect(result).toContain("declare type GassmaTestIgnoreConfig = {}");
+  });
+});

--- a/src/generate/typeGenerate/gassmaIgnoreType.ts
+++ b/src/generate/typeGenerate/gassmaIgnoreType.ts
@@ -1,15 +1,15 @@
 import { generateColumnUnionConfig } from "./generateColumnUnionConfig";
 
-const getGassmaUpdatedAtType = (
+const getGassmaIgnoreType = (
   dictYaml: Record<string, Record<string, unknown[]>>,
-  updatedAtModels: string[],
   schemaName: string,
 ): string => {
+  const allModels = Object.keys(dictYaml);
   return generateColumnUnionConfig(
     dictYaml,
-    updatedAtModels,
-    `Gassma${schemaName}UpdatedAtConfig`,
+    allModels,
+    `Gassma${schemaName}IgnoreConfig`,
   );
 };
 
-export { getGassmaUpdatedAtType };
+export { getGassmaIgnoreType };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -3,6 +3,7 @@ import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getGassmaCommonTypes } from "./gassmaCommonTypes";
 import { getGassmaDefaultsType } from "./gassmaDefaultsType";
 import { getGassmaErrorClasses } from "./gassmaErrorClasses";
+import { getGassmaIgnoreType } from "./gassmaIgnoreType";
 import { getGassmaUpdatedAtType } from "./gassmaUpdatedAtType";
 
 const getGassmaGlobalOmitConfig = (
@@ -24,6 +25,7 @@ const getGassmaClientOptions = (schemaName: string) => {
   omit?: O;
   defaults?: Gassma${schemaName}DefaultsConfig;
   updatedAt?: Gassma${schemaName}UpdatedAtConfig;
+  ignore?: Gassma${schemaName}IgnoreConfig;
 };\n\n`;
 };
 
@@ -85,6 +87,8 @@ const getGassmaSchemaClient = (
       options.updatedAtModels,
       schemaName,
     ) +
+    "\n" +
+    getGassmaIgnoreType(options.dictYaml, schemaName) +
     "\n" +
     getGassmaClientOptions(schemaName)
   );

--- a/src/generate/typeGenerate/generateColumnUnionConfig.ts
+++ b/src/generate/typeGenerate/generateColumnUnionConfig.ts
@@ -1,0 +1,28 @@
+const stripOptional = (key: string) =>
+  key.endsWith("?") ? key.slice(0, -1) : key;
+
+const generateColumnUnionConfig = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  modelNames: string[],
+  typeName: string,
+): string => {
+  if (modelNames.length === 0) {
+    return `declare type ${typeName} = {};\n`;
+  }
+
+  const body = modelNames.reduce((pre, modelName) => {
+    const fields = dictYaml[modelName];
+    if (!fields) return pre;
+
+    const columnNames = Object.keys(fields).map(
+      (key) => `"${stripOptional(key)}"`,
+    );
+    const union = columnNames.join(" | ");
+
+    return `${pre}  "${modelName}"?: ${union} | (${union})[];\n`;
+  }, "");
+
+  return `declare type ${typeName} = {\n${body}};\n`;
+};
+
+export { generateColumnUnionConfig };


### PR DESCRIPTION
## 概要
- `DefaultsConfig`、`UpdatedAtConfig`、`IgnoreConfig` をスキーマ固有の正確な型に変更
- `IgnoreConfig` 型を新規追加（gassma 本体 PR #107 対応）

## 変更内容

### 型精緻化
- 共通 namespace の汎用 `Gassma.DefaultsConfig` / `Gassma.UpdatedAtConfig` を削除
- `gassmaDefaultsType.ts` (新規): フィールド名・値の型が正確な `DefaultsConfig`
- `generateColumnUnionConfig.ts` (新規): カラム名リテラルユニオン生成の共通ヘルパー
- `gassmaUpdatedAtType.ts`: 共通ヘルパーを使用するようリファクタ
- declare type 間に空行を追加

### IgnoreConfig 追加（PR #107 対応）
- `gassmaIgnoreType.ts` (新規): 全モデル対象の `IgnoreConfig`
- `GassmaClientOptions` に `ignore` プロパティ追加

### 生成例
```typescript
declare type GassmaTestDefaultsConfig = {
  "User"?: {
    "isActive"?: boolean | (() => boolean);
    "createdAt"?: Date | (() => Date);
  };
};

declare type GassmaTestUpdatedAtConfig = {
  "Post"?: "id" | "title" | ... | ("id" | "title" | ...)[];
};

declare type GassmaTestIgnoreConfig = {
  "User"?: "id" | "email" | "name" | ... | ("id" | "email" | ...)[];
  // 全モデル
};
```

## テスト
- 全251テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)