### PR TITLE
feat: add @ignore schema exclusion and @map support

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -1,6 +1,8 @@
 import { generateClientJs } from "../../../generate/jsGenerate/generateClientJs";
 import type { DefaultsConfig } from "../../../generate/read/extractDefaults";
 import type { UpdatedAtConfig } from "../../../generate/read/extractUpdatedAt";
+import type { IgnoreConfig } from "../../../generate/read/extractIgnore";
+import type { MapConfig } from "../../../generate/read/extractMap";
 
 describe("generateClientJs", () => {
   it("should generate GassmaClient class with embedded relations", () => {
@@ -173,5 +175,86 @@ describe("generateClientJs", () => {
     expect(result).toContain("testUpdatedAt");
     expect(result).toContain("defaults: testDefaults");
     expect(result).toContain("updatedAt: testUpdatedAt");
+  });
+
+  it("should embed ignore config", () => {
+    const ignore: IgnoreConfig = {
+      User: ["internal", "debugLog"],
+      Post: ["tempData"],
+    };
+
+    const result = generateClientJs({}, "Test", undefined, undefined, ignore);
+
+    expect(result).toContain("testIgnore =");
+    expect(result).toContain("ignore: testIgnore");
+    expect(result).toContain('"User"');
+    expect(result).toContain('"internal"');
+    expect(result).toContain('"debugLog"');
+    expect(result).toContain('"Post"');
+    expect(result).toContain('"tempData"');
+  });
+
+  it("should not embed ignore when config is empty", () => {
+    const result = generateClientJs({}, "Test", undefined, undefined, {});
+
+    expect(result).not.toContain("Ignore");
+    expect(result).not.toContain("ignore");
+  });
+
+  it("should embed all configs together", () => {
+    const defaults: DefaultsConfig = {
+      User: { isActive: { kind: "static", value: true } },
+    };
+    const updatedAt: UpdatedAtConfig = {
+      User: ["updatedAt"],
+    };
+    const ignore: IgnoreConfig = {
+      User: ["internal"],
+    };
+
+    const result = generateClientJs({}, "Test", defaults, updatedAt, ignore);
+
+    expect(result).toContain("defaults: testDefaults");
+    expect(result).toContain("updatedAt: testUpdatedAt");
+    expect(result).toContain("ignore: testIgnore");
+  });
+
+  it("should embed map config", () => {
+    const map: MapConfig = {
+      User: { firstName: "first_name", lastName: "last_name" },
+      Post: { postTitle: "post_title" },
+    };
+
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      map,
+    );
+
+    expect(result).toContain("testMap =");
+    expect(result).toContain("map: testMap");
+    expect(result).toContain('"User"');
+    expect(result).toContain('"firstName"');
+    expect(result).toContain('"first_name"');
+    expect(result).toContain('"Post"');
+    expect(result).toContain('"postTitle"');
+    expect(result).toContain('"post_title"');
+  });
+
+  it("should not embed map when config is empty", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      {},
+    );
+
+    expect(result).not.toContain("Map");
+    expect(result).not.toContain("map:");
   });
 });

--- a/src/__test__/generate/read/extractIgnore.test.ts
+++ b/src/__test__/generate/read/extractIgnore.test.ts
@@ -1,0 +1,77 @@
+import { extractIgnore } from "../../../generate/read/extractIgnore";
+
+describe("extractIgnore", () => {
+  it("should extract @ignore fields", () => {
+    const schema = `
+model User {
+  id       Int    @id
+  name     String
+  internal String @ignore
+}
+`;
+    const result = extractIgnore(schema);
+    expect(result).toEqual({
+      User: ["internal"],
+    });
+  });
+
+  it("should extract multiple @ignore fields from one model", () => {
+    const schema = `
+model Post {
+  id       Int    @id
+  title    String
+  tempData String @ignore
+  debugLog String @ignore
+}
+`;
+    const result = extractIgnore(schema);
+    expect(result).toEqual({
+      Post: ["tempData", "debugLog"],
+    });
+  });
+
+  it("should extract from multiple models", () => {
+    const schema = `
+model User {
+  id       Int    @id
+  internal String @ignore
+}
+
+model Post {
+  id      Int    @id
+  tmpFlag String @ignore
+}
+`;
+    const result = extractIgnore(schema);
+    expect(result).toEqual({
+      User: ["internal"],
+      Post: ["tmpFlag"],
+    });
+  });
+
+  it("should return empty object when no @ignore fields", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractIgnore(schema);
+    expect(result).toEqual({});
+  });
+
+  it("should not confuse @ignore with other attributes", () => {
+    const schema = `
+model User {
+  id        Int      @id
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  internal  String   @ignore
+}
+`;
+    const result = extractIgnore(schema);
+    expect(result).toEqual({
+      User: ["internal"],
+    });
+  });
+});

