### PR TITLE
refactor: organize types tests into read/ subdirectory

### DIFF
--- a/src/__test__/types/read/include.test-d.ts
+++ b/src/__test__/types/read/include.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from "vitest";
-import type { GassmaClient } from "./__generated__/client";
+import type { GassmaClient } from "../__generated__/client";
 
 declare const client: GassmaClient;
 

--- a/src/__test__/types/read/omit.test-d.ts
+++ b/src/__test__/types/read/omit.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from "vitest";
-import type { GassmaClient } from "./__generated__/client";
+import type { GassmaClient } from "../__generated__/client";
 
 declare const client: GassmaClient;
 declare const clientOmit: GassmaClient<{ User: { email: true } }>;


### PR DESCRIPTION
## Summary

gassma-test の `test/<category>/`（read/, create/, update/, ...）構造に倣い、`src/__test__/types/` 配下のテストを **CRUD カテゴリ別ディレクトリ**に整理する土台を作る。

## 変更

- `src/__test__/types/include.test-d.ts` → `src/__test__/types/read/include.test-d.ts`
- `src/__test__/types/omit.test-d.ts` → `src/__test__/types/read/omit.test-d.ts`
- 各ファイルの `./__generated__/client` import を `../__generated__/client` に追従

## 整理後の構造

```
src/__test__/types/
├── __generated__/    ← 共有資産（gitignore）
├── fixtures/         ← 共有 fixture
└── read/             ← find 系の結果型
    ├── include.test-d.ts
    └── omit.test-d.ts
```

将来追加予定:
- `write/`（Phase 1b #18: create/update/delete の include 反映）
- `aggregate/`（Phase 2b）

`vitest.config.ts` の `typecheck.include`（`**/*.test-d.ts`）は再帰するため設定変更不要。

## Test plan
- [x] `npm run test:types`: 414 + Type Errors なし
- [x] `npm run typecheck`: OK
- [x] `npm run lint`: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>