### PR TITLE
feat: add autoincrement CLI type generation

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -3,6 +3,7 @@ import type { DefaultsConfig } from "../../../generate/read/extractDefaults";
 import type { UpdatedAtConfig } from "../../../generate/read/extractUpdatedAt";
 import type { IgnoreConfig } from "../../../generate/read/extractIgnore";
 import type { MapConfig } from "../../../generate/read/extractMap";
+import type { AutoincrementConfig } from "../../../generate/read/extractAutoincrement";
 
 describe("generateClientJs", () => {
   it("should generate GassmaClient class with embedded relations", () => {
@@ -322,5 +323,64 @@ describe("generateClientJs", () => {
 
     expect(result).not.toContain("MapSheets");
     expect(result).not.toContain("mapSheets");
+  });
+
+  it("should embed autoincrement config with single field", () => {
+    const autoincrement: AutoincrementConfig = {
+      User: ["id"],
+    };
+
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      autoincrement,
+    );
+
+    expect(result).toContain("testAutoincrement =");
+    expect(result).toContain("autoincrement: testAutoincrement");
+    expect(result).toContain('"User": "id"');
+  });
+
+  it("should embed autoincrement config with multiple fields", () => {
+    const autoincrement: AutoincrementConfig = {
+      User: ["id", "seq"],
+    };
+
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      autoincrement,
+    );
+
+    expect(result).toContain('"User": ["id", "seq"]');
+  });
+
+  it("should not embed autoincrement when config is empty", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {},
+    );
+
+    expect(result).not.toContain("Autoincrement");
+    expect(result).not.toContain("autoincrement");
   });
 });

--- a/src/__test__/generate/read/extractAutoincrement.test.ts
+++ b/src/__test__/generate/read/extractAutoincrement.test.ts
@@ -1,0 +1,73 @@
+import { extractAutoincrement } from "../../../generate/read/extractAutoincrement";
+
+describe("extractAutoincrement", () => {
+  it("should extract @default(autoincrement()) fields", () => {
+    const schema = `
+model User {
+  id   Int    @id @default(autoincrement())
+  name String
+}
+`;
+    const result = extractAutoincrement(schema);
+    expect(result).toEqual({
+      User: ["id"],
+    });
+  });
+
+  it("should extract from multiple models", () => {
+    const schema = `
+model User {
+  id   Int    @id @default(autoincrement())
+  name String
+}
+
+model Post {
+  id    Int    @id @default(autoincrement())
+  title String
+}
+`;
+    const result = extractAutoincrement(schema);
+    expect(result).toEqual({
+      User: ["id"],
+      Post: ["id"],
+    });
+  });
+
+  it("should return empty object when no autoincrement fields", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractAutoincrement(schema);
+    expect(result).toEqual({});
+  });
+
+  it("should not confuse autoincrement with other @default functions", () => {
+    const schema = `
+model User {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  name      String
+}
+`;
+    const result = extractAutoincrement(schema);
+    expect(result).toEqual({
+      User: ["id"],
+    });
+  });
+
+  it("should not confuse autoincrement with static defaults", () => {
+    const schema = `
+model User {
+  id       Int     @id @default(autoincrement())
+  isActive Boolean @default(true)
+}
+`;
+    const result = extractAutoincrement(schema);
+    expect(result).toEqual({
+      User: ["id"],
+    });
+  });
+});

