### PR TITLE
feat: add datasource.url, multi-file schema fix, and --watch option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gassma",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "GASsma is Google Apps Script(GAS) of SpreadSheet library that can be used like prisma.",
   "types": "index.d.ts",
   "bin": {

--- a/src/__test__/config/defineConfig.test.ts
+++ b/src/__test__/config/defineConfig.test.ts
@@ -10,4 +10,13 @@ describe("defineConfig", () => {
     const config = defineConfig({});
     expect(config).toEqual({});
   });
+
+  it("should accept datasource url", () => {
+    const config = defineConfig({
+      datasource: { url: "https://docs.google.com/spreadsheets/d/abc123" },
+    });
+    expect(config.datasource?.url).toBe(
+      "https://docs.google.com/spreadsheets/d/abc123",
+    );
+  });
 });

--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -487,4 +487,30 @@ describe("generateClientJs", () => {
 
     expect(result).not.toContain("exports.Role");
   });
+
+  it("should embed datasource url as id in constructor", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "https://docs.google.com/spreadsheets/d/abc123",
+    );
+
+    expect(result).toContain(
+      'id: "https://docs.google.com/spreadsheets/d/abc123"',
+    );
+  });
+
+  it("should not embed id when datasource url is undefined", () => {
+    const result = generateClientJs({}, "Test");
+
+    expect(result).not.toContain("id:");
+  });
 });

