### PR TITLE
test: add unit tests for Phase 2c auxiliary types (Phase 2 complete)

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaAggregateField.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaAggregateField.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaAggregateField } from "../../../generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField";
+
+describe("getOneGassmaAggregateField", () => {
+  it("should declare AggregateField with T and K extends string parameters", () => {
+    const result = getOneGassmaAggregateField("", "User");
+    expect(result).toContain(
+      "export type GassmaUserAggregateField<T, K extends string>",
+    );
+  });
+
+  it("should map _count keys to number", () => {
+    const result = getOneGassmaAggregateField("", "User");
+    expect(result).toContain('K extends "_count"');
+    expect(result).toContain(
+      "{ [P in keyof T as T[P] extends true ? P : never]: number }",
+    );
+  });
+
+  it("should resolve non _count keys via AggregateBaseReturn", () => {
+    const result = getOneGassmaAggregateField("", "User");
+    expect(result).toContain("P & keyof GassmaUserAggregateBaseReturn");
+  });
+
+  it("should map undefined T to never", () => {
+    const result = getOneGassmaAggregateField("", "User");
+    expect(result).toContain("T extends undefined");
+    expect(result).toContain("? never");
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaAggregateField("Test", "User");
+    expect(result).toContain("export type GassmaTestUserAggregateField");
+    expect(result).toContain("GassmaTestUserAggregateBaseReturn");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaAnyUse.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaAnyUse.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaAnyUse } from "../../../generate/typeGenerate/gassmaAnyUse/oneGassmaAnyUse";
+
+describe("getOneGassmaAnyUse", () => {
+  it("should emit Use with required column having no ?", () => {
+    const result = getOneGassmaAnyUse({ id: [1] }, "", "User");
+    expect(result).toContain("export type GassmaUserUse = {");
+    expect(result).toContain('"id":');
+    expect(result).not.toContain('"id"?:');
+  });
+
+  it("should mark optional columns (trailing ?) with ?", () => {
+    const result = getOneGassmaAnyUse({ "name?": ["a"] }, "", "User");
+    expect(result).toContain('"name"?:');
+    expect(result).not.toContain('"name?"');
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaAnyUse({ id: [1] }, "Test", "User");
+    expect(result).toContain("export type GassmaTestUserUse");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaByField.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaByField.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaByField } from "../../../generate/typeGenerate/gassmaByField/oneGassmaByField";
+
+describe("getOneGassmaByField", () => {
+  it("should declare ByField with key-or-keys parameter", () => {
+    const result = getOneGassmaByField("", "User");
+    expect(result).toContain(
+      "export type GassmaUserByField<T extends GassmaUserGroupByKeyOfBaseReturn | GassmaUserGroupByKeyOfBaseReturn[]>",
+    );
+  });
+
+  it("should map array case to indexed lookup over GroupByBaseReturn", () => {
+    const result = getOneGassmaByField("", "User");
+    expect(result).toContain("T extends GassmaUserGroupByKeyOfBaseReturn[]");
+    expect(result).toContain(
+      "[K in T[number]]: GassmaUserGroupByBaseReturn[K & keyof GassmaUserGroupByBaseReturn]",
+    );
+  });
+
+  it("should map single key case via keyof", () => {
+    const result = getOneGassmaByField("", "User");
+    expect(result).toContain("T extends keyof GassmaUserGroupByBaseReturn");
+    expect(result).toContain("[K in T]: GassmaUserGroupByBaseReturn[K]");
+  });
+
+  it("should fall through to never for non-matching T", () => {
+    const result = getOneGassmaByField("", "User");
+    expect(result).toContain(": never;");
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaByField("Test", "User");
+    expect(result).toContain("export type GassmaTestUserByField");
+    expect(result).toContain("GassmaTestUserGroupByBaseReturn");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaCreateMany.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCreateMany.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaCreateMany } from "../../../generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany";
+
+describe("getOneGassmaCreateMany", () => {
+  it("should emit CreateManyData with data array of Use", () => {
+    const result = getOneGassmaCreateMany("", "User");
+    expect(result).toContain("export type GassmaUserCreateManyData = {");
+    expect(result).toContain("data: GassmaUserUse[];");
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaCreateMany("Test", "User");
+    expect(result).toContain("export type GassmaTestUserCreateManyData");
+    expect(result).toContain("GassmaTestUserUse[]");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaDeleteData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteData.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { getGassmaDeleteData } from "../../../generate/typeGenerate/gassmaDeleteData";
+
+describe("getGassmaDeleteData", () => {
+  it("should emit DeleteData for each given sheet", () => {
+    const result = getGassmaDeleteData(["User", "Post"], "");
+    expect(result).toContain("GassmaUserDeleteData");
+    expect(result).toContain("GassmaPostDeleteData");
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getGassmaDeleteData(["User"], "Test");
+    expect(result).toContain("GassmaTestUserDeleteData");
+  });
+
+  it("should produce empty string for empty sheet list", () => {
+    expect(getGassmaDeleteData([], "")).toBe("");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaFindManyData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindManyData.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaFindManyData } from "../../../generate/typeGenerate/gassmaFindManyData/oneGassmaFindManyData";
+
+describe("getOneGassmaFindManyData", () => {
+  it("should emit FindManyData as alias of FindData", () => {
+    const result = getOneGassmaFindManyData("", "User");
+    expect(result).toContain(
+      "export type GassmaUserFindManyData = GassmaUserFindData;",
+    );
+  });
+
+  it("should prepend schemaName to both sides", () => {
+    const result = getOneGassmaFindManyData("Test", "User");
+    expect(result).toContain(
+      "export type GassmaTestUserFindManyData = GassmaTestUserFindData;",
+    );
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaHavingCore.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaHavingCore.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaHavingCore } from "../../../generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore";
+
+describe("getOneGassmaHavingCore", () => {
+  it("should emit a HavingCore type per column", () => {
+    const result = getOneGassmaHavingCore({ id: [1], name: ["a"] }, "", "User");
+    expect(result).toContain("export type GassmaUseridHavingCore");
+    // Note: getRemovedCantUseVarChar removes some characters; column names appear concatenated
+    expect(result).toContain("HavingCore = {");
+  });
+
+  it("should include _avg / _count / _max / _min / _sum + base intersection", () => {
+    const result = getOneGassmaHavingCore({ id: [1] }, "", "User");
+    expect(result).toContain("_avg?:");
+    expect(result).toContain("_count?:");
+    expect(result).toContain("_max?:");
+    expect(result).toContain("_min?:");
+    expect(result).toContain("_sum?:");
+    expect(result).toContain("FilterConditions;");
+    expect(result).toContain("} & GassmaUseridFilterConditions;");
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaHavingCore({ id: [1] }, "Test", "User");
+    expect(result).toContain("GassmaTestUseridHavingCore");
+  });
+
+  it("should produce empty string when no columns", () => {
+    expect(getOneGassmaHavingCore({}, "", "User")).toBe("");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaHavingUse.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaHavingUse.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaHavingUse } from "../../../generate/typeGenerate/gassmaHavingUse/oneGassmaHavingUse";
+
+describe("getOneGassmaHavingUse", () => {
+  it("should emit HavingUse with each column referencing the column HavingCore", () => {
+    const result = getOneGassmaHavingUse({ name: ["a"] }, "", "User");
+    expect(result).toContain("export type GassmaUserHavingUse = {");
+    expect(result).toContain('"name"?:');
+    expect(result).toContain("GassmaUsernameHavingCore");
+  });
+
+  it("should append | null for optional columns (trailing ?)", () => {
+    const result = getOneGassmaHavingUse({ "name?": ["a"] }, "", "User");
+    expect(result).toContain(" | null |");
+    expect(result).not.toContain('"name?"');
+  });
+
+  it("should include AND / OR / NOT logical operators", () => {
+    const result = getOneGassmaHavingUse({ id: [1] }, "", "User");
+    expect(result).toContain(
+      "AND?: GassmaUserHavingUse[] | GassmaUserHavingUse;",
+    );
+    expect(result).toContain("OR?: GassmaUserHavingUse[];");
+    expect(result).toContain(
+      "NOT?: GassmaUserHavingUse[] | GassmaUserHavingUse;",
+    );
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaHavingUse({ id: [1] }, "Test", "User");
+    expect(result).toContain("GassmaTestUserHavingUse");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaManyCount.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaManyCount.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { getGassmaManyCount } from "../../../generate/typeGenerate/gassmaManyCount";
+
+describe("getGassmaManyCount", () => {
+  it("should emit ManyReturn with { count: number }", () => {
+    const result = getGassmaManyCount();
+    expect(result).toContain("export type ManyReturn = {");
+    expect(result).toContain("count: number;");
+  });
+
+  it("should emit CreateManyReturn / UpdateManyReturn / DeleteManyReturn aliases", () => {
+    const result = getGassmaManyCount();
+    expect(result).toContain("export type CreateManyReturn = ManyReturn;");
+    expect(result).toContain("export type UpdateManyReturn = ManyReturn;");
+    expect(result).toContain("export type DeleteManyReturn = ManyReturn;");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaOmit.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaOmit.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaOmit } from "../../../generate/typeGenerate/gassmaOmit/oneGassmaOmit";
+
+describe("getOneGassmaOmit", () => {
+  it("should emit Omit with each column as optional true | false", () => {
+    const result = getOneGassmaOmit({ id: [1], name: ["a"] }, "", "User");
+    expect(result).toContain("export type GassmaUserOmit = {");
+    expect(result).toContain('"id"?: true | false;');
+    expect(result).toContain('"name"?: true | false;');
+  });
+
+  it("should strip trailing ? from column names", () => {
+    const result = getOneGassmaOmit({ "name?": ["a"] }, "", "User");
+    expect(result).toContain('"name"?: true | false;');
+    expect(result).not.toContain('"name?"');
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaOmit({ id: [1] }, "Test", "User");
+    expect(result).toContain("export type GassmaTestUserOmit");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaSelect.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaSelect.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaSelect } from "../../../generate/typeGenerate/gassmaSelect/oneGassmaSelect";
+
+describe("getOneGassmaSelect", () => {
+  it("should emit Select with each column as optional true", () => {
+    const result = getOneGassmaSelect({ id: [1], name: ["a"] }, "", "User");
+    expect(result).toContain("export type GassmaUserSelect = {");
+    expect(result).toContain('"id"?: true;');
+    expect(result).toContain('"name"?: true;');
+  });
+
+  it("should strip trailing ? from column names", () => {
+    const result = getOneGassmaSelect({ "name?": ["a"] }, "", "User");
+    expect(result).toContain('"name"?: true;');
+    expect(result).not.toContain('"name?"');
+  });
+
+  it("should emit empty body when no columns", () => {
+    const result = getOneGassmaSelect({}, "", "User");
+    expect(result).toContain("export type GassmaUserSelect = {");
+    expect(result).toContain("};");
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaSelect({ id: [1] }, "Test", "User");
+    expect(result).toContain("export type GassmaTestUserSelect");
+  });
+});


### PR DESCRIPTION
## Summary

型テスト戦略 **Phase 2c**。補助型 11 関数に単体テストを追加（**Phase 2 完結**）。

## 追加テスト（37 it）

| ファイル | 検証内容 |
|---------|---------|
| `gassmaAggregateField` | `<T, K extends string>` シグネチャ、`_count→number` map、`AggregateBaseReturn` 解決、`undefined→never`、schemaName |
| `gassmaSelect` | 各列 `"X"?: true`、`?` 除去、空 body、schemaName |
| `gassmaOmit` | 各列 `"X"?: true \| false`、`?` 除去、schemaName |
| `gassmaFindManyData` | `FindData` エイリアス、schemaName |
| `gassmaCreateMany` | `{ data: Use[] }`、schemaName |
| `gassmaDeleteData` | 各 sheet の DeleteData 出力、空 sheets で空文字列 |
| `gassmaByField` | 配列分岐 / 単一キー分岐 / fallthrough never、schemaName |
| `gassmaHavingCore` | 列ごとの HavingCore、`_avg`/`_count`/`_max`/`_min`/`_sum` + FilterConditions 交差、空 body |
| `gassmaHavingUse` | 列ごとの参照、optional の `\| null`、`AND`/`OR`/`NOT`、schemaName |
| `gassmaManyCount` | `ManyReturn` + `Create/Update/Delete` エイリアス |
| `gassmaAnyUse` | 必須/optional の `?` マーカー、schemaName |

## Test plan
- [x] `npm run test:types`: 94 ファイル 488 テスト + Type Errors なし（前回 83/451 → +11/+37）
- [x] `npm run typecheck`: OK
- [x] `npm run lint`: 230 ファイル エラー0
- [x] `npm run build`: tsup OK

## Phase 2 完結 / 残

これで Phase 2 が完結し、**カバレッジ拡大フェーズが終わり**ました。

| Phase | 状態 |
|-------|------|
| Phase 0 / 1a / 1a' / 1b#17 / 1b#18 / 2a / 2b / **Phase 2c** | ✅ 完了 |
| **Phase 3** | 🔲 gassma-test の `as` 段階除去 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>