--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -13,7 +13,7 @@ model User {
 
     expect(result).toEqual({
       User: {
-        id: ["number"],
+        "id?": ["number"],
         name: ["string"],
         "email?": ["string"],
       },
@@ -120,7 +120,7 @@ model User {
 `;
     const result = prismaReader(schema);
 
-    expect(result.User.id).toEqual(["number"]);
+    expect(result.User["id?"]).toEqual(["number"]);
     expect(result.User.email).toEqual(["string"]);
     expect(result.User.name).toEqual(["string"]);
   });
@@ -251,7 +251,7 @@ model User {
     expect(result.User.status).toEqual(["active", "inactive"]);
   });
 
-  it("should make fields with @default() optional (except autoincrement)", () => {
+  it("should make fields with @default() optional (including autoincrement)", () => {
     const schema = `
 model User {
   id        Int      @id @default(autoincrement())
@@ -262,9 +262,9 @@ model User {
 `;
     const result = prismaReader(schema);
 
-    // autoincrement() は除外 → 必須のまま
-    expect(result.User.id).toEqual(["number"]);
-    expect(result.User["id?"]).toBeUndefined();
+    // autoincrement() → オプショナル
+    expect(result.User["id?"]).toEqual(["number"]);
+    expect(result.User.id).toBeUndefined();
 
     // @default(true) → オプショナル
     expect(result.User["isActive?"]).toEqual(["boolean"]);

--- a/src/__test__/generate/typeGenerate/gassmaAutoincrementType.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaAutoincrementType.test.ts
@@ -1,0 +1,38 @@
+import { getGassmaAutoincrementType } from "../../../generate/typeGenerate/gassmaAutoincrementType";
+
+describe("getGassmaAutoincrementType", () => {
+  it("should generate type with specific model and field names", () => {
+    const dictYaml = {
+      User: { id: ["number"], name: ["string"] },
+      Post: { id: ["number"], title: ["string"] },
+    };
+    const result = getGassmaAutoincrementType(
+      dictYaml,
+      ["User", "Post"],
+      "Test",
+    );
+    expect(result).toBe(
+      `declare type GassmaTestAutoincrementConfig = {\n` +
+        `  "User"?: "id" | "name" | ("id" | "name")[];\n` +
+        `  "Post"?: "id" | "title" | ("id" | "title")[];\n` +
+        `};\n`,
+    );
+  });
+
+  it("should generate empty object type when no models", () => {
+    const result = getGassmaAutoincrementType({}, [], "Test");
+    expect(result).toBe(`declare type GassmaTestAutoincrementConfig = {};\n`);
+  });
+
+  it("should handle single model", () => {
+    const dictYaml = {
+      User: { id: ["number"], name: ["string"] },
+    };
+    const result = getGassmaAutoincrementType(dictYaml, ["User"], "Test");
+    expect(result).toBe(
+      `declare type GassmaTestAutoincrementConfig = {\n` +
+        `  "User"?: "id" | "name" | ("id" | "name")[];\n` +
+        `};\n`,
+    );
+  });
+});

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -4,6 +4,7 @@ import { generater } from "./generator";
 import { generateClientDts } from "./jsGenerate/generateClientDts";
 import { generateClientJs } from "./jsGenerate/generateClientJs";
 import { extractOutputPath } from "./read/extractOutputPath";
+import { extractAutoincrement } from "./read/extractAutoincrement";
 import { extractDefaults } from "./read/extractDefaults";
 import { extractRelations } from "./read/extractRelations";
 import { extractUpdatedAt } from "./read/extractUpdatedAt";
@@ -53,6 +54,7 @@ function generate(customDir?: string) {
 
     const parsed = prismaReader(schemaText);
     const relations = extractRelations(schemaText);
+    const autoincrement = extractAutoincrement(schemaText);
     const defaults = extractDefaults(schemaText);
     const updatedAt = extractUpdatedAt(schemaText);
     const ignore = extractIgnore(schemaText);
@@ -70,6 +72,7 @@ function generate(customDir?: string) {
       includeCommon,
       defaults,
       Object.keys(updatedAt),
+      Object.keys(autoincrement),
     );
     writer(resultString, baseName, outputPath);
     const clientJs = generateClientJs(
@@ -81,6 +84,7 @@ function generate(customDir?: string) {
       map,
       ignoreSheets,
       mapSheets,
+      autoincrement,
     );
     jsWriter(clientJs, `${baseName}Client`, outputPath);
     const clientDts = generateClientDts(schemaName);

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -45,6 +45,7 @@ const generater = (
   includeCommon?: boolean,
   defaults?: DefaultsConfig,
   updatedAtModels?: string[],
+  autoincrementModels?: string[],
 ) => {
   const schema = schemaName ?? "";
   const sheetNames = Object.keys(dictYaml);
@@ -52,6 +53,7 @@ const generater = (
     dictYaml,
     defaults: defaults ?? {},
     updatedAtModels: updatedAtModels ?? [],
+    autoincrementModels: autoincrementModels ?? [],
   });
 
   result += getGassmaSheet(sheetNames, schema);

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -3,6 +3,7 @@ import type { DefaultsConfig } from "../read/extractDefaults";
 import type { UpdatedAtConfig } from "../read/extractUpdatedAt";
 import type { IgnoreConfig } from "../read/extractIgnore";
 import type { MapConfig } from "../read/extractMap";
+import type { AutoincrementConfig } from "../read/extractAutoincrement";
 import type { MapSheetsConfig } from "../read/extractMapSheets";
 
 const FUNCTION_MAP: Record<string, string> = {
@@ -67,6 +68,18 @@ const serializeMap = (map: MapConfig): string => {
   return `{\n${entries.join(",\n")}\n  }`;
 };
 
+const serializeAutoincrement = (autoincrement: AutoincrementConfig): string => {
+  const entries = Object.keys(autoincrement).map((modelName) => {
+    const fields = autoincrement[modelName];
+    if (fields.length === 1) {
+      return `    "${modelName}": "${fields[0]}"`;
+    }
+    const values = fields.map((f) => `"${f}"`).join(", ");
+    return `    "${modelName}": [${values}]`;
+  });
+  return `{\n${entries.join(",\n")}\n  }`;
+};
+
 const generateClientJs = (
   relations: RelationsConfig,
   schemaName: string,
@@ -76,6 +89,7 @@ const generateClientJs = (
   map?: MapConfig,
   ignoreSheets?: string[],
   mapSheets?: MapSheetsConfig,
+  autoincrement?: AutoincrementConfig,
 ): string => {
   const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
@@ -89,6 +103,8 @@ const generateClientJs = (
   const hasMap = map && Object.keys(map).length > 0;
   const hasIgnoreSheets = ignoreSheets && ignoreSheets.length > 0;
   const hasMapSheets = mapSheets && Object.keys(mapSheets).length > 0;
+  const hasAutoincrement =
+    autoincrement && Object.keys(autoincrement).length > 0;
 
   const defaultsDecl = hasDefaults
     ? `const ${lowerName}Defaults = ${serializeDefaults(defaults)};\n\n`
@@ -114,6 +130,10 @@ const generateClientJs = (
     ? `const ${lowerName}MapSheets = ${serializeMapSheets(mapSheets)};\n\n`
     : "";
 
+  const autoincrementDecl = hasAutoincrement
+    ? `const ${lowerName}Autoincrement = ${serializeAutoincrement(autoincrement)};\n\n`
+    : "";
+
   const mergeProps = [`relations: ${lowerName}Relations`];
   if (hasDefaults) mergeProps.push(`defaults: ${lowerName}Defaults`);
   if (hasUpdatedAt) mergeProps.push(`updatedAt: ${lowerName}UpdatedAt`);
@@ -122,11 +142,13 @@ const generateClientJs = (
   if (hasIgnoreSheets)
     mergeProps.push(`ignoreSheets: ${lowerName}IgnoreSheets`);
   if (hasMapSheets) mergeProps.push(`mapSheets: ${lowerName}MapSheets`);
+  if (hasAutoincrement)
+    mergeProps.push(`autoincrement: ${lowerName}Autoincrement`);
   const mergeExpr = `Object.assign({}, options, { ${mergeProps.join(", ")} })`;
 
   return `const ${lowerName}Relations = ${relationsJson};
 
-${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}${ignoreSheetsDecl}${mapSheetsDecl}class GassmaClient {
+${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}${ignoreSheetsDecl}${mapSheetsDecl}${autoincrementDecl}class GassmaClient {
   constructor(options) {
     const mergedOptions = ${mergeExpr};
     const client = new Gassma.GassmaClient(mergedOptions);

--- a/src/generate/read/extractAutoincrement.ts
+++ b/src/generate/read/extractAutoincrement.ts
@@ -1,0 +1,41 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import { findDefaultFieldAttribute } from "@loancrate/prisma-schema-parser/dist/attributes";
+
+type AutoincrementConfig = {
+  [modelName: string]: string[];
+};
+
+const extractAutoincrement = (schemaText: string): AutoincrementConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: AutoincrementConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+
+    const fields: string[] = [];
+
+    decl.members.forEach((member) => {
+      if (member.kind !== "field") return;
+
+      const defaultAttr = findDefaultFieldAttribute(member);
+      if (!defaultAttr) return;
+
+      const expr = defaultAttr.expression;
+      if (
+        expr.kind === "functionCall" &&
+        expr.path.value[0] === "autoincrement"
+      ) {
+        fields.push(member.name.value);
+      }
+    });
+
+    if (fields.length > 0) {
+      result[decl.name.value] = fields;
+    }
+  });
+
+  return result;
+};
+
+export { extractAutoincrement };
+export type { AutoincrementConfig };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -27,7 +27,7 @@ function prismaReader(
       if (hasIgnoreAttribute(member)) return;
 
       const isOptional = member.type.kind === "optional";
-      const hasNonAutoDefault = hasNonAutoincrementDefault(member);
+      const hasDefaultValue = hasDefault(member);
       const isUpdatedAt = hasUpdatedAtAttribute(member);
       const baseType =
         member.type.kind === "optional" || member.type.kind === "required"
@@ -37,7 +37,7 @@ function prismaReader(
 
       const typeName = baseType.name.value;
       const fieldName =
-        isOptional || hasNonAutoDefault || isUpdatedAt
+        isOptional || hasDefaultValue || isUpdatedAt
           ? `${member.name.value}?`
           : member.name.value;
 
@@ -64,18 +64,11 @@ function prismaReader(
   return result;
 }
 
-const SKIP_DEFAULT_FUNCTIONS = ["autoincrement"];
-
-function hasNonAutoincrementDefault(
+function hasDefault(
   member: Parameters<typeof findDefaultFieldAttribute>[0],
 ): boolean {
   const attr = findDefaultFieldAttribute(member);
-  if (!attr) return false;
-  if (attr.expression.kind === "functionCall") {
-    const funcName = attr.expression.path.value[0];
-    return SKIP_DEFAULT_FUNCTIONS.indexOf(funcName) === -1;
-  }
-  return true;
+  return attr !== undefined;
 }
 
 function hasUpdatedAtAttribute(

--- a/src/generate/typeGenerate/gassmaAutoincrementType.ts
+++ b/src/generate/typeGenerate/gassmaAutoincrementType.ts
@@ -1,0 +1,15 @@
+import { generateColumnUnionConfig } from "./generateColumnUnionConfig";
+
+const getGassmaAutoincrementType = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  autoincrementModels: string[],
+  schemaName: string,
+): string => {
+  return generateColumnUnionConfig(
+    dictYaml,
+    autoincrementModels,
+    `Gassma${schemaName}AutoincrementConfig`,
+  );
+};
+
+export { getGassmaAutoincrementType };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -7,6 +7,7 @@ import { getGassmaIgnoreType } from "./gassmaIgnoreType";
 import { getGassmaIgnoreSheetsType } from "./gassmaIgnoreSheetsType";
 import { getGassmaMapType } from "./gassmaMapType";
 import { getGassmaMapSheetsType } from "./gassmaMapSheetsType";
+import { getGassmaAutoincrementType } from "./gassmaAutoincrementType";
 import { getGassmaUpdatedAtType } from "./gassmaUpdatedAtType";
 
 const getGassmaGlobalOmitConfig = (
@@ -28,6 +29,7 @@ const getGassmaClientOptions = (schemaName: string) => {
   omit?: O;
   defaults?: Gassma${schemaName}DefaultsConfig;
   updatedAt?: Gassma${schemaName}UpdatedAtConfig;
+  autoincrement?: Gassma${schemaName}AutoincrementConfig;
   ignore?: Gassma${schemaName}IgnoreConfig;
   ignoreSheets?: Gassma${schemaName}IgnoreSheetsConfig;
   map?: Gassma${schemaName}MapConfig;
@@ -63,6 +65,7 @@ type GassmaMainOptions = {
   dictYaml: Record<string, Record<string, unknown[]>>;
   defaults: DefaultsConfig;
   updatedAtModels: string[];
+  autoincrementModels: string[];
 };
 
 const getGassmaSchemaClient = (
@@ -102,6 +105,12 @@ const getGassmaSchemaClient = (
     "\n" +
     getGassmaMapSheetsType(options.dictYaml, schemaName) +
     "\n" +
+    getGassmaAutoincrementType(
+      options.dictYaml,
+      options.autoincrementModels,
+      schemaName,
+    ) +
+    "\n" +
     getGassmaClientOptions(schemaName)
   );
 };
@@ -117,6 +126,7 @@ const getGassmaMain = (
     dictYaml: {},
     defaults: {},
     updatedAtModels: [],
+    autoincrementModels: [],
   };
 
   return common + getGassmaSchemaClient(sheetNames, schemaName, mainOptions);


### PR DESCRIPTION
## 概要

gassma本体 PR #115 で追加された `autoincrement` オプションのCLI型生成対応。

- `@default(autoincrement())` フィールドを抽出する `extractAutoincrement` を追加
- `GassmaTestAutoincrementConfig` 型を厳密に生成（モデル名・フィールド名リテラル）
- `generateClientJs` に autoincrement 設定の埋め込みを追加
- `generate.ts` / `generator.ts` / `gassmaMain.ts` にワイヤリング

## テスト

- `extractAutoincrement`: 5テスト
- `gassmaAutoincrementType`: 3テスト
- `generateClientJs`: 3テスト追加（計24テスト）
- 全303テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)