### PR TITLE
feat: `gassma version` コマンド追加

### DIFF
--- a/src/__test__/version/getVersion.test.ts
+++ b/src/__test__/version/getVersion.test.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { getVersion } from "../../version/getVersion";
+
+describe("getVersion", () => {
+  it("should return version string from package.json", () => {
+    const version = getVersion();
+
+    expect(typeof version).toBe("string");
+    expect(version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("should match package.json version", () => {
+    const packageJsonPath = path.resolve(__dirname, "../../../package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    const version = getVersion();
+
+    expect(version).toBe(packageJson.version);
+  });
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,12 +1,13 @@
 import { Command } from "commander";
 import { ArgumentError } from "./error/mainError";
 import { generate } from "./generate/generate";
+import { getVersion } from "./version/getVersion";
 
 const program = new Command();
 
 program
   .name("gassma")
-  .version("1.0.0")
+  .version(getVersion())
   .description("A CLI for providing GASsma dynamic types from .prisma files");
 
 program
@@ -14,6 +15,13 @@ program
   .description("Generate type definitions from .prisma files")
   .action((directory) => {
     generate(directory);
+  });
+
+program
+  .command("version")
+  .description("Display the current version of GASsma CLI")
+  .action(() => {
+    console.log(`gassma v${getVersion()}`);
   });
 
 program.parse();

--- a/src/version/getVersion.ts
+++ b/src/version/getVersion.ts
@@ -1,0 +1,10 @@
+import path from "path";
+import fs from "fs";
+
+const getVersion = (): string => {
+  const packageJsonPath = path.resolve(__dirname, "../../package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+  return packageJson.version;
+};
+
+export { getVersion };


### PR DESCRIPTION
## 概要
- `gassma version` サブコマンドを追加（`gassma v0.10.0` を出力）
- `commander` の `.version()` もハードコード `"1.0.0"` から `package.json` の動的読み取りに修正
- `gassma --version` / `gassma -V` も正しいバージョンを返す

## 変更ファイル
- `src/version/getVersion.ts` — 新規。package.json からバージョンを読み取る関数
- `src/command.ts` — `version` サブコマンド追加 + `.version()` 修正
- `src/__test__/version/getVersion.test.ts` — 新規テスト

## テスト計画
- [x] `getVersion` がセマンティックバージョン文字列を返す
- [x] `getVersion` が `package.json` の version と一致する
- [x] 全316テストpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)