### PR TITLE
test: add unit tests for Phase 2b aggregation/groupBy types

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaAggregateBaseReturn.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaAggregateBaseReturn.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaAggregateBaseReturn } from "../../../generate/typeGenerate/gassmaAggregateBaseReturn/oneGassmaAggregateBaseReturn";
+
+describe("getOneGassmaAggregateBaseReturn", () => {
+  it("should emit AggregateBaseReturn declaration", () => {
+    const result = getOneGassmaAggregateBaseReturn({}, "", "User");
+    expect(result).toContain("export type GassmaUserAggregateBaseReturn = {");
+  });
+
+  it("should include numeric columns with aggregate type", () => {
+    const result = getOneGassmaAggregateBaseReturn(
+      { price: [1, 2, 3] },
+      "",
+      "Product",
+    );
+    expect(result).toContain('"price":');
+  });
+
+  it("should preserve special type hints (string/Date/boolean) as aggregate type", () => {
+    const result = getOneGassmaAggregateBaseReturn(
+      { when: ["Date", "Date"] },
+      "",
+      "User",
+    );
+    expect(result).toContain('"when": Date');
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaAggregateBaseReturn({}, "Test", "User");
+    expect(result).toContain("export type GassmaTestUserAggregateBaseReturn");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaAggregateResult.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaAggregateResult.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaAggregateResult } from "../../../generate/typeGenerate/gassmaAggregateResult/oneGassmaAggregateResult";
+
+describe("getOneGassmaAggregateResult", () => {
+  it("should declare AggregateResult with T extends AggregateData", () => {
+    const result = getOneGassmaAggregateResult("", "User");
+    expect(result).toContain(
+      "export type GassmaUserAggregateResult<T extends GassmaUserAggregateData>",
+    );
+  });
+
+  it("should filter keys by _avg/_count/_max/_min/_sum", () => {
+    const result = getOneGassmaAggregateResult("", "User");
+    expect(result).toContain(
+      'K extends "_avg" | "_count" | "_max" | "_min" | "_sum"',
+    );
+  });
+
+  it("should resolve each key via AggregateField<T[K], K>", () => {
+    const result = getOneGassmaAggregateResult("", "User");
+    expect(result).toContain("GassmaUserAggregateField<T[K], K>");
+  });
+
+  it("should map undefined to never", () => {
+    const result = getOneGassmaAggregateResult("", "User");
+    expect(result).toContain("T[K] extends undefined");
+    expect(result).toContain("? never");
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaAggregateResult("Test", "User");
+    expect(result).toContain("export type GassmaTestUserAggregateResult");
+    expect(result).toContain("GassmaTestUserAggregateField");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaGroupByBaseReturn.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaGroupByBaseReturn.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaGroupByBaseReturn } from "../../../generate/typeGenerate/gassmaGroupByBaseReturn/oneGassmaGroupByBaseReturn";
+
+describe("getOneGassmaGroupByBaseReturn", () => {
+  it("should emit alias of CreateReturn", () => {
+    const result = getOneGassmaGroupByBaseReturn("", "User");
+    expect(result).toContain(
+      "export type GassmaUserGroupByBaseReturn = GassmaUserCreateReturn;",
+    );
+  });
+
+  it("should prepend schemaName to both sides", () => {
+    const result = getOneGassmaGroupByBaseReturn("Test", "User");
+    expect(result).toContain(
+      "export type GassmaTestUserGroupByBaseReturn = GassmaTestUserCreateReturn;",
+    );
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaGroupByData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaGroupByData.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaGroupByData } from "../../../generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData";
+
+describe("getOneGassmaGroupByData", () => {
+  it("should extend AggregateData with by + having", () => {
+    const result = getOneGassmaGroupByData(
+      { id: [1], name: ["a"] },
+      "",
+      "User",
+    );
+    expect(result).toContain(
+      "export type GassmaUserGroupByData = GassmaUserAggregateData & {",
+    );
+    expect(result).toContain("by:");
+    expect(result).toContain("having?: GassmaUserHavingUse;");
+  });
+
+  it("should include all column names as by union", () => {
+    const result = getOneGassmaGroupByData(
+      { id: [1], name: ["a"] },
+      "",
+      "User",
+    );
+    expect(result).toContain('"id"');
+    expect(result).toContain('"name"');
+  });
+
+  it("should strip trailing ? from column names", () => {
+    const result = getOneGassmaGroupByData({ "name?": ["a"] }, "", "User");
+    expect(result).toContain('"name"');
+    expect(result).not.toContain('"name?"');
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaGroupByData({ id: [1] }, "Test", "User");
+    expect(result).toContain("export type GassmaTestUserGroupByData");
+    expect(result).toContain("GassmaTestUserAggregateData");
+    expect(result).toContain("GassmaTestUserHavingUse");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaGroupByKeyOfBaseReturn.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaGroupByKeyOfBaseReturn.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaGroupByKeyOfBaseReturn } from "../../../generate/typeGenerate/gassmaGroupByKeyOfBaseReturn/oneGassmaGroupByKeyOfBaseReturn";
+
+describe("getOneGassmaGroupByKeyOfBaseReturn", () => {
+  it("should emit keyof GroupByBaseReturn alias", () => {
+    const result = getOneGassmaGroupByKeyOfBaseReturn("", "User");
+    expect(result).toContain(
+      "export type GassmaUserGroupByKeyOfBaseReturn = keyof GassmaUserGroupByBaseReturn;",
+    );
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaGroupByKeyOfBaseReturn("Test", "User");
+    expect(result).toContain(
+      "export type GassmaTestUserGroupByKeyOfBaseReturn = keyof GassmaTestUserGroupByBaseReturn;",
+    );
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaGroupByResult.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaGroupByResult.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaGroupByResult } from "../../../generate/typeGenerate/gassmaGroupByResult/oneGassmaGroupByResult";
+
+describe("getOneGassmaGroupByResult", () => {
+  it("should declare GroupByResult with T extends GroupByData", () => {
+    const result = getOneGassmaGroupByResult("", "User");
+    expect(result).toContain(
+      "export type GassmaUserGroupByResult<T extends GassmaUserGroupByData>",
+    );
+  });
+
+  it("should intersect ByField<T['by']> with aggregate keys mapping", () => {
+    const result = getOneGassmaGroupByResult("", "User");
+    expect(result).toContain('GassmaUserByField<T["by"]>');
+    expect(result).toContain(
+      'K extends "_avg" | "_count" | "_max" | "_min" | "_sum"',
+    );
+  });
+
+  it("should resolve each key via AggregateField<T[K], K>", () => {
+    const result = getOneGassmaGroupByResult("", "User");
+    expect(result).toContain("GassmaUserAggregateField<T[K], K>");
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaGroupByResult("Test", "User");
+    expect(result).toContain("export type GassmaTestUserGroupByResult");
+    expect(result).toContain("GassmaTestUserByField");
+  });
+});


### PR DESCRIPTION
## Summary

型テスト戦略 **Phase 2b**。集計・グループ化6関数の単体テストを追加（**回帰防止**）。

## 追加テスト（21 it）

| ファイル | 検証内容 |
|---------|---------|
| `gassmaAggregateBaseReturn` | 宣言、数値列の集計型、特殊型ヒント（Date）保持、schemaName |
| `gassmaAggregateResult` | `<T extends AggregateData>` シグネチャ、`_avg/_count/_max/_min/_sum` フィルタ、`AggregateField<T[K], K>` 解決、`undefined→never`、schemaName |
| `gassmaGroupByData` | `AggregateData & {by, having?}` 拡張、by の union、`?` 除去、schemaName |
| `gassmaGroupByBaseReturn` | `CreateReturn` エイリアス、schemaName |
| `gassmaGroupByKeyOfBaseReturn` | `keyof GroupByBaseReturn` エイリアス、schemaName |
| `gassmaGroupByResult` | `<T extends GroupByData> = ByField<T["by"]> &` 集計マッピング、schemaName |

## Test plan
- [x] `npm run test:types`: 83 ファイル 451 テスト + Type Errors なし（前回 77/430 → +6/+21）
- [x] `npm run typecheck`: OK
- [x] `npm run lint`: 219 ファイル エラー0
- [x] `npm run build`: tsup OK

## 残タスク
- **Phase 2c**: 補助型10関数（AggregateField / Select / Omit / FindManyData / CreateMany / DeleteData / ByField / HavingCore / HavingUse / ManyCount / AnyUse）
- **Phase 3**: gassma-test の `as` 段階除去（Phase 1 の成果を活かす回帰テスト化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>