### PR TITLE
feat: add `gassma.config.ts` support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@loancrate/prisma-schema-parser": "^3.0.0",
         "@prisma/internals": "^7.5.0",
         "@types/node": "^22.10.2",
-        "commander": "^12.1.0"
+        "commander": "^12.1.0",
+        "jiti": "^2.6.1"
       },
       "bin": {
         "gassma": "bin/index.js"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,16 @@
   "bin": {
     "gassma": "bin/index.js"
   },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts"
+    },
+    "./config": {
+      "types": "./dist/config/defineConfig.d.ts",
+      "require": "./dist/config/defineConfig.js",
+      "import": "./dist/config/defineConfig.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "test": "jest",
@@ -21,7 +31,8 @@
     "@loancrate/prisma-schema-parser": "^3.0.0",
     "@prisma/internals": "^7.5.0",
     "@types/node": "^22.10.2",
-    "commander": "^12.1.0"
+    "commander": "^12.1.0",
+    "jiti": "^2.6.1"
   },
   "keywords": [
     "Google Apps Script",

--- a/src/__test__/config/defineConfig.test.ts
+++ b/src/__test__/config/defineConfig.test.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "../../config/defineConfig";
+
+describe("defineConfig", () => {
+  it("should return the config object as-is", () => {
+    const config = defineConfig({ schema: "gassma/schema.prisma" });
+    expect(config).toEqual({ schema: "gassma/schema.prisma" });
+  });
+
+  it("should work without schema", () => {
+    const config = defineConfig({});
+    expect(config).toEqual({});
+  });
+});

--- a/src/__test__/config/loadConfig.test.ts
+++ b/src/__test__/config/loadConfig.test.ts
@@ -1,0 +1,60 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { loadConfig } from "../../config/loadConfig";
+
+describe("loadConfig", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-config-"));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should return undefined when no gassma.config.ts exists", () => {
+    const config = loadConfig();
+    expect(config).toBeUndefined();
+  });
+
+  it("should load schema from gassma.config.ts", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma.config.ts"),
+      `export default { schema: "gassma/test.prisma" };`,
+    );
+
+    const config = loadConfig();
+    expect(config).toEqual({ schema: "gassma/test.prisma" });
+  });
+
+  it("should load config with defineConfig", () => {
+    const defineConfigPath = path.resolve(
+      __dirname,
+      "../../config/defineConfig",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma.config.ts"),
+      `import { defineConfig } from "${defineConfigPath}";
+export default defineConfig({ schema: "gassma/schema.prisma" });`,
+    );
+
+    const config = loadConfig();
+    expect(config).toEqual({ schema: "gassma/schema.prisma" });
+  });
+
+  it("should return config without schema when schema is not specified", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma.config.ts"),
+      `export default {};`,
+    );
+
+    const config = loadConfig();
+    expect(config).toEqual({});
+  });
+});

--- a/src/__test__/config/resolveSchemaFiles.test.ts
+++ b/src/__test__/config/resolveSchemaFiles.test.ts
@@ -1,0 +1,104 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { resolveSchemaFiles } from "../../config/resolveSchemaFiles";
+
+describe("resolveSchemaFiles", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-resolve-"));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("--schema option (highest priority)", () => {
+    it("should resolve from --schema option", () => {
+      const dir = path.join(tmpDir, "gassma");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "test.prisma"), "content");
+
+      const files = resolveSchemaFiles({ schema: "gassma/test.prisma" });
+      expect(files).toHaveLength(1);
+      expect(files[0].displayName).toBe("test.prisma");
+    });
+
+    it("should throw if --schema file not found", () => {
+      expect(() =>
+        resolveSchemaFiles({ schema: "gassma/notfound.prisma" }),
+      ).toThrow("Schema file not found");
+    });
+  });
+
+  describe("gassma.config.ts (second priority)", () => {
+    it("should resolve from gassma.config.ts schema path", () => {
+      const dir = path.join(tmpDir, "custom");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "schema.prisma"), "content");
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma.config.ts"),
+        `export default { schema: "custom/schema.prisma" };`,
+      );
+
+      const files = resolveSchemaFiles({});
+      expect(files).toHaveLength(1);
+      expect(files[0].filePath).toBe(path.join("custom", "schema.prisma"));
+    });
+
+    it("should resolve directory from gassma.config.ts", () => {
+      const dir = path.join(tmpDir, "custom");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "a.prisma"), "content");
+      fs.writeFileSync(path.join(dir, "b.prisma"), "content");
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma.config.ts"),
+        `export default { schema: "custom" };`,
+      );
+
+      const files = resolveSchemaFiles({});
+      expect(files).toHaveLength(2);
+    });
+
+    it("--schema should override gassma.config.ts", () => {
+      const dir = path.join(tmpDir, "gassma");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "override.prisma"), "content");
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma.config.ts"),
+        `export default { schema: "other/schema.prisma" };`,
+      );
+
+      const files = resolveSchemaFiles({ schema: "gassma/override.prisma" });
+      expect(files).toHaveLength(1);
+      expect(files[0].displayName).toBe("override.prisma");
+    });
+  });
+
+  describe("default ./gassma directory (lowest priority)", () => {
+    it("should resolve from default gassma/ directory", () => {
+      const dir = path.join(tmpDir, "gassma");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "schema.prisma"), "content");
+
+      const files = resolveSchemaFiles({});
+      expect(files).toHaveLength(1);
+    });
+
+    it("should throw if gassma/ directory not found", () => {
+      expect(() => resolveSchemaFiles({})).toThrow("directory not found");
+    });
+
+    it("should throw if no .prisma files found", () => {
+      const dir = path.join(tmpDir, "gassma");
+      fs.mkdirSync(dir, { recursive: true });
+
+      expect(() => resolveSchemaFiles({})).toThrow("No .prisma files found");
+    });
+  });
+});

