### PR TITLE
feat: enum @map対応のマッピング定数生成

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -26,4 +26,68 @@ describe("generateClientDts", () => {
     expect(result).toContain("options?: GassmaFugaClientOptions");
     expect(result).toContain("readonly sheets: GassmaFugaSheet");
   });
+
+  it("should export enum constants and types", () => {
+    const enums = {
+      Role: [
+        { name: "ADMIN", value: "ADMIN" },
+        { name: "USER", value: "USER" },
+        { name: "MODERATOR", value: "MODERATOR" },
+      ],
+    };
+    const result = generateClientDts("Test", enums);
+
+    expect(result).toContain("export declare const Role: {");
+    expect(result).toContain('  readonly ADMIN: "ADMIN";');
+    expect(result).toContain('  readonly USER: "USER";');
+    expect(result).toContain('  readonly MODERATOR: "MODERATOR";');
+    expect(result).toContain(
+      "export type Role = (typeof Role)[keyof typeof Role];",
+    );
+  });
+
+  it("should export enum constants with @map values", () => {
+    const enums = {
+      Role: [
+        { name: "admin", value: "ADMIN" },
+        { name: "user", value: "USER" },
+        { name: "moderator", value: "MODERATOR" },
+      ],
+    };
+    const result = generateClientDts("Test", enums);
+
+    expect(result).toContain("export declare const Role: {");
+    expect(result).toContain('  readonly admin: "ADMIN";');
+    expect(result).toContain('  readonly user: "USER";');
+    expect(result).toContain('  readonly moderator: "MODERATOR";');
+    expect(result).toContain(
+      "export type Role = (typeof Role)[keyof typeof Role];",
+    );
+  });
+
+  it("should export multiple enums", () => {
+    const enums = {
+      Role: [
+        { name: "ADMIN", value: "ADMIN" },
+        { name: "USER", value: "USER" },
+      ],
+      Status: [
+        { name: "ACTIVE", value: "ACTIVE" },
+        { name: "INACTIVE", value: "INACTIVE" },
+      ],
+    };
+    const result = generateClientDts("Test", enums);
+
+    expect(result).toContain("export declare const Role");
+    expect(result).toContain("export type Role");
+    expect(result).toContain("export declare const Status");
+    expect(result).toContain("export type Status");
+  });
+
+  it("should not export enums when none exist", () => {
+    const result = generateClientDts("Test", {});
+
+    expect(result).not.toContain("export declare const");
+    expect(result).not.toContain("export type");
+  });
 });

--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -383,4 +383,108 @@ describe("generateClientJs", () => {
     expect(result).not.toContain("Autoincrement");
     expect(result).not.toContain("autoincrement");
   });
+
+  it("should export enum constants", () => {
+    const enums = {
+      Role: [
+        { name: "ADMIN", value: "ADMIN" },
+        { name: "USER", value: "USER" },
+        { name: "MODERATOR", value: "MODERATOR" },
+      ],
+    };
+
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      enums,
+    );
+
+    expect(result).toContain("const Role = {");
+    expect(result).toContain('  ADMIN: "ADMIN"');
+    expect(result).toContain('  USER: "USER"');
+    expect(result).toContain('  MODERATOR: "MODERATOR"');
+    expect(result).toContain("exports.Role = Role;");
+  });
+
+  it("should export enum constants with @map values", () => {
+    const enums = {
+      Role: [
+        { name: "admin", value: "ADMIN" },
+        { name: "user", value: "USER" },
+        { name: "moderator", value: "MODERATOR" },
+      ],
+    };
+
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      enums,
+    );
+
+    expect(result).toContain("const Role = {");
+    expect(result).toContain('  admin: "ADMIN"');
+    expect(result).toContain('  user: "USER"');
+    expect(result).toContain('  moderator: "MODERATOR"');
+    expect(result).toContain("exports.Role = Role;");
+  });
+
+  it("should export multiple enum constants", () => {
+    const enums = {
+      Role: [
+        { name: "ADMIN", value: "ADMIN" },
+        { name: "USER", value: "USER" },
+      ],
+      Status: [
+        { name: "ACTIVE", value: "ACTIVE" },
+        { name: "INACTIVE", value: "INACTIVE" },
+      ],
+    };
+
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      enums,
+    );
+
+    expect(result).toContain("exports.Role = Role;");
+    expect(result).toContain("exports.Status = Status;");
+  });
+
+  it("should not export enums when config is empty", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {},
+    );
+
+    expect(result).not.toContain("exports.Role");
+  });
 });

