### PR TITLE
feat: reflect include in write methods (Phase 1b #18)

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -36,13 +36,13 @@ describe("getOneGassmaController", () => {
 
   it("should have generic delete method with model-specific type", () => {
     expect(result).toContain(
-      'delete<T extends GassmaUserDeleteSingleData>(deleteData: T): GassmaUserFindResult<T["select"], undefined, T["omit"], GO> | null',
+      'delete<T extends GassmaUserDeleteSingleData>(deleteData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO> | null',
     );
   });
 
   it("should have generic upsert method with model-specific type", () => {
     expect(result).toContain(
-      'upsert<T extends GassmaUserUpsertSingleData>(upsertData: T): GassmaUserFindResult<T["select"], undefined, T["omit"], GO>',
+      'upsert<T extends GassmaUserUpsertSingleData>(upsertData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO>',
     );
   });
 
@@ -70,13 +70,13 @@ describe("getOneGassmaController", () => {
 
   it("should have generic create method with FindResult return", () => {
     expect(result).toContain(
-      'create<T extends GassmaUserCreateData>(createdData: T): GassmaUserFindResult<T["select"], undefined, T["omit"], GO>',
+      'create<T extends GassmaUserCreateData>(createdData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO>',
     );
   });
 
   it("should have generic update method with model-specific type", () => {
     expect(result).toContain(
-      'update<T extends GassmaUserUpdateSingleData>(updateData: T): GassmaUserFindResult<T["select"], undefined, T["omit"], GO> | null',
+      'update<T extends GassmaUserUpdateSingleData>(updateData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO> | null',
     );
   });
 

--- a/src/__test__/types/write/create.test-d.ts
+++ b/src/__test__/types/write/create.test-d.ts
@@ -1,0 +1,11 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+const u = client.User.create({
+  data: { email: "x@example.com", score: 0 },
+  include: { posts: true },
+});
+expectTypeOf<(typeof u)["posts"]>().toBeArray();
+expectTypeOf<(typeof u)["posts"][number]["title"]>().toEqualTypeOf<string>();

--- a/src/__test__/types/write/createManyAndReturn.test-d.ts
+++ b/src/__test__/types/write/createManyAndReturn.test-d.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+const us = client.User.createManyAndReturn({
+  data: [{ email: "x@example.com", score: 0 }],
+  include: { posts: true },
+});
+expectTypeOf<(typeof us)[number]["posts"]>().toBeArray();
+expectTypeOf<
+  (typeof us)[number]["posts"][number]["title"]
+>().toEqualTypeOf<string>();

--- a/src/__test__/types/write/delete.test-d.ts
+++ b/src/__test__/types/write/delete.test-d.ts
@@ -1,0 +1,12 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+const u = client.User.delete({
+  where: { id: 1 },
+  include: { posts: true },
+});
+type U = NonNullable<typeof u>;
+expectTypeOf<U["posts"]>().toBeArray();
+expectTypeOf<U["posts"][number]["title"]>().toEqualTypeOf<string>();

--- a/src/__test__/types/write/update.test-d.ts
+++ b/src/__test__/types/write/update.test-d.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+const u = client.User.update({
+  where: { id: 1 },
+  data: { name: "y" },
+  include: { posts: true },
+});
+type U = NonNullable<typeof u>;
+expectTypeOf<U["posts"]>().toBeArray();
+expectTypeOf<U["posts"][number]["title"]>().toEqualTypeOf<string>();

--- a/src/__test__/types/write/upsert.test-d.ts
+++ b/src/__test__/types/write/upsert.test-d.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+const u = client.User.upsert({
+  where: { id: 1 },
+  create: { email: "x@example.com", score: 0 },
+  update: { name: "y" },
+  include: { posts: true },
+});
+expectTypeOf<(typeof u)["posts"]>().toBeArray();
+expectTypeOf<(typeof u)["posts"][number]["title"]>().toEqualTypeOf<string>();

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -11,16 +11,16 @@ export declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma
     endColumnNumber: number
   ): void;
   createMany(createdData: Gassma${schemaName}${sheetName}CreateManyData): CreateManyReturn;
-  createManyAndReturn<T extends Gassma${schemaName}${sheetName}CreateManyAndReturnData>(createdData: T): ${fr}<T["select"], undefined, T["omit"], GO>[];
-  create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): ${fr}<T["select"], undefined, T["omit"], GO>;
+  createManyAndReturn<T extends Gassma${schemaName}${sheetName}CreateManyAndReturnData>(createdData: T): ${fr}<T["select"], T["include"], T["omit"], GO>[];
+  create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): ${fr}<T["select"], T["include"], T["omit"], GO>;
   findFirst<T extends Gassma${schemaName}${sheetName}FindFirstData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO> | null;
   findFirstOrThrow<T extends Gassma${schemaName}${sheetName}FindFirstData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO>;
   findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO>[];
-  update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): ${fr}<T["select"], undefined, T["omit"], GO> | null;
+  update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): ${fr}<T["select"], T["include"], T["omit"], GO> | null;
   updateMany(updateData: Gassma${schemaName}${sheetName}UpdateData): UpdateManyReturn;
   updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): Gassma${schemaName}${sheetName}DefaultFindResult[];
-  upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): ${fr}<T["select"], undefined, T["omit"], GO>;
-  delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): ${fr}<T["select"], undefined, T["omit"], GO> | null;
+  upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): ${fr}<T["select"], T["include"], T["omit"], GO>;
+  delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): ${fr}<T["select"], T["include"], T["omit"], GO> | null;
   deleteMany(deleteData: Gassma${schemaName}${sheetName}DeleteData): DeleteManyReturn;
   aggregate<T extends Gassma${schemaName}${sheetName}AggregateData>(aggregateData: T): Gassma${schemaName}${sheetName}AggregateResult<T>;
   count(coutData: Gassma${schemaName}${sheetName}CountData): number;


### PR DESCRIPTION
## Summary

型テスト戦略 **Phase 1b の #18**。書き込み系メソッドの結果型に include を反映し、find 系と揃える。これで Phase 1 完了。

## 変更

### controller の型引数（5メソッド）
- `create` / `createManyAndReturn` / `update` / `upsert` / `delete` で **`<T["select"], undefined, T["omit"], GO>` → `<T["select"], T["include"], T["omit"], GO>`**
- 各書き込み系 Data 型（CreateData / UpdateSingleData / etc）は既に `include?` を持っていたため、controller のみの変更で完結

### 型テスト
- `src/__test__/types/write/` に 5 メソッド分の `.test-d.ts` を追加
  - `create.test-d.ts`
  - `createManyAndReturn.test-d.ts`
  - `update.test-d.ts`（戻り値 `| null` を NonNullable で剥がす）
  - `upsert.test-d.ts`
  - `delete.test-d.ts`（戻り値 `| null`）
- 各テストは include で含めたリレーション（`posts`）が **配列として結果型に出る**ことを expectTypeOf で検証

### 文字列マッチテスト追従
- `gassmaController.test.ts` の `undefined` を `T["include"]` に一括追従

## Test plan
- [x] `npm run test:types`: 74 ファイル 414 テスト + Type Errors なし
- [x] `npm run typecheck`: OK
- [x] `npm run lint`: 210 ファイル エラー0
- [x] `npm run build`: tsup OK

## Phase 1 完了

これで Phase 0（jest→vitest）/ Phase 1a（include 基本形）/ Phase 1b（ネスト・write 系の include 反映）が揃いました。残るのは Phase 2（型テストカバレッジ拡大）と Phase 3（gassma-test の as 除去）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>