### PR TITLE
feat: CountData/AggregateDataの型生成にcursorを追加

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaAggregateData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaAggregateData.test.ts
@@ -1,0 +1,17 @@
+import { getOneGassmaAggregateData } from "../../../generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData";
+
+describe("getOneGassmaAggregateData", () => {
+  it("should generate AggregateData type with cursor property", () => {
+    const result = getOneGassmaAggregateData("", "User");
+
+    expect(result).toContain("export type GassmaUserAggregateData");
+    expect(result).toContain("cursor?: Partial<GassmaUserUse>;");
+  });
+
+  it("should generate AggregateData type with schema name", () => {
+    const result = getOneGassmaAggregateData("App", "User");
+
+    expect(result).toContain("export type GassmaAppUserAggregateData");
+    expect(result).toContain("cursor?: Partial<GassmaAppUserUse>;");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaCountData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCountData.test.ts
@@ -1,0 +1,17 @@
+import { getOneGassmaCountData } from "../../../generate/typeGenerate/gassmaCountData/oneGassmaCountData";
+
+describe("getOneGassmaCountData", () => {
+  it("should generate CountData type with cursor property", () => {
+    const result = getOneGassmaCountData("", "User");
+
+    expect(result).toContain("export type GassmaUserCountData");
+    expect(result).toContain("cursor?: Partial<GassmaUserUse>;");
+  });
+
+  it("should generate CountData type with schema name", () => {
+    const result = getOneGassmaCountData("App", "User");
+
+    expect(result).toContain("export type GassmaAppUserCountData");
+    expect(result).toContain("cursor?: Partial<GassmaAppUserUse>;");
+  });
+});

--- a/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
+++ b/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
@@ -5,6 +5,7 @@ export type Gassma${schemaName}${sheetName}AggregateData = {
   orderBy?: Gassma${schemaName}${sheetName}OrderBy;
   take?: number;
   skip?: number;
+  cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
   _avg?: Gassma${schemaName}${sheetName}Select;
   _count?: Gassma${schemaName}${sheetName}Select;
   _max?: Gassma${schemaName}${sheetName}Select;

--- a/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
+++ b/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
@@ -5,6 +5,7 @@ export type Gassma${schemaName}${sheetName}CountData = {
   orderBy?: Gassma${schemaName}${sheetName}OrderBy;
   take?: number;
   skip?: number;
+  cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
 };
 `;
 };


### PR DESCRIPTION
## 概要
- gassma本体のcursorサポートに合わせて、CLI型生成にも `cursor` プロパティを追加

## 変更内容
- `oneGassmaCountData.ts`: `cursor?: Partial<...Use>` を生成に追加
- `oneGassmaAggregateData.ts`: 同上
- テスト4件追加（CountData 2件 + AggregateData 2件）

## テスト計画
- [x] CountData に cursor が生成されること
- [x] AggregateData に cursor が生成されること
- [x] スキーマ名付きで正しく生成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)