### PR TITLE
refactor: remove sheets property and use interface merging

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -13,10 +13,13 @@ describe("generateClientDts", () => {
     expect(result).toContain("options?: GassmaHogeClientOptions");
   });
 
-  it("should have readonly sheets property with schema-specific type", () => {
+  it("should have interface merging with schema-specific Sheet type", () => {
     const result = generateClientDts("Hoge");
 
-    expect(result).toContain("readonly sheets: GassmaHogeSheet");
+    expect(result).toContain(
+      "export interface GassmaClient<O extends GassmaHogeGlobalOmitConfig = {}> extends GassmaHogeSheet<O>",
+    );
+    expect(result).not.toContain("readonly sheets");
   });
 
   it("should work with different schema names", () => {
@@ -24,7 +27,9 @@ describe("generateClientDts", () => {
 
     expect(result).toContain("export declare class GassmaClient");
     expect(result).toContain("options?: GassmaFugaClientOptions");
-    expect(result).toContain("readonly sheets: GassmaFugaSheet");
+    expect(result).toContain(
+      "export interface GassmaClient<O extends GassmaFugaGlobalOmitConfig = {}> extends GassmaFugaSheet<O>",
+    );
   });
 
   it("should export enum constants and types", () => {

--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -9,7 +9,7 @@ describe("getGassmaMain", () => {
     expect(result).toContain(
       "class GassmaClient<T extends keyof GassmaClientMap>",
     );
-    expect(result).toContain('GassmaClientMap[T]["sheets"]');
+    expect(result).not.toContain('GassmaClientMap[T]["sheets"]');
     expect(result).toContain('GassmaClientMap[T]["options"]');
   });
 
@@ -17,7 +17,7 @@ describe("getGassmaMain", () => {
     const result = getGassmaMain(["User", "Post"], "Test");
 
     expect(result).toContain('"Test": {');
-    expect(result).toContain("sheets: GassmaTestSheet");
+    expect(result).not.toContain("sheets: GassmaTestSheet");
     expect(result).toContain("options: GassmaTestClientOptions");
   });
 

--- a/src/__test__/typecheck/typecheck.test.ts
+++ b/src/__test__/typecheck/typecheck.test.ts
@@ -109,7 +109,7 @@ import { GassmaClient } from "./client";
 
 // グローバルomitなし: 全フィールドアクセス可能
 declare const client: GassmaClient;
-const r1 = client.sheets.User.findFirst({ where: { id: 1 } });
+const r1 = client.User.findFirst({ where: { id: 1 } });
 if (r1) {
   const email: string = r1.email;
   const name: string | null = r1.name;
@@ -117,7 +117,7 @@ if (r1) {
 
 // グローバルomitあり: email が返り値から除外される
 declare const clientOmit: GassmaClient<{ User: { email: true } }>;
-const r2 = clientOmit.sheets.User.findFirst({ where: { id: 1 } });
+const r2 = clientOmit.User.findFirst({ where: { id: 1 } });
 if (r2) {
   const name: string | null = r2.name;
   // @ts-expect-error email はグローバルomitで除外
@@ -125,19 +125,19 @@ if (r2) {
 }
 
 // omit: { email: false } でグローバルomitを解除
-const r3 = clientOmit.sheets.User.findFirst({ where: { id: 1 }, omit: { email: false } });
+const r3 = clientOmit.User.findFirst({ where: { id: 1 }, omit: { email: false } });
 if (r3) {
   const email: string = r3.email;
 }
 
 // select はグローバルomitを上書き
-const r4 = clientOmit.sheets.User.findFirst({ where: { id: 1 }, select: { email: true } });
+const r4 = clientOmit.User.findFirst({ where: { id: 1 }, select: { email: true } });
 if (r4) {
   const email: string = r4.email;
 }
 
 // クエリomitも返り値に反映
-const r5 = client.sheets.User.findFirst({ where: { id: 1 }, omit: { name: true } });
+const r5 = client.User.findFirst({ where: { id: 1 }, omit: { name: true } });
 if (r5) {
   const email: string = r5.email;
   // @ts-expect-error name はクエリomitで除外
@@ -145,7 +145,7 @@ if (r5) {
 }
 
 // findMany でも同様
-const r6 = clientOmit.sheets.User.findMany({ where: {} });
+const r6 = clientOmit.User.findMany({ where: {} });
 // @ts-expect-error email はグローバルomitで除外
 r6[0]?.email;
 `;

--- a/src/generate/jsGenerate/generateClientDts.ts
+++ b/src/generate/jsGenerate/generateClientDts.ts
@@ -1,9 +1,9 @@
 import type { EnumsConfig } from "../read/extractEnums";
 
 const generateClientDts = (schemaName: string, enums?: EnumsConfig): string => {
-  let result = `export declare class GassmaClient<O extends Gassma${schemaName}GlobalOmitConfig = {}> {
+  let result = `export interface GassmaClient<O extends Gassma${schemaName}GlobalOmitConfig = {}> extends Gassma${schemaName}Sheet<O> {}
+export declare class GassmaClient<O extends Gassma${schemaName}GlobalOmitConfig = {}> {
   constructor(options?: Gassma${schemaName}ClientOptions<O>);
-  readonly sheets: Gassma${schemaName}Sheet<O>;
 }
 `;
 

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -169,7 +169,7 @@ ${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}${ignoreSheetsDecl}${mapSh
   constructor(options) {
     const mergedOptions = ${mergeExpr};
     const client = new Gassma.GassmaClient(mergedOptions);
-    this.sheets = client.sheets;
+    Object.assign(this, client);
   }
 }
 

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -47,7 +47,6 @@ ${commonTypes}
 
   class GassmaClient<T extends keyof GassmaClientMap> {
     constructor(idOrOptions?: string | GassmaClientMap[T]["options"]);
-    readonly sheets: GassmaClientMap[T]["sheets"];
   }
 
   class FieldRef {
@@ -76,7 +75,6 @@ const getGassmaSchemaClient = (
   const clientMapEntry = `export namespace Gassma {
   interface GassmaClientMap {
     "${schemaName}": {
-      sheets: Gassma${schemaName}Sheet;
       options: Gassma${schemaName}ClientOptions;
       globalOmitConfig: Gassma${schemaName}GlobalOmitConfig;
     };


### PR DESCRIPTION
## Summary
- 生成コードで`readonly sheets`プロパティを廃止し、interface mergingで直接アクセスに変更
- 生成JS: `this.sheets = client.sheets` → `Object.assign(this, client)`
- 生成DTS: `export interface GassmaClient<O> extends GassmaSheet<O> {}` で型をマージ
- base `Gassma.GassmaClient`からも`sheets`参照を削除

## Test plan
- [x] 全66テストスイート（411テスト）通過
- [x] tscビルド成功
- [x] typecheckテスト（tsc --noEmit）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)