--- a/src/__test__/generate/read/extractMap.test.ts
+++ b/src/__test__/generate/read/extractMap.test.ts
@@ -1,0 +1,75 @@
+import { extractMap } from "../../../generate/read/extractMap";
+
+describe("extractMap", () => {
+  it("should extract @map fields", () => {
+    const schema = `
+model User {
+  id        Int    @id
+  firstName String @map("first_name")
+}
+`;
+    const result = extractMap(schema);
+    expect(result).toEqual({
+      User: { firstName: "first_name" },
+    });
+  });
+
+  it("should extract multiple @map fields from one model", () => {
+    const schema = `
+model User {
+  id        Int    @id
+  firstName String @map("first_name")
+  lastName  String @map("last_name")
+}
+`;
+    const result = extractMap(schema);
+    expect(result).toEqual({
+      User: { firstName: "first_name", lastName: "last_name" },
+    });
+  });
+
+  it("should extract from multiple models", () => {
+    const schema = `
+model User {
+  id        Int    @id
+  firstName String @map("first_name")
+}
+
+model Post {
+  id       Int    @id
+  postName String @map("post_name")
+}
+`;
+    const result = extractMap(schema);
+    expect(result).toEqual({
+      User: { firstName: "first_name" },
+      Post: { postName: "post_name" },
+    });
+  });
+
+  it("should return empty object when no @map fields", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractMap(schema);
+    expect(result).toEqual({});
+  });
+
+  it("should not confuse @map with @@map", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String @map("user_name")
+
+  @@map("users")
+}
+`;
+    const result = extractMap(schema);
+    expect(result).toEqual({
+      User: { name: "user_name" },
+    });
+  });
+});

--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -320,4 +320,38 @@ model Post {
       authorId: ["number"],
     });
   });
+
+  it("should exclude @ignore fields from result", () => {
+    const schema = `
+model User {
+  id       Int    @id
+  name     String
+  internal String @ignore
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User).toEqual({
+      id: ["number"],
+      name: ["string"],
+    });
+    expect(result.User.internal).toBeUndefined();
+  });
+
+  it("should exclude @ignore optional fields from result", () => {
+    const schema = `
+model Post {
+  id       Int     @id
+  title    String
+  debugLog String? @ignore
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.Post).toEqual({
+      id: ["number"],
+      title: ["string"],
+    });
+    expect(result.Post["debugLog?"]).toBeUndefined();
+  });
 });

--- a/src/__test__/generate/typeGenerate/gassmaMapType.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMapType.test.ts
@@ -1,0 +1,53 @@
+import { getGassmaMapType } from "../../../generate/typeGenerate/gassmaMapType";
+
+describe("getGassmaMapType", () => {
+  it("should generate schema-specific map config with all models", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        name: ["string"],
+        "email?": ["string"],
+      },
+      Post: {
+        id: ["number"],
+        title: ["string"],
+      },
+    };
+    const result = getGassmaMapType(dictYaml, "Test");
+
+    expect(result).toContain("declare type GassmaTestMapConfig");
+    expect(result).toContain('"User"?:');
+    expect(result).toContain('"Post"?:');
+  });
+
+  it("should use field names as keys with string values", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: {
+        id: ["number"],
+        name: ["string"],
+        "email?": ["string"],
+      },
+    };
+    const result = getGassmaMapType(dictYaml, "Test");
+
+    expect(result).toContain('"id"?: string');
+    expect(result).toContain('"name"?: string');
+    expect(result).toContain('"email"?: string');
+  });
+
+  it("should handle empty dictYaml", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {};
+    const result = getGassmaMapType(dictYaml, "Test");
+
+    expect(result).toContain("declare type GassmaTestMapConfig = {}");
+  });
+
+  it("should use schema name in type name", () => {
+    const dictYaml: Record<string, Record<string, unknown[]>> = {
+      User: { id: ["number"] },
+    };
+    const result = getGassmaMapType(dictYaml, "Fuga");
+
+    expect(result).toContain("declare type GassmaFugaMapConfig");
+  });
+});

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -7,6 +7,8 @@ import { extractOutputPath } from "./read/extractOutputPath";
 import { extractDefaults } from "./read/extractDefaults";
 import { extractRelations } from "./read/extractRelations";
 import { extractUpdatedAt } from "./read/extractUpdatedAt";
+import { extractIgnore } from "./read/extractIgnore";
+import { extractMap } from "./read/extractMap";
 import { prismaReader } from "./read/prismaReader";
 import { writer } from "./writer";
 import { jsWriter } from "./jsWriter";
@@ -51,6 +53,8 @@ function generate(customDir?: string) {
     const relations = extractRelations(schemaText);
     const defaults = extractDefaults(schemaText);
     const updatedAt = extractUpdatedAt(schemaText);
+    const ignore = extractIgnore(schemaText);
+    const map = extractMap(schemaText);
     const baseName = path.basename(file, ".prisma");
     const schemaName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
     const includeCommon = !commonWritten.has(outputPath);
@@ -69,6 +73,8 @@ function generate(customDir?: string) {
       schemaName,
       defaults,
       updatedAt,
+      ignore,
+      map,
     );
     jsWriter(clientJs, `${baseName}Client`, outputPath);
     const clientDts = generateClientDts(schemaName);

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -1,6 +1,8 @@
 import type { RelationsConfig } from "../read/extractRelations";
 import type { DefaultsConfig } from "../read/extractDefaults";
 import type { UpdatedAtConfig } from "../read/extractUpdatedAt";
+import type { IgnoreConfig } from "../read/extractIgnore";
+import type { MapConfig } from "../read/extractMap";
 
 const FUNCTION_MAP: Record<string, string> = {
   now: "() => new Date()",
@@ -32,11 +34,33 @@ const serializeUpdatedAt = (updatedAt: UpdatedAtConfig): string => {
   return `{\n${entries.join(",\n")}\n  }`;
 };
 
+const serializeIgnore = (ignore: IgnoreConfig): string => {
+  const entries = Object.keys(ignore).map((modelName) => {
+    const fields = ignore[modelName];
+    const values = fields.map((f) => `"${f}"`).join(", ");
+    return `    "${modelName}": [${values}]`;
+  });
+  return `{\n${entries.join(",\n")}\n  }`;
+};
+
+const serializeMap = (map: MapConfig): string => {
+  const entries = Object.keys(map).map((modelName) => {
+    const fields = map[modelName];
+    const fieldEntries = Object.keys(fields).map((codeName) => {
+      return `      "${codeName}": "${fields[codeName]}"`;
+    });
+    return `    "${modelName}": {\n${fieldEntries.join(",\n")}\n    }`;
+  });
+  return `{\n${entries.join(",\n")}\n  }`;
+};
+
 const generateClientJs = (
   relations: RelationsConfig,
   schemaName: string,
   defaults?: DefaultsConfig,
   updatedAt?: UpdatedAtConfig,
+  ignore?: IgnoreConfig,
+  map?: MapConfig,
 ): string => {
   const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
@@ -46,6 +70,8 @@ const generateClientJs = (
 
   const hasDefaults = defaults && Object.keys(defaults).length > 0;
   const hasUpdatedAt = updatedAt && Object.keys(updatedAt).length > 0;
+  const hasIgnore = ignore && Object.keys(ignore).length > 0;
+  const hasMap = map && Object.keys(map).length > 0;
 
   const defaultsDecl = hasDefaults
     ? `const ${lowerName}Defaults = ${serializeDefaults(defaults)};\n\n`
@@ -55,14 +81,24 @@ const generateClientJs = (
     ? `const ${lowerName}UpdatedAt = ${serializeUpdatedAt(updatedAt)};\n\n`
     : "";
 
+  const ignoreDecl = hasIgnore
+    ? `const ${lowerName}Ignore = ${serializeIgnore(ignore)};\n\n`
+    : "";
+
+  const mapDecl = hasMap
+    ? `const ${lowerName}Map = ${serializeMap(map)};\n\n`
+    : "";
+
   const mergeProps = [`relations: ${lowerName}Relations`];
   if (hasDefaults) mergeProps.push(`defaults: ${lowerName}Defaults`);
   if (hasUpdatedAt) mergeProps.push(`updatedAt: ${lowerName}UpdatedAt`);
+  if (hasIgnore) mergeProps.push(`ignore: ${lowerName}Ignore`);
+  if (hasMap) mergeProps.push(`map: ${lowerName}Map`);
   const mergeExpr = `Object.assign({}, options, { ${mergeProps.join(", ")} })`;
 
   return `const ${lowerName}Relations = ${relationsJson};
 
-${defaultsDecl}${updatedAtDecl}class GassmaClient {
+${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}class GassmaClient {
   constructor(options) {
     const mergedOptions = ${mergeExpr};
     const client = new Gassma.GassmaClient(mergedOptions);

--- a/src/generate/read/extractIgnore.ts
+++ b/src/generate/read/extractIgnore.ts
@@ -1,0 +1,36 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+
+type IgnoreConfig = {
+  [modelName: string]: string[];
+};
+
+const extractIgnore = (schemaText: string): IgnoreConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: IgnoreConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+
+    const fields: string[] = [];
+
+    decl.members.forEach((member) => {
+      if (member.kind !== "field") return;
+      const hasIgnore = (member.attributes ?? []).some(
+        (attr) =>
+          attr.kind === "fieldAttribute" && attr.path.value[0] === "ignore",
+      );
+      if (hasIgnore) {
+        fields.push(member.name.value);
+      }
+    });
+
+    if (fields.length > 0) {
+      result[decl.name.value] = fields;
+    }
+  });
+
+  return result;
+};
+
+export { extractIgnore };
+export type { IgnoreConfig };

--- a/src/generate/read/extractMap.ts
+++ b/src/generate/read/extractMap.ts
@@ -1,0 +1,47 @@
+import {
+  parsePrismaSchema,
+  findFirstAttribute,
+} from "@loancrate/prisma-schema-parser";
+
+type MapConfig = {
+  [modelName: string]: {
+    [codeName: string]: string;
+  };
+};
+
+const extractMap = (schemaText: string): MapConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: MapConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+
+    const fields: Record<string, string> = {};
+
+    decl.members.forEach((member) => {
+      if (member.kind !== "field") return;
+
+      const mapAttr = findFirstAttribute(member.attributes, "map");
+      if (!mapAttr) return;
+
+      const firstArg = mapAttr.args?.[0];
+      if (!firstArg) return;
+
+      const expr =
+        firstArg.kind === "namedArgument" ? firstArg.expression : firstArg;
+
+      if (expr.kind === "literal" && typeof expr.value === "string") {
+        fields[member.name.value] = expr.value;
+      }
+    });
+
+    if (Object.keys(fields).length > 0) {
+      result[decl.name.value] = fields;
+    }
+  });
+
+  return result;
+};
+
+export { extractMap };
+export type { MapConfig };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -23,6 +23,7 @@ function prismaReader(
     decl.members.forEach((member) => {
       if (member.kind !== "field") return;
       if (!isScalarField(member, ast)) return;
+      if (hasIgnoreAttribute(member)) return;
 
       const isOptional = member.type.kind === "optional";
       const hasNonAutoDefault = hasNonAutoincrementDefault(member);
@@ -82,6 +83,14 @@ function hasUpdatedAtAttribute(
   return (member.attributes ?? []).some(
     (attr) =>
       attr.kind === "fieldAttribute" && attr.path.value[0] === "updatedAt",
+  );
+}
+
+function hasIgnoreAttribute(
+  member: Parameters<typeof findDefaultFieldAttribute>[0],
+): boolean {
+  return (member.attributes ?? []).some(
+    (attr) => attr.kind === "fieldAttribute" && attr.path.value[0] === "ignore",
   );
 }
 

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -17,12 +17,6 @@ const getGassmaCommonTypes = () => {
   type FalseKeys<T> = { [K in keyof T]: T[K] extends false ? K : never }[keyof T];
   type ResolveOmitKeys<GO, QO> = Exclude<TrueKeys<GO>, FalseKeys<QO>> | TrueKeys<QO>;
 
-  type MapConfig = {
-    [sheetName: string]: {
-      [codeName: string]: string;
-    };
-  };
-
   type ManyReturn = {
     count: number;
   };

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -17,6 +17,12 @@ const getGassmaCommonTypes = () => {
   type FalseKeys<T> = { [K in keyof T]: T[K] extends false ? K : never }[keyof T];
   type ResolveOmitKeys<GO, QO> = Exclude<TrueKeys<GO>, FalseKeys<QO>> | TrueKeys<QO>;
 
+  type MapConfig = {
+    [sheetName: string]: {
+      [codeName: string]: string;
+    };
+  };
+
   type ManyReturn = {
     count: number;
   };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -26,6 +26,7 @@ const getGassmaClientOptions = (schemaName: string) => {
   defaults?: Gassma${schemaName}DefaultsConfig;
   updatedAt?: Gassma${schemaName}UpdatedAtConfig;
   ignore?: Gassma${schemaName}IgnoreConfig;
+  map?: Gassma.MapConfig;
 };\n\n`;
 };
 

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -4,6 +4,7 @@ import { getGassmaCommonTypes } from "./gassmaCommonTypes";
 import { getGassmaDefaultsType } from "./gassmaDefaultsType";
 import { getGassmaErrorClasses } from "./gassmaErrorClasses";
 import { getGassmaIgnoreType } from "./gassmaIgnoreType";
+import { getGassmaMapType } from "./gassmaMapType";
 import { getGassmaUpdatedAtType } from "./gassmaUpdatedAtType";
 
 const getGassmaGlobalOmitConfig = (
@@ -26,7 +27,7 @@ const getGassmaClientOptions = (schemaName: string) => {
   defaults?: Gassma${schemaName}DefaultsConfig;
   updatedAt?: Gassma${schemaName}UpdatedAtConfig;
   ignore?: Gassma${schemaName}IgnoreConfig;
-  map?: Gassma.MapConfig;
+  map?: Gassma${schemaName}MapConfig;
 };\n\n`;
 };
 
@@ -90,6 +91,8 @@ const getGassmaSchemaClient = (
     ) +
     "\n" +
     getGassmaIgnoreType(options.dictYaml, schemaName) +
+    "\n" +
+    getGassmaMapType(options.dictYaml, schemaName) +
     "\n" +
     getGassmaClientOptions(schemaName)
   );

--- a/src/generate/typeGenerate/gassmaMapType.ts
+++ b/src/generate/typeGenerate/gassmaMapType.ts
@@ -1,0 +1,29 @@
+const stripOptional = (key: string) =>
+  key.endsWith("?") ? key.slice(0, -1) : key;
+
+const getGassmaMapType = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
+): string => {
+  const modelNames = Object.keys(dictYaml);
+  const typeName = `Gassma${schemaName}MapConfig`;
+
+  if (modelNames.length === 0) {
+    return `declare type ${typeName} = {};\n`;
+  }
+
+  const body = modelNames.reduce((pre, modelName) => {
+    const fields = dictYaml[modelName];
+    if (!fields) return pre;
+
+    const fieldEntries = Object.keys(fields)
+      .map((key) => `      "${stripOptional(key)}"?: string;`)
+      .join("\n");
+
+    return `${pre}  "${modelName}"?: {\n${fieldEntries}\n  };\n`;
+  }, "");
+
+  return `declare type ${typeName} = {\n${body}};\n`;
+};
+
+export { getGassmaMapType };


### PR DESCRIPTION
## 概要

`@ignore` と `@map` のスキーマ抽出・JS生成・型生成を追加。

## PR #54 との違い

| 機能 | PR #54 | 本PR #55 |
|------|--------|----------|
| `@ignore` 型生成（IgnoreConfig） | ✅ | - |
| `@ignore` スキーマ抽出（extractIgnore） | - | ✅ |
| `@ignore` dictYaml除外（prismaReader） | - | ✅ |
| `@ignore` JS埋め込み（generateClientJs） | - | ✅ |
| `@map` 全般 | - | ✅ |

## 変更内容

### @ignore（スキーマ抽出 + JS生成）
- `extractIgnore.ts`: スキーマから `@ignore` フィールドを抽出
- `prismaReader.ts`: `@ignore` フィールドを dictYaml から除外（型に含めない）
- `generateClientJs.ts`: ignore 設定をクライアントJSに埋め込み

### @map（新規）
- `extractMap.ts`: スキーマから `@map("name")` マッピングを抽出
- `generateClientJs.ts`: map 設定をクライアントJSに埋め込み
- `gassmaCommonTypes.ts`: `MapConfig` 型を共通名前空間に追加
- `gassmaMain.ts`: `ClientOptions` に `map` プロパティ追加

## テスト

extractIgnore: 5件、extractMap: 5件、prismaReader: 2件追加、generateClientJs: 4件追加
全268テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)