### PR TITLE
feat: @@ignore と @@map の CLI サポートを追加

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -257,4 +257,70 @@ describe("generateClientJs", () => {
     expect(result).not.toContain("Map");
     expect(result).not.toContain("map:");
   });
+
+  it("should embed ignoreSheets config", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ["InternalLog", "TempData"],
+    );
+
+    expect(result).toContain("testIgnoreSheets =");
+    expect(result).toContain("ignoreSheets: testIgnoreSheets");
+    expect(result).toContain('"InternalLog"');
+    expect(result).toContain('"TempData"');
+  });
+
+  it("should not embed ignoreSheets when empty", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [],
+    );
+
+    expect(result).not.toContain("IgnoreSheets");
+    expect(result).not.toContain("ignoreSheets");
+  });
+
+  it("should embed mapSheets config", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { User: "users", Post: "posts" },
+    );
+
+    expect(result).toContain("testMapSheets =");
+    expect(result).toContain("mapSheets: testMapSheets");
+    expect(result).toContain('"User": "users"');
+    expect(result).toContain('"Post": "posts"');
+  });
+
+  it("should not embed mapSheets when empty", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {},
+    );
+
+    expect(result).not.toContain("MapSheets");
+    expect(result).not.toContain("mapSheets");
+  });
 });

--- a/src/__test__/generate/read/extractIgnoreSheets.test.ts
+++ b/src/__test__/generate/read/extractIgnoreSheets.test.ts
@@ -1,0 +1,69 @@
+import { extractIgnoreSheets } from "../../../generate/read/extractIgnoreSheets";
+
+describe("extractIgnoreSheets", () => {
+  it("should extract @@ignore models", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+
+model InternalLog {
+  id      Int    @id
+  message String
+
+  @@ignore
+}
+`;
+    const result = extractIgnoreSheets(schema);
+    expect(result).toEqual(["InternalLog"]);
+  });
+
+  it("should extract multiple @@ignore models", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+
+model TempData {
+  id   Int    @id
+  data String
+
+  @@ignore
+}
+
+model DebugLog {
+  id      Int    @id
+  message String
+
+  @@ignore
+}
+`;
+    const result = extractIgnoreSheets(schema);
+    expect(result).toEqual(["TempData", "DebugLog"]);
+  });
+
+  it("should return empty array when no @@ignore models", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractIgnoreSheets(schema);
+    expect(result).toEqual([]);
+  });
+
+  it("should not confuse @@ignore with @ignore", () => {
+    const schema = `
+model User {
+  id       Int    @id
+  name     String
+  internal String @ignore
+}
+`;
+    const result = extractIgnoreSheets(schema);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/__test__/generate/read/extractMapSheets.test.ts
+++ b/src/__test__/generate/read/extractMapSheets.test.ts
@@ -1,0 +1,71 @@
+import { extractMapSheets } from "../../../generate/read/extractMapSheets";
+
+describe("extractMapSheets", () => {
+  it("should extract @@map models", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+
+  @@map("users")
+}
+`;
+    const result = extractMapSheets(schema);
+    expect(result).toEqual({ User: "users" });
+  });
+
+  it("should extract multiple @@map models", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+
+  @@map("users")
+}
+
+model Post {
+  id    Int    @id
+  title String
+
+  @@map("posts")
+}
+`;
+    const result = extractMapSheets(schema);
+    expect(result).toEqual({ User: "users", Post: "posts" });
+  });
+
+  it("should return empty object when no @@map models", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractMapSheets(schema);
+    expect(result).toEqual({});
+  });
+
+  it("should not confuse @@map with @map", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String @map("user_name")
+}
+`;
+    const result = extractMapSheets(schema);
+    expect(result).toEqual({});
+  });
+
+  it("should handle @@map and @map together", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String @map("user_name")
+
+  @@map("users")
+}
+`;
+    const result = extractMapSheets(schema);
+    expect(result).toEqual({ User: "users" });
+  });
+});