--- a/src/__test__/init/generateConfigTemplate.test.ts
+++ b/src/__test__/init/generateConfigTemplate.test.ts
@@ -1,0 +1,17 @@
+import { generateConfigTemplate } from "../../init/generateConfigTemplate";
+
+describe("generateConfigTemplate", () => {
+  it("should generate config with default schema path", () => {
+    const result = generateConfigTemplate({});
+    expect(result).toContain('import { defineConfig } from "gassma/config"');
+    expect(result).toContain('schema: "gassma/schema.prisma"');
+    expect(result).toContain("export default defineConfig");
+  });
+
+  it("should use custom schema path", () => {
+    const result = generateConfigTemplate({
+      schemaPath: "custom/my.prisma",
+    });
+    expect(result).toContain('schema: "custom/my.prisma"');
+  });
+});

--- a/src/__test__/init/initCommand.test.ts
+++ b/src/__test__/init/initCommand.test.ts
@@ -65,4 +65,24 @@ describe("init", () => {
 
     expect(fs.existsSync(path.join(gassmaDir, "schema.prisma"))).toBe(true);
   });
+
+  it("should create gassma.config.ts", () => {
+    init();
+
+    const configPath = path.join(tmpDir, "gassma.config.ts");
+    expect(fs.existsSync(configPath)).toBe(true);
+
+    const content = fs.readFileSync(configPath, "utf-8");
+    expect(content).toContain("defineConfig");
+    expect(content).toContain('schema: "gassma/schema.prisma"');
+  });
+
+  it("should not overwrite existing gassma.config.ts", () => {
+    const configPath = path.join(tmpDir, "gassma.config.ts");
+    fs.writeFileSync(configPath, "existing config");
+
+    init();
+
+    expect(fs.readFileSync(configPath, "utf-8")).toBe("existing config");
+  });
 });

--- a/src/config/defineConfig.ts
+++ b/src/config/defineConfig.ts
@@ -1,0 +1,10 @@
+type GassmaConfig = {
+  schema?: string;
+};
+
+const defineConfig = (config: GassmaConfig): GassmaConfig => {
+  return config;
+};
+
+export { defineConfig };
+export type { GassmaConfig };

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+import { createJiti } from "jiti";
+import type { GassmaConfig } from "./defineConfig";
+
+const CONFIG_FILE_NAME = "gassma.config.ts";
+
+const loadConfig = (): GassmaConfig | undefined => {
+  const configPath = path.resolve(process.cwd(), CONFIG_FILE_NAME);
+
+  if (!fs.existsSync(configPath)) {
+    return undefined;
+  }
+
+  const jiti = createJiti(configPath);
+  const mod = jiti(configPath);
+  const config = (mod.default ?? mod) as GassmaConfig;
+
+  return config;
+};
+
+export { loadConfig };

