### PR TITLE
feat: add `gassma init` command

### DIFF
--- a/src/__test__/init/generateTemplate.test.ts
+++ b/src/__test__/init/generateTemplate.test.ts
@@ -1,0 +1,39 @@
+import { generateTemplate } from "../../init/generateTemplate";
+
+describe("generateTemplate", () => {
+  it("should generate a basic schema template", () => {
+    const result = generateTemplate({});
+
+    expect(result).toContain("generator client");
+    expect(result).toContain('provider = "prisma-client-js"');
+    expect(result).toContain("output");
+  });
+
+  it("should use custom output path", () => {
+    const result = generateTemplate({ output: "./src/generated/db" });
+
+    expect(result).toContain('./src/generated/db"');
+  });
+
+  it("should use default output path when not specified", () => {
+    const result = generateTemplate({});
+
+    expect(result).toContain('./src/generated/gassma"');
+  });
+
+  it("should include User model with --with-model", () => {
+    const result = generateTemplate({ withModel: true });
+
+    expect(result).toContain("model User");
+    expect(result).toContain("id");
+    expect(result).toContain("@id");
+    expect(result).toContain("email");
+    expect(result).toContain("name");
+  });
+
+  it("should not include model without --with-model", () => {
+    const result = generateTemplate({});
+
+    expect(result).not.toContain("model User");
+  });
+});

--- a/src/__test__/init/initCommand.test.ts
+++ b/src/__test__/init/initCommand.test.ts
@@ -1,0 +1,68 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { init } from "../../init/initCommand";
+
+describe("init", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-init-"));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should create gassma directory and schema.prisma", () => {
+    init();
+
+    const schemaPath = path.join(tmpDir, "gassma", "schema.prisma");
+    expect(fs.existsSync(schemaPath)).toBe(true);
+
+    const content = fs.readFileSync(schemaPath, "utf-8");
+    expect(content).toContain("generator client");
+    expect(content).toContain('output   = "./src/generated/gassma"');
+  });
+
+  it("should throw if schema.prisma already exists", () => {
+    const gassmaDir = path.join(tmpDir, "gassma");
+    fs.mkdirSync(gassmaDir, { recursive: true });
+    fs.writeFileSync(path.join(gassmaDir, "schema.prisma"), "existing");
+
+    expect(() => init()).toThrow("already exists");
+  });
+
+  it("should pass output option to template", () => {
+    init({ output: "./custom/output" });
+
+    const content = fs.readFileSync(
+      path.join(tmpDir, "gassma", "schema.prisma"),
+      "utf-8",
+    );
+    expect(content).toContain('./custom/output"');
+  });
+
+  it("should include model with withModel option", () => {
+    init({ withModel: true });
+
+    const content = fs.readFileSync(
+      path.join(tmpDir, "gassma", "schema.prisma"),
+      "utf-8",
+    );
+    expect(content).toContain("model User");
+  });
+
+  it("should not recreate existing gassma directory", () => {
+    const gassmaDir = path.join(tmpDir, "gassma");
+    fs.mkdirSync(gassmaDir, { recursive: true });
+
+    init();
+
+    expect(fs.existsSync(path.join(gassmaDir, "schema.prisma"))).toBe(true);
+  });
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { ArgumentError } from "./error/mainError";
 import { generate } from "./generate/generate";
+import { init } from "./init/initCommand";
 import { validate } from "./validate/validateCommand";
 import { getVersion } from "./version/getVersion";
 
@@ -25,6 +26,15 @@ program
   .option("--schema <path>", "Path to a specific .prisma file to validate")
   .action((options) => {
     validate({ schema: options.schema });
+  });
+
+program
+  .command("init")
+  .description("Initialize a new GASsma project with a schema.prisma file")
+  .option("--output <path>", "Custom output path for generated files")
+  .option("--with-model", "Include a sample User model in the schema")
+  .action((options) => {
+    init({ output: options.output, withModel: options.withModel });
   });
 
 program

--- a/src/init/generateTemplate.ts
+++ b/src/init/generateTemplate.ts
@@ -1,0 +1,29 @@
+type TemplateOptions = {
+  output?: string;
+  withModel?: boolean;
+};
+
+const generateTemplate = (options: TemplateOptions): string => {
+  const output = options.output ?? "./src/generated/gassma";
+
+  let template = `generator client {
+  provider = "prisma-client-js"
+  output   = "${output}"
+}
+`;
+
+  if (options.withModel) {
+    template += `
+model User {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String
+}
+`;
+  }
+
+  return template;
+};
+
+export { generateTemplate };
+export type { TemplateOptions };

--- a/src/init/initCommand.ts
+++ b/src/init/initCommand.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+import { generateTemplate } from "./generateTemplate";
+
+type InitOptions = {
+  output?: string;
+  withModel?: boolean;
+};
+
+function init(options?: InitOptions) {
+  const gassmaDir = "./gassma";
+  const schemaPath = path.join(gassmaDir, "schema.prisma");
+
+  if (fs.existsSync(schemaPath)) {
+    throw new Error(
+      `${schemaPath} already exists. To reinitialize, remove it first.`,
+    );
+  }
+
+  if (!fs.existsSync(gassmaDir)) {
+    fs.mkdirSync(gassmaDir, { recursive: true });
+    console.log(`📁 Created ${gassmaDir}/ directory`);
+  }
+
+  const template = generateTemplate({
+    output: options?.output,
+    withModel: options?.withModel,
+  });
+
+  fs.writeFileSync(schemaPath, template, "utf-8");
+  console.log(`📄 Created ${schemaPath}`);
+  console.log(
+    "\n✅ GASsma initialized. Edit gassma/schema.prisma to define your models.",
+  );
+}
+
+export { init };


### PR DESCRIPTION
## 概要
- `gassma init` コマンドを追加。`gassma/schema.prisma` を自動生成してプロジェクトを初期化する
- `--output <path>` オプションで生成先パスをカスタマイズ可能
- `--with-model` オプションでサンプル User モデルを含むスキーマを生成可能
- 既存の `schema.prisma` がある場合はエラーで安全に停止

## テスト
- `generateTemplate` テスト 5件
- `initCommand` テスト 5件（ファイル生成、重複チェック、オプション反映）
- 全335テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)