--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -354,4 +354,24 @@ model Post {
     });
     expect(result.Post["debugLog?"]).toBeUndefined();
   });
+
+  it("should exclude @@ignore models from result", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+
+model InternalLog {
+  id      Int    @id
+  message String
+
+  @@ignore
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(Object.keys(result)).toEqual(["User"]);
+    expect(result.InternalLog).toBeUndefined();
+  });
 });

--- a/src/__test__/generate/typeGenerate/gassmaIgnoreSheetsType.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaIgnoreSheetsType.test.ts
@@ -1,0 +1,29 @@
+import { getGassmaIgnoreSheetsType } from "../../../generate/typeGenerate/gassmaIgnoreSheetsType";
+
+describe("getGassmaIgnoreSheetsType", () => {
+  it("should generate union type from model names", () => {
+    const dictYaml = {
+      User: { id: ["number"], name: ["string"] },
+      Post: { id: ["number"], title: ["string"] },
+    };
+    const result = getGassmaIgnoreSheetsType(dictYaml, "Test");
+    expect(result).toBe(
+      `declare type GassmaTestIgnoreSheetsConfig = "User" | "Post" | ("User" | "Post")[];\n`,
+    );
+  });
+
+  it("should generate empty object type when no models", () => {
+    const result = getGassmaIgnoreSheetsType({}, "Test");
+    expect(result).toBe(`declare type GassmaTestIgnoreSheetsConfig = never;\n`);
+  });
+
+  it("should handle single model", () => {
+    const dictYaml = {
+      User: { id: ["number"] },
+    };
+    const result = getGassmaIgnoreSheetsType(dictYaml, "Test");
+    expect(result).toBe(
+      `declare type GassmaTestIgnoreSheetsConfig = "User" | ("User")[];\n`,
+    );
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaMapSheetsType.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMapSheetsType.test.ts
@@ -1,0 +1,34 @@
+import { getGassmaMapSheetsType } from "../../../generate/typeGenerate/gassmaMapSheetsType";
+
+describe("getGassmaMapSheetsType", () => {
+  it("should generate type with specific model names", () => {
+    const dictYaml = {
+      User: { id: ["number"], name: ["string"] },
+      Post: { id: ["number"], title: ["string"] },
+    };
+    const result = getGassmaMapSheetsType(dictYaml, "Test");
+    expect(result).toBe(
+      `declare type GassmaTestMapSheetsConfig = {\n` +
+        `  "User"?: string;\n` +
+        `  "Post"?: string;\n` +
+        `};\n`,
+    );
+  });
+
+  it("should generate empty object type when no models", () => {
+    const result = getGassmaMapSheetsType({}, "Test");
+    expect(result).toBe(`declare type GassmaTestMapSheetsConfig = {};\n`);
+  });
+
+  it("should handle single model", () => {
+    const dictYaml = {
+      User: { id: ["number"] },
+    };
+    const result = getGassmaMapSheetsType(dictYaml, "Test");
+    expect(result).toBe(
+      `declare type GassmaTestMapSheetsConfig = {\n` +
+        `  "User"?: string;\n` +
+        `};\n`,
+    );
+  });
+});

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -8,7 +8,9 @@ import { extractDefaults } from "./read/extractDefaults";
 import { extractRelations } from "./read/extractRelations";
 import { extractUpdatedAt } from "./read/extractUpdatedAt";
 import { extractIgnore } from "./read/extractIgnore";
+import { extractIgnoreSheets } from "./read/extractIgnoreSheets";
 import { extractMap } from "./read/extractMap";
+import { extractMapSheets } from "./read/extractMapSheets";
 import { prismaReader } from "./read/prismaReader";
 import { writer } from "./writer";
 import { jsWriter } from "./jsWriter";
@@ -54,7 +56,9 @@ function generate(customDir?: string) {
     const defaults = extractDefaults(schemaText);
     const updatedAt = extractUpdatedAt(schemaText);
     const ignore = extractIgnore(schemaText);
+    const ignoreSheets = extractIgnoreSheets(schemaText);
     const map = extractMap(schemaText);
+    const mapSheets = extractMapSheets(schemaText);
     const baseName = path.basename(file, ".prisma");
     const schemaName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
     const includeCommon = !commonWritten.has(outputPath);
@@ -75,6 +79,8 @@ function generate(customDir?: string) {
       updatedAt,
       ignore,
       map,
+      ignoreSheets,
+      mapSheets,
     );
     jsWriter(clientJs, `${baseName}Client`, outputPath);
     const clientDts = generateClientDts(schemaName);

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -3,6 +3,7 @@ import type { DefaultsConfig } from "../read/extractDefaults";
 import type { UpdatedAtConfig } from "../read/extractUpdatedAt";
 import type { IgnoreConfig } from "../read/extractIgnore";
 import type { MapConfig } from "../read/extractMap";
+import type { MapSheetsConfig } from "../read/extractMapSheets";
 
 const FUNCTION_MAP: Record<string, string> = {
   now: "() => new Date()",
@@ -43,6 +44,18 @@ const serializeIgnore = (ignore: IgnoreConfig): string => {
   return `{\n${entries.join(",\n")}\n  }`;
 };
 
+const serializeIgnoreSheets = (ignoreSheets: string[]): string => {
+  const values = ignoreSheets.map((s) => `"${s}"`).join(", ");
+  return `[${values}]`;
+};
+
+const serializeMapSheets = (mapSheets: MapSheetsConfig): string => {
+  const entries = Object.keys(mapSheets).map((modelName) => {
+    return `    "${modelName}": "${mapSheets[modelName]}"`;
+  });
+  return `{\n${entries.join(",\n")}\n  }`;
+};
+
 const serializeMap = (map: MapConfig): string => {
   const entries = Object.keys(map).map((modelName) => {
     const fields = map[modelName];
@@ -61,6 +74,8 @@ const generateClientJs = (
   updatedAt?: UpdatedAtConfig,
   ignore?: IgnoreConfig,
   map?: MapConfig,
+  ignoreSheets?: string[],
+  mapSheets?: MapSheetsConfig,
 ): string => {
   const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
@@ -72,6 +87,8 @@ const generateClientJs = (
   const hasUpdatedAt = updatedAt && Object.keys(updatedAt).length > 0;
   const hasIgnore = ignore && Object.keys(ignore).length > 0;
   const hasMap = map && Object.keys(map).length > 0;
+  const hasIgnoreSheets = ignoreSheets && ignoreSheets.length > 0;
+  const hasMapSheets = mapSheets && Object.keys(mapSheets).length > 0;
 
   const defaultsDecl = hasDefaults
     ? `const ${lowerName}Defaults = ${serializeDefaults(defaults)};\n\n`
@@ -89,16 +106,27 @@ const generateClientJs = (
     ? `const ${lowerName}Map = ${serializeMap(map)};\n\n`
     : "";
 
+  const ignoreSheetsDecl = hasIgnoreSheets
+    ? `const ${lowerName}IgnoreSheets = ${serializeIgnoreSheets(ignoreSheets)};\n\n`
+    : "";
+
+  const mapSheetsDecl = hasMapSheets
+    ? `const ${lowerName}MapSheets = ${serializeMapSheets(mapSheets)};\n\n`
+    : "";
+
   const mergeProps = [`relations: ${lowerName}Relations`];
   if (hasDefaults) mergeProps.push(`defaults: ${lowerName}Defaults`);
   if (hasUpdatedAt) mergeProps.push(`updatedAt: ${lowerName}UpdatedAt`);
   if (hasIgnore) mergeProps.push(`ignore: ${lowerName}Ignore`);
   if (hasMap) mergeProps.push(`map: ${lowerName}Map`);
+  if (hasIgnoreSheets)
+    mergeProps.push(`ignoreSheets: ${lowerName}IgnoreSheets`);
+  if (hasMapSheets) mergeProps.push(`mapSheets: ${lowerName}MapSheets`);
   const mergeExpr = `Object.assign({}, options, { ${mergeProps.join(", ")} })`;
 
   return `const ${lowerName}Relations = ${relationsJson};
 
-${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}class GassmaClient {
+${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}${ignoreSheetsDecl}${mapSheetsDecl}class GassmaClient {
   constructor(options) {
     const mergedOptions = ${mergeExpr};
     const client = new Gassma.GassmaClient(mergedOptions);

--- a/src/generate/read/extractIgnoreSheets.ts
+++ b/src/generate/read/extractIgnoreSheets.ts
@@ -1,0 +1,23 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+
+const extractIgnoreSheets = (schemaText: string): string[] => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: string[] = [];
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+
+    const hasModelIgnore = (decl.members ?? []).some(
+      (member) =>
+        member.kind === "blockAttribute" && member.path.value[0] === "ignore",
+    );
+
+    if (hasModelIgnore) {
+      result.push(decl.name.value);
+    }
+  });
+
+  return result;
+};
+
+export { extractIgnoreSheets };

--- a/src/generate/read/extractMapSheets.ts
+++ b/src/generate/read/extractMapSheets.ts
@@ -1,0 +1,36 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+
+type MapSheetsConfig = {
+  [modelName: string]: string;
+};
+
+const extractMapSheets = (schemaText: string): MapSheetsConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: MapSheetsConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+
+    const mapAttr = (decl.members ?? []).find(
+      (member) =>
+        member.kind === "blockAttribute" && member.path.value[0] === "map",
+    );
+
+    if (!mapAttr || mapAttr.kind !== "blockAttribute") return;
+
+    const firstArg = mapAttr.args?.[0];
+    if (!firstArg) return;
+
+    const expr =
+      firstArg.kind === "namedArgument" ? firstArg.expression : firstArg;
+
+    if (expr.kind === "literal" && typeof expr.value === "string") {
+      result[decl.name.value] = expr.value;
+    }
+  });
+
+  return result;
+};
+
+export { extractMapSheets };
+export type { MapSheetsConfig };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -16,6 +16,7 @@ function prismaReader(
 
   ast.declarations.forEach((decl) => {
     if (decl.kind !== "model") return;
+    if (hasModelIgnoreAttribute(decl)) return;
 
     const modelName = decl.name.value;
     const fields: Record<string, unknown[]> = {};
@@ -83,6 +84,15 @@ function hasUpdatedAtAttribute(
   return (member.attributes ?? []).some(
     (attr) =>
       attr.kind === "fieldAttribute" && attr.path.value[0] === "updatedAt",
+  );
+}
+
+function hasModelIgnoreAttribute(decl: {
+  members?: ReadonlyArray<{ kind: string; path?: { value: string[] } }>;
+}): boolean {
+  return (decl.members ?? []).some(
+    (member) =>
+      member.kind === "blockAttribute" && member.path?.value[0] === "ignore",
   );
 }
 

--- a/src/generate/typeGenerate/gassmaIgnoreSheetsType.ts
+++ b/src/generate/typeGenerate/gassmaIgnoreSheetsType.ts
@@ -1,0 +1,17 @@
+const getGassmaIgnoreSheetsType = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
+): string => {
+  const modelNames = Object.keys(dictYaml);
+  const typeName = `Gassma${schemaName}IgnoreSheetsConfig`;
+
+  if (modelNames.length === 0) {
+    return `declare type ${typeName} = never;\n`;
+  }
+
+  const union = modelNames.map((name) => `"${name}"`).join(" | ");
+
+  return `declare type ${typeName} = ${union} | (${union})[];\n`;
+};
+
+export { getGassmaIgnoreSheetsType };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -4,7 +4,9 @@ import { getGassmaCommonTypes } from "./gassmaCommonTypes";
 import { getGassmaDefaultsType } from "./gassmaDefaultsType";
 import { getGassmaErrorClasses } from "./gassmaErrorClasses";
 import { getGassmaIgnoreType } from "./gassmaIgnoreType";
+import { getGassmaIgnoreSheetsType } from "./gassmaIgnoreSheetsType";
 import { getGassmaMapType } from "./gassmaMapType";
+import { getGassmaMapSheetsType } from "./gassmaMapSheetsType";
 import { getGassmaUpdatedAtType } from "./gassmaUpdatedAtType";
 
 const getGassmaGlobalOmitConfig = (
@@ -27,7 +29,9 @@ const getGassmaClientOptions = (schemaName: string) => {
   defaults?: Gassma${schemaName}DefaultsConfig;
   updatedAt?: Gassma${schemaName}UpdatedAtConfig;
   ignore?: Gassma${schemaName}IgnoreConfig;
+  ignoreSheets?: Gassma${schemaName}IgnoreSheetsConfig;
   map?: Gassma${schemaName}MapConfig;
+  mapSheets?: Gassma${schemaName}MapSheetsConfig;
 };\n\n`;
 };
 
@@ -92,7 +96,11 @@ const getGassmaSchemaClient = (
     "\n" +
     getGassmaIgnoreType(options.dictYaml, schemaName) +
     "\n" +
+    getGassmaIgnoreSheetsType(options.dictYaml, schemaName) +
+    "\n" +
     getGassmaMapType(options.dictYaml, schemaName) +
+    "\n" +
+    getGassmaMapSheetsType(options.dictYaml, schemaName) +
     "\n" +
     getGassmaClientOptions(schemaName)
   );

--- a/src/generate/typeGenerate/gassmaMapSheetsType.ts
+++ b/src/generate/typeGenerate/gassmaMapSheetsType.ts
@@ -1,0 +1,17 @@
+const getGassmaMapSheetsType = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
+): string => {
+  const modelNames = Object.keys(dictYaml);
+  const typeName = `Gassma${schemaName}MapSheetsConfig`;
+
+  if (modelNames.length === 0) {
+    return `declare type ${typeName} = {};\n`;
+  }
+
+  const body = modelNames.map((name) => `  "${name}"?: string;`).join("\n");
+
+  return `declare type ${typeName} = {\n${body}\n};\n`;
+};
+
+export { getGassmaMapSheetsType };


### PR DESCRIPTION
## 概要

- `@@ignore`（モデルレベル無視）と `@@map("name")`（モデルレベルマッピング）の CLI 型生成・JS 埋め込みを追加
- アバウトな型（`[key: string]` や `unknown`）を使わず、スキーマから厳密な型を生成

## 変更内容

### @@ignore
- `extractIgnoreSheets.ts`: スキーマから `@@ignore` モデル名を抽出
- `prismaReader.ts`: `@@ignore` モデルを dictYaml（型生成元）から完全除外
- `gassmaIgnoreSheetsType.ts`: モデル名のユニオン型を生成（例: `"User" | "Post" | ("User" | "Post")[]`）
- `generateClientJs.ts`: `ignoreSheets` 設定を JS に埋め込み

### @@map
- `extractMapSheets.ts`: スキーマから `@@map("name")` マッピングを抽出
- `gassmaMapSheetsType.ts`: モデル名をキーとする厳密な型を生成（例: `{ "User"?: string; "Post"?: string; }`）
- `generateClientJs.ts`: `mapSheets` 設定を JS に埋め込み

### 共通
- `gassmaMain.ts`: `ClientOptions` に `ignoreSheets` / `mapSheets` を追加
- `generate.ts`: 抽出処理の呼び出しと JS 生成への受け渡し

## テスト

- extractIgnoreSheets: 4件
- extractMapSheets: 5件
- gassmaIgnoreSheetsType: 3件
- gassmaMapSheetsType: 3件
- generateClientJs: 4件追加
- prismaReader: 1件追加
- 全292テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)