--- a/src/config/resolveSchemaFiles.ts
+++ b/src/config/resolveSchemaFiles.ts
@@ -1,0 +1,75 @@
+import fs from "fs";
+import path from "path";
+import { parseSchemaPath } from "../generate/parseSchemaPath";
+import { loadConfig } from "./loadConfig";
+
+type SchemaOptions = {
+  schema?: string;
+};
+
+type SchemaFile = {
+  filePath: string;
+  displayName: string;
+};
+
+const resolveSchemaFiles = (options: SchemaOptions): SchemaFile[] => {
+  if (options.schema) {
+    return resolveFromSchemaOption(options.schema);
+  }
+
+  const config = loadConfig();
+  if (config?.schema) {
+    return resolveFromConfigSchema(config.schema);
+  }
+
+  return resolveFromDefaultDir();
+};
+
+const resolveFromSchemaOption = (schema: string): SchemaFile[] => {
+  const { dir, file } = parseSchemaPath(schema);
+  const filePath = path.join(dir, file);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Schema file not found: ${filePath}`);
+  }
+  return [{ filePath, displayName: file }];
+};
+
+const resolveFromConfigSchema = (schema: string): SchemaFile[] => {
+  if (schema.endsWith(".prisma")) {
+    const filePath = schema;
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Schema file not found: ${filePath}`);
+    }
+    return [{ filePath, displayName: path.basename(filePath) }];
+  }
+
+  return resolveFromDir(schema);
+};
+
+const resolveFromDefaultDir = (): SchemaFile[] => {
+  return resolveFromDir("./gassma");
+};
+
+const resolveFromDir = (dir: string): SchemaFile[] => {
+  if (!fs.existsSync(dir)) {
+    throw new Error(
+      `${dir}/ directory not found. Please create ${dir}/ directory with .prisma files.`,
+    );
+  }
+
+  const prismaFiles = fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith(".prisma"));
+
+  if (prismaFiles.length === 0) {
+    throw new Error(`No .prisma files found in ${dir}/ directory.`);
+  }
+
+  return prismaFiles.map((file) => ({
+    filePath: path.join(dir, file),
+    displayName: file,
+  }));
+};
+
+export { resolveSchemaFiles };
+export type { SchemaFile };

