### PR TITLE
chore: update .npmignore for npm publish and bump to v1.0.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,13 +1,23 @@
+# IDE・Editor
+.vscode/
 .claude/
-.vscode/*
+.mcp.json
+
+# CI・Git hooks
 .github/
-node_modules/
+.husky/
+
+# Source code, Dev tools
 src/
 devTypes/
 gassma/
+LLM/
+coverage/
 
-package-lock.json
-.gitignore
+# Setting
 tsconfig.json
 biome.json
-.mcp.json
+jest.config.ts
+.gitignore
+package-lock.json
+CLAUDE.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 akahoshi1421
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gassma",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "description": "GASsma is Google Apps Script(GAS) of SpreadSheet library that can be used like prisma.",
   "types": "index.d.ts",
   "bin": {


### PR DESCRIPTION
## Summary
- `.npmignore` を整理し、npm publishに不要なファイル（`LLM/`, `coverage/`, `jest.config.ts`, `.husky/`, `CLAUDE.md`）を除外対象に追加
- バージョンを `0.11.0` → `1.0.0` に更新

## Test plan
- [x] `npm pack --dry-run` で含まれるファイルが `dist/`, `bin/`, `index.d.ts`, `package.json`, `README.md` のみであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)