--- a/src/__test__/generate/watchGenerate.test.ts
+++ b/src/__test__/generate/watchGenerate.test.ts
@@ -1,0 +1,125 @@
+import fs from "fs";
+import path from "path";
+import { watchGenerate } from "../../generate/watchGenerate";
+
+jest.mock("fs");
+jest.mock("../../generate/generate", () => ({
+  generate: jest.fn(),
+}));
+jest.mock("../../config/resolveSchemaFiles", () => ({
+  resolveSchemaFiles: jest.fn(),
+}));
+
+const mockFs = jest.mocked(fs);
+
+import { generate } from "../../generate/generate";
+import { resolveSchemaFiles } from "../../config/resolveSchemaFiles";
+
+const mockGenerate = jest.mocked(generate);
+const mockResolveSchemaFiles = jest.mocked(resolveSchemaFiles);
+
+describe("watchGenerate", () => {
+  let mockWatcher: { close: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation();
+    mockWatcher = { close: jest.fn() };
+    mockFs.watch.mockReturnValue(mockWatcher as unknown as fs.FSWatcher);
+    mockResolveSchemaFiles.mockReturnValue([
+      { filePath: "gassma/schema.prisma", displayName: "schema.prisma" },
+    ]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should run generate once on start", () => {
+    watchGenerate();
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pass schema option to generate and resolveSchemaFiles", () => {
+    watchGenerate({ schema: "custom/path.prisma" });
+    expect(mockGenerate).toHaveBeenCalledWith({ schema: "custom/path.prisma" });
+    expect(mockResolveSchemaFiles).toHaveBeenCalledWith({
+      schema: "custom/path.prisma",
+    });
+  });
+
+  it("should watch the directory of schema files", () => {
+    mockResolveSchemaFiles.mockReturnValue([
+      { filePath: "gassma/schema.prisma", displayName: "schema.prisma" },
+    ]);
+    watchGenerate();
+    expect(mockFs.watch).toHaveBeenCalledWith("gassma", expect.any(Function));
+  });
+
+  it("should re-generate when a .prisma file changes", () => {
+    watchGenerate();
+    mockGenerate.mockClear();
+
+    const watchCallback = mockFs.watch.mock.calls[0][1] as (
+      event: string,
+      filename: string | null,
+    ) => void;
+    watchCallback("change", "schema.prisma");
+
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not re-generate when a non-.prisma file changes", () => {
+    watchGenerate();
+    mockGenerate.mockClear();
+
+    const watchCallback = mockFs.watch.mock.calls[0][1] as (
+      event: string,
+      filename: string | null,
+    ) => void;
+    watchCallback("change", "readme.md");
+
+    expect(mockGenerate).toHaveBeenCalledTimes(0);
+  });
+
+  it("should not re-generate when filename is null", () => {
+    watchGenerate();
+    mockGenerate.mockClear();
+
+    const watchCallback = mockFs.watch.mock.calls[0][1] as (
+      event: string,
+      filename: string | null,
+    ) => void;
+    watchCallback("change", null);
+
+    expect(mockGenerate).toHaveBeenCalledTimes(0);
+  });
+
+  it("should return a close function that stops the watcher", () => {
+    const close = watchGenerate();
+    close();
+    expect(mockWatcher.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("should watch multiple directories when schema files are in different dirs", () => {
+    mockResolveSchemaFiles.mockReturnValue([
+      { filePath: "gassma/schema.prisma", displayName: "schema.prisma" },
+      { filePath: "gassma/models/user.prisma", displayName: "user.prisma" },
+    ]);
+    watchGenerate();
+    expect(mockFs.watch).toHaveBeenCalledWith("gassma", expect.any(Function));
+    expect(mockFs.watch).toHaveBeenCalledWith(
+      path.join("gassma", "models"),
+      expect.any(Function),
+    );
+  });
+
+  it("should not duplicate watchers for the same directory", () => {
+    mockResolveSchemaFiles.mockReturnValue([
+      { filePath: "gassma/schema.prisma", displayName: "schema.prisma" },
+      { filePath: "gassma/base.prisma", displayName: "base.prisma" },
+    ]);
+    watchGenerate();
+    expect(mockFs.watch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__test__/init/generateConfigTemplate.test.ts
+++ b/src/__test__/init/generateConfigTemplate.test.ts
@@ -14,4 +14,10 @@ describe("generateConfigTemplate", () => {
     });
     expect(result).toContain('schema: "custom/my.prisma"');
   });
+
+  it("should include empty datasource url", () => {
+    const result = generateConfigTemplate({});
+    expect(result).toContain('url: ""');
+    expect(result).toContain("datasource:");
+  });
 });

--- a/src/command.ts
+++ b/src/command.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { ArgumentError } from "./error/mainError";
 import { format } from "./format/formatCommand";
 import { generate } from "./generate/generate";
+import { watchGenerate } from "./generate/watchGenerate";
 import { init } from "./init/initCommand";
 import { validate } from "./validate/validateCommand";
 import { getVersion } from "./version/getVersion";
@@ -17,8 +18,13 @@ program
   .command("generate")
   .description("Generate type definitions from .prisma files")
   .option("--schema <path>", "Path to a specific .prisma file to generate")
+  .option("--watch", "Watch for changes and regenerate automatically")
   .action((options) => {
-    generate({ schema: options.schema });
+    if (options.watch) {
+      watchGenerate({ schema: options.schema });
+    } else {
+      generate({ schema: options.schema });
+    }
   });
 
 program

--- a/src/config/defineConfig.ts
+++ b/src/config/defineConfig.ts
@@ -1,5 +1,8 @@
 type GassmaConfig = {
   schema?: string;
+  datasource?: {
+    url?: string;
+  };
 };
 
 const defineConfig = (config: GassmaConfig): GassmaConfig => {

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -15,6 +15,7 @@ import { extractMapSheets } from "./read/extractMapSheets";
 import { extractEnums } from "./read/extractEnums";
 import { prismaReader } from "./read/prismaReader";
 import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
+import { loadConfig } from "../config/loadConfig";
 import { writer } from "./writer";
 import { jsWriter } from "./jsWriter";
 
@@ -26,7 +27,9 @@ function generate(options?: GenerateOptions) {
   const files = resolveSchemaFiles({ schema: options?.schema });
   const dir = path.dirname(files[0].filePath);
   const fileNames = files.map((f) => f.displayName);
-  generateFromFiles(dir, fileNames);
+  const config = loadConfig();
+  const datasourceUrl = config?.datasource?.url;
+  generateFromFiles(dir, fileNames, datasourceUrl);
 }
 
 function findOutputPath(gassmaDir: string, prismaFiles: string[]): string {
@@ -42,7 +45,11 @@ function findOutputPath(gassmaDir: string, prismaFiles: string[]): string {
   );
 }
 
-function generateFromFiles(gassmaDir: string, prismaFiles: string[]) {
+function generateFromFiles(
+  gassmaDir: string,
+  prismaFiles: string[],
+  datasourceUrl?: string,
+) {
   console.log(
     `📁 Found ${prismaFiles.length} .prisma file(s) in ${path.basename(gassmaDir)} directory`,
   );
@@ -93,6 +100,7 @@ function generateFromFiles(gassmaDir: string, prismaFiles: string[]) {
       mapSheets,
       autoincrement,
       enums,
+      datasourceUrl,
     );
     jsWriter(clientJs, `${baseName}Client`, outputPath);
     const clientDts = generateClientDts(schemaName, enums);

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -29,11 +29,25 @@ function generate(options?: GenerateOptions) {
   generateFromFiles(dir, fileNames);
 }
 
+function findOutputPath(gassmaDir: string, prismaFiles: string[]): string {
+  for (let i = 0; i < prismaFiles.length; i++) {
+    const filePath = path.join(gassmaDir, prismaFiles[i]);
+    const schemaText = fs.readFileSync(filePath, "utf-8");
+    const outputPath = extractOutputPath(schemaText);
+    if (outputPath) return outputPath;
+  }
+  throw new Error(
+    "No output path found in any .prisma file. Please add 'output' to the generator block.\n" +
+      'Example:\n  generator client {\n    provider = "prisma-client-js"\n    output   = "./generated/gassma"\n  }',
+  );
+}
+
 function generateFromFiles(gassmaDir: string, prismaFiles: string[]) {
   console.log(
     `📁 Found ${prismaFiles.length} .prisma file(s) in ${path.basename(gassmaDir)} directory`,
   );
 
+  const sharedOutputPath = findOutputPath(gassmaDir, prismaFiles);
   const commonWritten = new Set<string>();
 
   prismaFiles.forEach((file) => {
@@ -42,12 +56,7 @@ function generateFromFiles(gassmaDir: string, prismaFiles: string[]) {
 
     const schemaText = fs.readFileSync(filePath, "utf-8");
 
-    const outputPath = extractOutputPath(schemaText);
-    if (!outputPath)
-      throw new Error(
-        `No output path found in ${file}. Please add 'output' to the generator block.\n` +
-          `Example:\n  generator client {\n    provider = "prisma-client-js"\n    output   = "./generated/gassma"\n  }`,
-      );
+    const outputPath = extractOutputPath(schemaText) ?? sharedOutputPath;
 
     const parsed = prismaReader(schemaText);
     const relations = extractRelations(schemaText);

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -92,6 +92,7 @@ const generateClientJs = (
   mapSheets?: MapSheetsConfig,
   autoincrement?: AutoincrementConfig,
   enums?: EnumsConfig,
+  datasourceUrl?: string,
 ): string => {
   const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
@@ -148,7 +149,9 @@ const generateClientJs = (
         .join("\n")
     : "";
 
-  const mergeProps = [`relations: ${lowerName}Relations`];
+  const mergeProps: string[] = [];
+  if (datasourceUrl) mergeProps.push(`id: "${datasourceUrl}"`);
+  mergeProps.push(`relations: ${lowerName}Relations`);
   if (hasDefaults) mergeProps.push(`defaults: ${lowerName}Defaults`);
   if (hasUpdatedAt) mergeProps.push(`updatedAt: ${lowerName}UpdatedAt`);
   if (hasIgnore) mergeProps.push(`ignore: ${lowerName}Ignore`);

--- a/src/generate/watchGenerate.ts
+++ b/src/generate/watchGenerate.ts
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+import { generate } from "./generate";
+import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
+import type { GenerateOptions } from "./generate";
+
+const watchGenerate = (options?: GenerateOptions): (() => void) => {
+  generate(options);
+
+  const files = resolveSchemaFiles({ schema: options?.schema });
+  const dirs = [...new Set(files.map((f) => path.dirname(f.filePath)))];
+
+  console.log(`\n👀 Watching ${dirs.join(", ")} for changes...`);
+
+  const watchers = dirs.map((dir) =>
+    fs.watch(dir, (_event: string, filename: string | null) => {
+      if (!filename || !filename.endsWith(".prisma")) return;
+      console.log(`\n🔄 Detected change in ${filename}, regenerating...`);
+      generate(options);
+    }),
+  );
+
+  return () => {
+    watchers.forEach((w) => w.close());
+  };
+};
+
+export { watchGenerate };

--- a/src/init/generateConfigTemplate.ts
+++ b/src/init/generateConfigTemplate.ts
@@ -9,6 +9,9 @@ const generateConfigTemplate = (options: ConfigTemplateOptions): string => {
 
 export default defineConfig({
   schema: "${schemaPath}",
+  datasource: {
+    url: "",
+  },
 });
 `;
 };


### PR DESCRIPTION
## 概要
- `gassma.config.ts` に `datasource.url` を追加。スプレッドシートURLを設定可能に
- `gassma generate` 時に URL が生成クライアントの `id` に自動埋め込みされ、`new GassmaClient()` だけで接続可能に
- multi-file schema で generator ブロックが別ファイルにある場合の output 共有を修正
- `gassma generate --watch` でスキーマファイル変更時に自動再生成する機能を追加
- バージョンを 0.11.0 に更新

## --watch 機能
- `fs.watch` でスキーマディレクトリを監視
- `.prisma` ファイルの変更時のみ再生成
- `--schema` オプションとの併用対応
- 複数ディレクトリの監視対応

## テスト
- `generateClientJs` に datasource url 埋め込みテスト 2件追加
- `defineConfig` に datasource テスト 1件追加
- `generateConfigTemplate` に datasource テスト 1件追加
- `watchGenerate` テスト 9件追加
- 全373テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)