### PR TITLE
feat: `gassma validate` コマンド追加

### DIFF
--- a/src/__test__/validate/validate.test.ts
+++ b/src/__test__/validate/validate.test.ts
@@ -1,0 +1,71 @@
+import { validateSchema } from "../../validate/validate";
+
+describe("validateSchema", () => {
+  it("should return valid for a correct schema", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("should return error for invalid syntax", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+
+model User {
+  id   Int    @id
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("should return error when generator output is missing", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ type: "missingOutput" }),
+    );
+  });
+
+  it("should return error when no generator block exists", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ type: "missingGenerator" }),
+    );
+  });
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { ArgumentError } from "./error/mainError";
 import { generate } from "./generate/generate";
+import { validate } from "./validate/validateCommand";
 import { getVersion } from "./version/getVersion";
 
 const program = new Command();
@@ -16,6 +17,14 @@ program
   .option("--schema <path>", "Path to a specific .prisma file to generate")
   .action((options) => {
     generate({ schema: options.schema });
+  });
+
+program
+  .command("validate")
+  .description("Validate .prisma files in the gassma directory")
+  .option("--schema <path>", "Path to a specific .prisma file to validate")
+  .action((options) => {
+    validate({ schema: options.schema });
   });
 
 program

--- a/src/validate/validate.ts
+++ b/src/validate/validate.ts
@@ -1,0 +1,55 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+
+type ValidationError = {
+  type: "syntax" | "missingGenerator" | "missingOutput";
+  message: string;
+};
+
+type ValidationResult = {
+  valid: boolean;
+  errors: ValidationError[];
+};
+
+const validateSchema = (schemaText: string): ValidationResult => {
+  const errors: ValidationError[] = [];
+
+  try {
+    const ast = parsePrismaSchema(schemaText);
+
+    let hasGenerator = false;
+
+    ast.declarations.forEach((decl) => {
+      if (decl.kind !== "generator") return;
+      hasGenerator = true;
+
+      const hasOutput = decl.members.some(
+        (member) => member.kind === "config" && member.name.value === "output",
+      );
+
+      if (!hasOutput) {
+        errors.push({
+          type: "missingOutput",
+          message:
+            'Generator block is missing "output" field. Please specify the output directory.',
+        });
+      }
+    });
+
+    if (!hasGenerator) {
+      errors.push({
+        type: "missingGenerator",
+        message: "No generator block found. A generator block is required.",
+      });
+    }
+  } catch (e) {
+    errors.push({
+      type: "syntax",
+      message: e instanceof Error ? e.message : "Unknown syntax error",
+    });
+  }
+
+  return { valid: errors.length === 0, errors };
+};
+
+export { validateSchema };
+export type { ValidationResult, ValidationError };

--- a/src/validate/validateCommand.ts
+++ b/src/validate/validateCommand.ts
@@ -1,0 +1,68 @@
+import fs from "fs";
+import path from "path";
+import { validateSchema } from "./validate";
+import { parseSchemaPath } from "../generate/parseSchemaPath";
+
+type ValidateOptions = {
+  schema?: string;
+};
+
+function validate(options?: ValidateOptions) {
+  const files = resolveFiles(options);
+
+  let hasError = false;
+
+  files.forEach(({ filePath, displayName }) => {
+    const schemaText = fs.readFileSync(filePath, "utf-8");
+    const result = validateSchema(schemaText);
+
+    if (result.valid) {
+      console.log(`The schema at ${path.resolve(filePath)} is valid 🚀`);
+    } else {
+      hasError = true;
+      console.error(`❌ Validation failed for ${displayName}:`);
+      result.errors.forEach((error) => {
+        console.error(`  - ${error.message}`);
+      });
+    }
+  });
+
+  if (hasError) {
+    process.exit(1);
+  }
+}
+
+function resolveFiles(
+  options?: ValidateOptions,
+): Array<{ filePath: string; displayName: string }> {
+  if (options?.schema) {
+    const { dir, file } = parseSchemaPath(options.schema);
+    const filePath = path.join(dir, file);
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Schema file not found: ${filePath}`);
+    }
+    return [{ filePath, displayName: file }];
+  }
+
+  const gassmaDir = "./gassma";
+  if (!fs.existsSync(gassmaDir)) {
+    throw new Error(
+      `${gassmaDir}/ directory not found. Please create ${gassmaDir}/ directory with .prisma files.`,
+    );
+  }
+
+  const prismaFiles = fs
+    .readdirSync(gassmaDir)
+    .filter((file) => file.endsWith(".prisma"));
+
+  if (prismaFiles.length === 0) {
+    throw new Error(`No .prisma files found in ${gassmaDir}/ directory.`);
+  }
+
+  return prismaFiles.map((file) => ({
+    filePath: path.join(gassmaDir, file),
+    displayName: file,
+  }));
+}
+
+export { validate };


### PR DESCRIPTION
## 概要
- `.prisma`ファイルの構文チェック・整合性チェックを行う`gassma validate`コマンドを追加
- Prismaの`prisma validate`と同等の機能

## チェック項目
- 構文エラー（パーサーエラー検出）
- `generator`ブロックの存在チェック
- `output`フィールドの必須チェック

## 使い方
```bash
gassma validate                              # ./gassma内の全.prismaファイルを検証
gassma validate --schema gassma/test.prisma  # 特定ファイルのみ検証
```

## 成功時の出力
```
The schema at /path/to/gassma/test.prisma is valid 🚀
```

## 変更ファイル
- `src/validate/validate.ts` — スキーマ検証ロジック
- `src/validate/validateCommand.ts` — CLIコマンドハンドラ
- `src/command.ts` — `validate`サブコマンド追加
- `src/__test__/validate/validate.test.ts` — テスト

## テスト計画
- [x] 正常なスキーマ → valid
- [x] 構文エラー → errors
- [x] generator output欠落 → missingOutput
- [x] generatorブロック欠落 → missingGenerator
- [x] 全325テストpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)