--- a/src/__test__/generate/read/extractEnums.test.ts
+++ b/src/__test__/generate/read/extractEnums.test.ts
@@ -1,7 +1,7 @@
 import { extractEnums } from "../../../generate/read/extractEnums";
 
 describe("extractEnums", () => {
-  it("should extract enum values", () => {
+  it("should extract enum entries without @map", () => {
     const schema = `
 enum Role {
   ADMIN
@@ -17,7 +17,11 @@ model User {
     const result = extractEnums(schema);
 
     expect(result).toEqual({
-      Role: ["ADMIN", "USER", "MODERATOR"],
+      Role: [
+        { name: "ADMIN", value: "ADMIN" },
+        { name: "USER", value: "USER" },
+        { name: "MODERATOR", value: "MODERATOR" },
+      ],
     });
   });
 
@@ -42,8 +46,62 @@ model User {
     const result = extractEnums(schema);
 
     expect(result).toEqual({
-      Role: ["ADMIN", "USER"],
-      Status: ["ACTIVE", "INACTIVE"],
+      Role: [
+        { name: "ADMIN", value: "ADMIN" },
+        { name: "USER", value: "USER" },
+      ],
+      Status: [
+        { name: "ACTIVE", value: "ACTIVE" },
+        { name: "INACTIVE", value: "INACTIVE" },
+      ],
+    });
+  });
+
+  it("should use @map value when present", () => {
+    const schema = `
+enum Role {
+  admin     @map("ADMIN")
+  user      @map("USER")
+  moderator @map("MODERATOR")
+}
+
+model User {
+  id   Int  @id
+  role Role
+}
+`;
+    const result = extractEnums(schema);
+
+    expect(result).toEqual({
+      Role: [
+        { name: "admin", value: "ADMIN" },
+        { name: "user", value: "USER" },
+        { name: "moderator", value: "MODERATOR" },
+      ],
+    });
+  });
+
+  it("should mix @map and non-@map values", () => {
+    const schema = `
+enum Role {
+  admin     @map("ADMIN")
+  USER
+  moderator @map("MOD")
+}
+
+model User {
+  id   Int  @id
+  role Role
+}
+`;
+    const result = extractEnums(schema);
+
+    expect(result).toEqual({
+      Role: [
+        { name: "admin", value: "ADMIN" },
+        { name: "USER", value: "USER" },
+        { name: "moderator", value: "MOD" },
+      ],
     });
   });
 

--- a/src/__test__/generate/read/prismaReader.test.ts
+++ b/src/__test__/generate/read/prismaReader.test.ts
@@ -207,6 +207,24 @@ model User {
     expect(result.User.role).toEqual(["ADMIN", "USER", "MODERATOR"]);
   });
 
+  it("should use @map values for enum fields", () => {
+    const schema = `
+enum Role {
+  admin     @map("ADMIN")
+  user      @map("USER")
+  moderator @map("MODERATOR")
+}
+
+model User {
+  id   Int  @id
+  role Role
+}
+`;
+    const result = prismaReader(schema);
+
+    expect(result.User.role).toEqual(["ADMIN", "USER", "MODERATOR"]);
+  });
+
   it("should handle optional enum fields", () => {
     const schema = `
 enum Status {

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -12,6 +12,7 @@ import { extractIgnore } from "./read/extractIgnore";
 import { extractIgnoreSheets } from "./read/extractIgnoreSheets";
 import { extractMap } from "./read/extractMap";
 import { extractMapSheets } from "./read/extractMapSheets";
+import { extractEnums } from "./read/extractEnums";
 import { prismaReader } from "./read/prismaReader";
 import { writer } from "./writer";
 import { jsWriter } from "./jsWriter";
@@ -61,6 +62,7 @@ function generate(customDir?: string) {
     const ignoreSheets = extractIgnoreSheets(schemaText);
     const map = extractMap(schemaText);
     const mapSheets = extractMapSheets(schemaText);
+    const enums = extractEnums(schemaText);
     const baseName = path.basename(file, ".prisma");
     const schemaName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
     const includeCommon = !commonWritten.has(outputPath);
@@ -85,9 +87,10 @@ function generate(customDir?: string) {
       ignoreSheets,
       mapSheets,
       autoincrement,
+      enums,
     );
     jsWriter(clientJs, `${baseName}Client`, outputPath);
-    const clientDts = generateClientDts(schemaName);
+    const clientDts = generateClientDts(schemaName, enums);
     writer(clientDts, `${baseName}Client`, outputPath);
   });
 

--- a/src/generate/jsGenerate/generateClientDts.ts
+++ b/src/generate/jsGenerate/generateClientDts.ts
@@ -1,9 +1,22 @@
-const generateClientDts = (schemaName: string): string => {
-  return `export declare class GassmaClient<O extends Gassma${schemaName}GlobalOmitConfig = {}> {
+import type { EnumsConfig } from "../read/extractEnums";
+
+const generateClientDts = (schemaName: string, enums?: EnumsConfig): string => {
+  let result = `export declare class GassmaClient<O extends Gassma${schemaName}GlobalOmitConfig = {}> {
   constructor(options?: Gassma${schemaName}ClientOptions<O>);
   readonly sheets: Gassma${schemaName}Sheet<O>;
 }
 `;
+
+  if (enums && Object.keys(enums).length > 0) {
+    Object.keys(enums).forEach((enumName) => {
+      const entries = enums[enumName]
+        .map((e) => `  readonly ${e.name}: "${e.value}";`)
+        .join("\n");
+      result += `\nexport declare const ${enumName}: {\n${entries}\n};\nexport type ${enumName} = (typeof ${enumName})[keyof typeof ${enumName}];\n`;
+    });
+  }
+
+  return result;
 };
 
 export { generateClientDts };

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -5,6 +5,7 @@ import type { IgnoreConfig } from "../read/extractIgnore";
 import type { MapConfig } from "../read/extractMap";
 import type { AutoincrementConfig } from "../read/extractAutoincrement";
 import type { MapSheetsConfig } from "../read/extractMapSheets";
+import type { EnumsConfig } from "../read/extractEnums";
 
 const FUNCTION_MAP: Record<string, string> = {
   now: "() => new Date()",
@@ -90,6 +91,7 @@ const generateClientJs = (
   ignoreSheets?: string[],
   mapSheets?: MapSheetsConfig,
   autoincrement?: AutoincrementConfig,
+  enums?: EnumsConfig,
 ): string => {
   const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
@@ -105,6 +107,7 @@ const generateClientJs = (
   const hasMapSheets = mapSheets && Object.keys(mapSheets).length > 0;
   const hasAutoincrement =
     autoincrement && Object.keys(autoincrement).length > 0;
+  const hasEnums = enums && Object.keys(enums).length > 0;
 
   const defaultsDecl = hasDefaults
     ? `const ${lowerName}Defaults = ${serializeDefaults(defaults)};\n\n`
@@ -134,6 +137,17 @@ const generateClientJs = (
     ? `const ${lowerName}Autoincrement = ${serializeAutoincrement(autoincrement)};\n\n`
     : "";
 
+  const enumDecls = hasEnums
+    ? Object.keys(enums)
+        .map((enumName) => {
+          const entries = enums[enumName]
+            .map((e) => `  ${e.name}: "${e.value}"`)
+            .join(",\n");
+          return `const ${enumName} = {\n${entries}\n};\nexports.${enumName} = ${enumName};\n`;
+        })
+        .join("\n")
+    : "";
+
   const mergeProps = [`relations: ${lowerName}Relations`];
   if (hasDefaults) mergeProps.push(`defaults: ${lowerName}Defaults`);
   if (hasUpdatedAt) mergeProps.push(`updatedAt: ${lowerName}UpdatedAt`);
@@ -157,7 +171,7 @@ ${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}${ignoreSheetsDecl}${mapSh
 }
 
 exports.GassmaClient = GassmaClient;
-`;
+${hasEnums ? "\n" + enumDecls : ""}`;
 };
 
 export { generateClientJs };

--- a/src/generate/read/extractEnums.ts
+++ b/src/generate/read/extractEnums.ts
@@ -1,6 +1,14 @@
-import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import {
+  parsePrismaSchema,
+  findFirstAttribute,
+} from "@loancrate/prisma-schema-parser";
 
-type EnumsConfig = Record<string, string[]>;
+type EnumEntry = {
+  name: string;
+  value: string;
+};
+
+type EnumsConfig = Record<string, EnumEntry[]>;
 
 const extractEnums = (schemaText: string): EnumsConfig => {
   const ast = parsePrismaSchema(schemaText);
@@ -9,15 +17,31 @@ const extractEnums = (schemaText: string): EnumsConfig => {
   ast.declarations.forEach((decl) => {
     if (decl.kind !== "enum") return;
 
-    const values = decl.members
+    const entries = decl.members
       .filter((member) => member.kind === "enumValue")
-      .map((member) => member.name.value);
+      .map((member) => {
+        const name = member.name.value;
+        const mapAttr = findFirstAttribute(member.attributes, "map");
+        if (!mapAttr) return { name, value: name };
 
-    result[decl.name.value] = values;
+        const firstArg = mapAttr.args?.[0];
+        if (!firstArg) return { name, value: name };
+
+        const expr =
+          firstArg.kind === "namedArgument" ? firstArg.expression : firstArg;
+
+        if (expr.kind === "literal" && typeof expr.value === "string") {
+          return { name, value: expr.value };
+        }
+
+        return { name, value: name };
+      });
+
+    result[decl.name.value] = entries;
   });
 
   return result;
 };
 
 export { extractEnums };
-export type { EnumsConfig };
+export type { EnumsConfig, EnumEntry };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -41,9 +41,9 @@ function prismaReader(
           ? `${member.name.value}?`
           : member.name.value;
 
-      const enumValues = enums[typeName];
-      if (enumValues) {
-        fields[fieldName] = enumValues;
+      const enumEntries = enums[typeName];
+      if (enumEntries) {
+        fields[fieldName] = enumEntries.map((e) => e.value);
         return;
       }
 


### PR DESCRIPTION
## 概要
- `EnumsConfig`の型を`string[]`から`{ name: value }[]`に変更し、enum memberの`@map`属性に対応
- `@map("ADMIN")`がある場合、`Role.admin = "ADMIN"`のような定数を生成（nameがキー、@map値がバリュー）
- `prismaReader`でenum型フィールドの型定義にも`@map`値を使用（`"ADMIN" | "USER" | "MODERATOR"`）

## 変更ファイル
- `extractEnums.ts` — `findFirstAttribute`で`@map`値を抽出、`EnumEntry`型追加
- `prismaReader.ts` — `entry.value`を使って型定義のユニオン型を生成
- `generateClientJs.ts` — `EnumEntry`のname/valueでenum定数を生成
- `generateClientDts.ts` — 同上（型宣言側）
- `generate.ts` — `extractEnums`を呼び出しclientJs/clientDtsに渡す
- テストファイル4件 — `@map`付きenumのテストケース追加

## テスト計画
- [x] `extractEnums` — `@map`あり/なし/混在のテスト
- [x] `prismaReader` — `@map`付きenum値が型定義に反映されるテスト
- [x] `generateClientJs` — `@map`付きenum定数生成テスト
- [x] `generateClientDts` — `@map`付きenum型宣言テスト
- [x] 全314テストpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)