### PR TITLE
docs: proofread README and add Japanese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GASsma-cli
 
+[日本語](docs/README.ja.md) | English
+
 GASsma-cli is a CLI tool for [GASsma](https://github.com/akahoshi1421/gassma).
 
 It generates type files and client JS files for GASsma from `.prisma` files, similar to Prisma CLI.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,144 @@
 # GASsma-cli
+
+GASsma-cli is a CLI tool for [GASsma](https://github.com/akahoshi1421/gassma).
+
+It generates type files and client JS files for GASsma from `.prisma` files, similar to Prisma CLI.
+
+Without GASsma-cli, you need to manually write GASsma-specific configurations such as relations, default values, and other definitions. With GASsma-cli, you get almost the same development experience as Prisma by using `.prisma` files.
+
+## Usage
+
+1. Install GASsma-cli
+
+```sh
+npm i gassma
+```
+
+2. Execute init command
+
+```sh
+npx gassma init
+```
+
+It will generate `schema.prisma` and `gassma.config.ts` after executing the above command.
+
+3. Write database definition and config
+
+Example...
+
+```prisma
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+  name  String
+  email String?
+  age   Int
+  profile Profile?
+}
+
+model Profile {
+  id      Int     @id @default(autoincrement())
+  bio     String?
+  website String?
+  userId  Int     @id
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+}
+```
+
+```ts
+import { defineConfig } from "gassma/config";
+
+export default defineConfig({
+  schema: "gassma/schema.prisma",
+  datasource: {
+    url: "", // If you operate a spreadsheet that is not bound to GAS, enter the spreadsheet URL here.
+  },
+});
+```
+
+[NOTE] GASsma-cli also has `format` and `validate` commands, similar to Prisma.
+
+4. Execute generating command
+
+```sh
+npx gassma generate
+```
+
+`schemaClient.js` and `schemaClient.d.ts` will be generated.
+
+5. Development
+
+You can develop with GASsma just like Prisma by importing the generated client file (`schemaClient.js`), which includes database relations and other definitions.
+
+```ts
+import { GassmaClient } from "../generated/gassma2/schemaClient";
+
+const gassma = new GassmaClient();
+
+function myFunction() {
+  const result = gassma.User.findMany({
+    where: {
+      id: { gte: 10 }
+    }
+  });
+
+  console.log(result);
+}
+```
+
+## CLI commands reference
+
+### init
+
+Generate schema file and `gassma.config.ts` file.
+
+#### options
+
+|name|description|
+|--|--|
+|`--output <path>`|Custom output path for generated files|
+|`--with-model`|Include a sample User model in the schema|
+
+### generate
+
+Generate type definition files and a client JS file with relation settings, autoincrement, default values, and more from .prisma files.
+
+#### options
+
+|name|description|
+|--|--|
+|`--schema <path>`|Path to a specific .prisma file to generate|
+|`--watch`|Watch for changes and regenerate automatically|
+
+### format
+
+Format .prisma files.
+
+#### options
+
+|name|description|
+|--|--|
+|`--schema <path>`|Path to a specific .prisma file to format|
+|`--check`|Check if files are formatted without modifying them|
+
+### validate
+
+Validate .prisma files.
+
+#### options
+
+|name|description|
+|--|--|
+|`--schema <path>`|Path to a specific .prisma file to validate|
+
+## Detail reference
+
+https://akahoshi1421.github.io/gassma-reference/docs/reference/type-generation/
+
+## License
+
+MIT

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,0 +1,146 @@
+# GASsma-cli
+
+日本語 | [English](../README.md)
+
+GASsma-cli は [GASsma](https://github.com/akahoshi1421/gassma) 用の CLI ツールです。
+
+Prisma CLI と同様に、`.prisma` ファイルから GASsma 用の型定義ファイルとクライアント JS ファイルを生成します。
+
+GASsma-cli を使わない場合、リレーションやデフォルト値などの設定を手動で記述する必要があります。GASsma-cli を使えば、`.prisma` ファイルを利用することで Prisma とほぼ同じ開発体験が得られます。
+
+## 使い方
+
+1. GASsma-cli をインストール
+
+```sh
+npm i gassma
+```
+
+2. init コマンドを実行
+
+```sh
+npx gassma init
+```
+
+上記コマンドを実行すると、`schema.prisma` と `gassma.config.ts` が生成されます。
+
+3. データベース定義と設定を記述
+
+例...
+
+```prisma
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+  name  String
+  email String?
+  age   Int
+  profile Profile?
+}
+
+model Profile {
+  id      Int     @id @default(autoincrement())
+  bio     String?
+  website String?
+  userId  Int     @id
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+}
+```
+
+```ts
+import { defineConfig } from "gassma/config";
+
+export default defineConfig({
+  schema: "gassma/schema.prisma",
+  datasource: {
+    url: "", // GAS に結びついていないスプレッドシートを操作する場合は、スプレッドシートの URL を記入してください。
+  },
+});
+```
+
+[NOTE] GASsma-cli には Prisma と同様に `format` と `validate` コマンドもあります。
+
+4. 生成コマンドを実行
+
+```sh
+npx gassma generate
+```
+
+`schemaClient.js` と `schemaClient.d.ts` が生成されます。
+
+5. 開発
+
+生成されたクライアントファイル（`schemaClient.js`）をインポートすることで、データベースのリレーションやその他の定義が組み込まれた状態で、Prisma と同じように GASsma で開発できます。
+
+```ts
+import { GassmaClient } from "../generated/gassma2/schemaClient";
+
+const gassma = new GassmaClient();
+
+function myFunction() {
+  const result = gassma.User.findMany({
+    where: {
+      id: { gte: 10 }
+    }
+  });
+
+  console.log(result);
+}
+```
+
+## CLI コマンドリファレンス
+
+### init
+
+スキーマファイルと `gassma.config.ts` ファイルを生成します。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--output <path>`|生成ファイルのカスタム出力先パス|
+|`--with-model`|サンプルの User モデルをスキーマに含める|
+
+### generate
+
+`.prisma` ファイルから型定義ファイルと、リレーション設定・autoincrement・デフォルト値などが組み込まれたクライアント JS ファイルを生成します。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--schema <path>`|生成対象の `.prisma` ファイルのパス|
+|`--watch`|変更を監視して自動的に再生成|
+
+### format
+
+`.prisma` ファイルをフォーマットします。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--schema <path>`|フォーマット対象の `.prisma` ファイルのパス|
+|`--check`|ファイルを変更せずにフォーマット済みかチェック|
+
+### validate
+
+`.prisma` ファイルをバリデーションします。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--schema <path>`|バリデーション対象の `.prisma` ファイルのパス|
+
+## 詳細リファレンス
+
+https://akahoshi1421.github.io/gassma-reference/docs/reference/type-generation/
+
+## ライセンス
+
+MIT


### PR DESCRIPTION
## 概要

- README.md の文法修正・校閲
- 日本語版 README（`docs/README.ja.md`）を追加

## 変更内容

### README.md 校閲
- 冠詞・前置詞の修正（`is cli tool` → `is a CLI tool` 等）
- 不自然な文の書き直し（L7, L78 等）
- コメント文の改善（スプレッドシートURL設定の説明）

### docs/README.ja.md 新規作成
- README.md の日本語訳
- gassma 本体と同じく `日本語 | English` のリンク付き