--- a/src/format/formatCommand.ts
+++ b/src/format/formatCommand.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { formatSchema } from "@prisma/internals";
-import { parseSchemaPath } from "../generate/parseSchemaPath";
+import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
 
 type FormatOptions = {
   schema?: string;
@@ -9,7 +9,7 @@ type FormatOptions = {
 };
 
 async function format(options?: FormatOptions): Promise<boolean> {
-  const files = resolveFiles(options);
+  const files = resolveSchemaFiles({ schema: options?.schema });
   const schemas: [string, string][] = files.map(({ filePath }) => [
     path.basename(filePath),
     fs.readFileSync(filePath, "utf-8"),
@@ -30,39 +30,6 @@ async function format(options?: FormatOptions): Promise<boolean> {
   });
 
   return true;
-}
-
-function resolveFiles(
-  options?: FormatOptions,
-): Array<{ filePath: string; displayName: string }> {
-  if (options?.schema) {
-    const { dir, file } = parseSchemaPath(options.schema);
-    const filePath = path.join(dir, file);
-    if (!fs.existsSync(filePath)) {
-      throw new Error(`Schema file not found: ${filePath}`);
-    }
-    return [{ filePath, displayName: file }];
-  }
-
-  const gassmaDir = "./gassma";
-  if (!fs.existsSync(gassmaDir)) {
-    throw new Error(
-      `${gassmaDir}/ directory not found. Please create ${gassmaDir}/ directory with .prisma files.`,
-    );
-  }
-
-  const prismaFiles = fs
-    .readdirSync(gassmaDir)
-    .filter((file) => file.endsWith(".prisma"));
-
-  if (prismaFiles.length === 0) {
-    throw new Error(`No .prisma files found in ${gassmaDir}/ directory.`);
-  }
-
-  return prismaFiles.map((file) => ({
-    filePath: path.join(gassmaDir, file),
-    displayName: file,
-  }));
 }
 
 export { format };

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -14,7 +14,7 @@ import { extractMap } from "./read/extractMap";
 import { extractMapSheets } from "./read/extractMapSheets";
 import { extractEnums } from "./read/extractEnums";
 import { prismaReader } from "./read/prismaReader";
-import { parseSchemaPath } from "./parseSchemaPath";
+import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
 import { writer } from "./writer";
 import { jsWriter } from "./jsWriter";
 
@@ -23,28 +23,10 @@ type GenerateOptions = {
 };
 
 function generate(options?: GenerateOptions) {
-  if (options?.schema) {
-    const { dir, file } = parseSchemaPath(options.schema);
-    return generateFromFiles(dir, [file]);
-  }
-
-  const gassmaDir = "./gassma";
-
-  if (!fs.existsSync(gassmaDir))
-    throw new Error(
-      `${gassmaDir}/ directory not found. Please create ${gassmaDir}/ directory with .prisma files.`,
-    );
-
-  const prismaFiles = fs
-    .readdirSync(gassmaDir)
-    .filter((file) => file.endsWith(".prisma"));
-
-  if (prismaFiles.length === 0)
-    throw new Error(
-      `No .prisma files found in ${gassmaDir}/ directory. Please create at least one .prisma file.`,
-    );
-
-  generateFromFiles(gassmaDir, prismaFiles);
+  const files = resolveSchemaFiles({ schema: options?.schema });
+  const dir = path.dirname(files[0].filePath);
+  const fileNames = files.map((f) => f.displayName);
+  generateFromFiles(dir, fileNames);
 }
 
 function generateFromFiles(gassmaDir: string, prismaFiles: string[]) {

--- a/src/init/generateConfigTemplate.ts
+++ b/src/init/generateConfigTemplate.ts
@@ -1,0 +1,17 @@
+type ConfigTemplateOptions = {
+  schemaPath?: string;
+};
+
+const generateConfigTemplate = (options: ConfigTemplateOptions): string => {
+  const schemaPath = options.schemaPath ?? "gassma/schema.prisma";
+
+  return `import { defineConfig } from "gassma/config";
+
+export default defineConfig({
+  schema: "${schemaPath}",
+});
+`;
+};
+
+export { generateConfigTemplate };
+export type { ConfigTemplateOptions };

--- a/src/init/initCommand.ts
+++ b/src/init/initCommand.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { generateTemplate } from "./generateTemplate";
+import { generateConfigTemplate } from "./generateConfigTemplate";
 
 type InitOptions = {
   output?: string;
@@ -10,6 +11,7 @@ type InitOptions = {
 function init(options?: InitOptions) {
   const gassmaDir = "./gassma";
   const schemaPath = path.join(gassmaDir, "schema.prisma");
+  const configPath = "./gassma.config.ts";
 
   if (fs.existsSync(schemaPath)) {
     throw new Error(
@@ -29,6 +31,15 @@ function init(options?: InitOptions) {
 
   fs.writeFileSync(schemaPath, template, "utf-8");
   console.log(`📄 Created ${schemaPath}`);
+
+  if (!fs.existsSync(configPath)) {
+    const configTemplate = generateConfigTemplate({
+      schemaPath: "gassma/schema.prisma",
+    });
+    fs.writeFileSync(configPath, configTemplate, "utf-8");
+    console.log(`📄 Created ${configPath}`);
+  }
+
   console.log(
     "\n✅ GASsma initialized. Edit gassma/schema.prisma to define your models.",
   );

--- a/src/validate/validateCommand.ts
+++ b/src/validate/validateCommand.ts
@@ -1,14 +1,14 @@
 import fs from "fs";
 import path from "path";
 import { validateSchema } from "./validate";
-import { parseSchemaPath } from "../generate/parseSchemaPath";
+import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
 
 type ValidateOptions = {
   schema?: string;
 };
 
 function validate(options?: ValidateOptions) {
-  const files = resolveFiles(options);
+  const files = resolveSchemaFiles({ schema: options?.schema });
 
   let hasError = false;
 
@@ -30,39 +30,6 @@ function validate(options?: ValidateOptions) {
   if (hasError) {
     process.exit(1);
   }
-}
-
-function resolveFiles(
-  options?: ValidateOptions,
-): Array<{ filePath: string; displayName: string }> {
-  if (options?.schema) {
-    const { dir, file } = parseSchemaPath(options.schema);
-    const filePath = path.join(dir, file);
-    if (!fs.existsSync(filePath)) {
-      throw new Error(`Schema file not found: ${filePath}`);
-    }
-    return [{ filePath, displayName: file }];
-  }
-
-  const gassmaDir = "./gassma";
-  if (!fs.existsSync(gassmaDir)) {
-    throw new Error(
-      `${gassmaDir}/ directory not found. Please create ${gassmaDir}/ directory with .prisma files.`,
-    );
-  }
-
-  const prismaFiles = fs
-    .readdirSync(gassmaDir)
-    .filter((file) => file.endsWith(".prisma"));
-
-  if (prismaFiles.length === 0) {
-    throw new Error(`No .prisma files found in ${gassmaDir}/ directory.`);
-  }
-
-  return prismaFiles.map((file) => ({
-    filePath: path.join(gassmaDir, file),
-    displayName: file,
-  }));
 }
 
 export { validate };


### PR DESCRIPTION
## 概要
- `gassma.config.ts` による設定ファイルサポートを追加（Prisma v7 の `prisma.config.ts` に相当）
- `defineConfig()` 関数を `gassma/config` エントリポイントから提供
- `gassma init` で `gassma.config.ts` も自動生成
- スキーマ解決の優先順位: `--schema` > `gassma.config.ts` > デフォルト `./gassma`
- `validate` / `format` / `generate` の重複した `resolveFiles` を `resolveSchemaFiles` に統合

## 設定例
```ts
import { defineConfig } from "gassma/config";

export default defineConfig({
  schema: "gassma/schema.prisma",
});
```

## テスト
- `defineConfig` テスト 2件
- `loadConfig` テスト 4件
- `resolveSchemaFiles` テスト 8件
- `generateConfigTemplate` テスト 2件
- `initCommand` テスト 7件（config.ts 生成含む）
- 全360テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)