### PR TITLE
feat: env()ヘルパーとGassmaConfig型export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export type { GassmaConfig } from "./dist/config/defineConfig";

--- a/src/__test__/config/env.test.ts
+++ b/src/__test__/config/env.test.ts
@@ -1,0 +1,32 @@
+import { env } from "../../config/env";
+
+describe("env", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return the value of an existing environment variable", () => {
+    process.env.TEST_URL = "https://example.com";
+    expect(env("TEST_URL")).toBe("https://example.com");
+  });
+
+  it("should throw if the environment variable is not set", () => {
+    delete process.env.MISSING_VAR;
+    expect(() => env("MISSING_VAR")).toThrow(
+      'Environment variable "MISSING_VAR" is not set',
+    );
+  });
+
+  it("should throw if the environment variable is empty string", () => {
+    process.env.EMPTY_VAR = "";
+    expect(() => env("EMPTY_VAR")).toThrow(
+      'Environment variable "EMPTY_VAR" is not set',
+    );
+  });
+});

--- a/src/config/defineConfig.ts
+++ b/src/config/defineConfig.ts
@@ -10,4 +10,5 @@ const defineConfig = (config: GassmaConfig): GassmaConfig => {
 };
 
 export { defineConfig };
+export { env } from "./env";
 export type { GassmaConfig };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,9 @@
+const env = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable "${name}" is not set`);
+  }
+  return value;
+};
+
+export { env };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,7 +53,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
## Summary
- `env()` ヘルパー関数を追加（Prismaの `prisma.config.ts` の `env()` 相当）
- `gassma/config` から `env` を re-export
- ルート `index.d.ts` から `GassmaConfig` 型を export（`import type { GassmaConfig } from "gassma"` が可能に）
- `tsconfig.json` で `declaration: true` を有効化（`.d.ts` 生成）

## 使用例

```typescript
// gassma.config.ts (Prisma風)
import "dotenv/config";
import type { GassmaConfig } from "gassma";
import { env } from "gassma/config";

export default {
  schema: "gassma",
  datasource: {
    url: env("SPREADSHEET_URL"),
  },
} satisfies GassmaConfig;
```

## Test plan
- [x] env(): 環境変数取得、未設定時throw、空文字時throw
- [x] 全395テスト通過
- [x] gassma-testで `env("SPREADSHEET_URL")` 経由の generate 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)