### PR TITLE
test: スカラー型の網羅テスト追加 + fixture 拡充

### DIFF
--- a/src/__test__/types/fixtures/schema.prisma
+++ b/src/__test__/types/fixtures/schema.prisma
@@ -49,3 +49,37 @@ model Category {
   parent   Category?  @relation("CategoryTree", fields: [parentId], references: [id])
   children Category[] @relation("CategoryTree")
 }
+
+enum Role {
+  ADMIN
+  USER
+  MODERATOR
+}
+
+enum Status {
+  active   @map("ACTIVE")
+  archived @map("ARCHIVED")
+}
+
+/// enum・@updatedAt・@map・@@map・@ignore・replaceType の検証用
+model Member {
+  id        Int      @id @default(autoincrement())
+  role      Role
+  status    Status
+  firstName String   @map("名前")
+  secret    String   @ignore
+  /// @gassma.replaceType "small", "large"
+  size      String
+  updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+
+  @@map("メンバー一覧")
+}
+
+/// @@ignore の検証用（クライアントから除外される）
+model AuditLog {
+  id      Int    @id @default(autoincrement())
+  message String
+
+  @@ignore
+}

--- a/src/__test__/types/read/scalar.test-d.ts
+++ b/src/__test__/types/read/scalar.test-d.ts
@@ -1,0 +1,100 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// findFirst の結果型（select/omit/include なし）が全スカラーを持つ
+{
+  const r = client.User.findFirst({ where: { id: 1 } });
+  type R = NonNullable<typeof r>;
+
+  // 必須（@default あり）→ null にならない
+  expectTypeOf<R["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<R["isActive"]>().toEqualTypeOf<boolean>();
+  expectTypeOf<R["createdAt"]>().toEqualTypeOf<Date>();
+
+  // 必須（@default なし）→ null にならない
+  expectTypeOf<R["email"]>().toEqualTypeOf<string>();
+
+  // nullable（Type?）→ | null
+  expectTypeOf<R["name"]>().toEqualTypeOf<string | null>();
+  expectTypeOf<R["age"]>().toEqualTypeOf<number | null>();
+}
+
+// findMany / findFirstOrThrow でも同じ結果型
+{
+  const rs = client.User.findMany({ where: {} });
+  expectTypeOf<(typeof rs)[number]["isActive"]>().toEqualTypeOf<boolean>();
+  expectTypeOf<(typeof rs)[number]["age"]>().toEqualTypeOf<number | null>();
+
+  const r = client.User.findFirstOrThrow({ where: { id: 1 } });
+  expectTypeOf<(typeof r)["isActive"]>().toEqualTypeOf<boolean>();
+}
+
+// Prisma 型 → TS 型のマッピング
+{
+  const p = client.Post.findFirstOrThrow({ where: { id: 1 } });
+  type P = typeof p;
+  expectTypeOf<P["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<P["published"]>().toEqualTypeOf<boolean>();
+  expectTypeOf<P["authorId"]>().toEqualTypeOf<number>();
+}
+
+// @gassma.addType: 基底型にユニオンを追加する
+{
+  const r = client.User.findFirstOrThrow({ where: { id: 1 } });
+  // score Float + addType boolean
+  expectTypeOf<(typeof r)["score"]>().toEqualTypeOf<number | boolean>();
+  // rating Int? + addType string, boolean
+  expectTypeOf<(typeof r)["rating"]>().toEqualTypeOf<
+    number | string | boolean | null
+  >();
+
+  const p = client.Post.findFirstOrThrow({ where: { id: 1 } });
+  // content String? + addType number
+  expectTypeOf<(typeof p)["content"]>().toEqualTypeOf<string | number | null>();
+}
+
+// enum → リテラルユニオン。@map 付きは値側にマップされる
+{
+  const m = client.Member.findFirstOrThrow({ where: { id: 1 } });
+  type M = typeof m;
+  expectTypeOf<M["role"]>().toEqualTypeOf<"ADMIN" | "USER" | "MODERATOR">();
+  expectTypeOf<M["status"]>().toEqualTypeOf<"ACTIVE" | "ARCHIVED">();
+}
+
+// @gassma.replaceType: 基底型を置換する（string を含まない）
+{
+  const m = client.Member.findFirstOrThrow({ where: { id: 1 } });
+  expectTypeOf<(typeof m)["size"]>().toEqualTypeOf<"small" | "large">();
+}
+
+// @updatedAt: 結果型では必須（null にならない）
+{
+  const m = client.Member.findFirstOrThrow({ where: { id: 1 } });
+  expectTypeOf<(typeof m)["updatedAt"]>().toEqualTypeOf<Date>();
+}
+
+// @map: コード上のフィールド名でアクセスする（シート側の名前は出てこない）
+{
+  const m = client.Member.findFirstOrThrow({ where: { id: 1 } });
+  expectTypeOf<(typeof m)["firstName"]>().toEqualTypeOf<string>();
+  expectTypeOf<typeof m>().not.toHaveProperty("名前");
+}
+
+// @ignore: 結果型から除外される
+{
+  const m = client.Member.findFirstOrThrow({ where: { id: 1 } });
+  expectTypeOf<typeof m>().not.toHaveProperty("secret");
+}
+
+// @@ignore: クライアントから除外される
+{
+  expectTypeOf<GassmaClient>().not.toHaveProperty("AuditLog");
+}
+
+// @@map: コード上はモデル名でアクセスする
+{
+  expectTypeOf<GassmaClient>().toHaveProperty("Member");
+  expectTypeOf<GassmaClient>().not.toHaveProperty("メンバー一覧");
+}

--- a/src/__test__/types/write/inputScalar.test-d.ts
+++ b/src/__test__/types/write/inputScalar.test-d.ts
@@ -1,0 +1,77 @@
+import { expectTypeOf } from "vitest";
+import type {
+  GassmaClient,
+  GassmaUserUse,
+  GassmaMemberUse,
+} from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// create の data: @default / @updatedAt / nullable は省略できる
+{
+  // 必須（@default なし）だけ渡せば作れる
+  const r = client.User.create({
+    data: { email: "a@example.com", score: 0 },
+  });
+  expectTypeOf<(typeof r)["email"]>().toEqualTypeOf<string>();
+}
+
+// 入力型の optional / required
+{
+  // @default あり → 省略可
+  expectTypeOf<GassmaUserUse>().toHaveProperty("id");
+  expectTypeOf<GassmaUserUse["id"]>().toEqualTypeOf<number | undefined>();
+  expectTypeOf<GassmaUserUse["isActive"]>().toEqualTypeOf<
+    boolean | undefined
+  >();
+  expectTypeOf<GassmaUserUse["createdAt"]>().toEqualTypeOf<Date | undefined>();
+
+  // @default なし・必須 → 省略不可（undefined を含まない）
+  expectTypeOf<GassmaUserUse["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<GassmaUserUse["score"]>().toEqualTypeOf<number | boolean>();
+
+  // nullable → 省略可、かつ null を渡せる
+  expectTypeOf<GassmaUserUse["name"]>().toEqualTypeOf<
+    string | null | undefined
+  >();
+  expectTypeOf<GassmaUserUse["age"]>().toEqualTypeOf<
+    number | null | undefined
+  >();
+}
+
+// @updatedAt は入力で省略可
+{
+  expectTypeOf<GassmaMemberUse["updatedAt"]>().toEqualTypeOf<
+    Date | undefined
+  >();
+}
+
+// enum / replaceType は入力型でもリテラルユニオン
+{
+  expectTypeOf<GassmaMemberUse["role"]>().toEqualTypeOf<
+    "ADMIN" | "USER" | "MODERATOR"
+  >();
+  expectTypeOf<GassmaMemberUse["status"]>().toEqualTypeOf<
+    "ACTIVE" | "ARCHIVED"
+  >();
+  expectTypeOf<GassmaMemberUse["size"]>().toEqualTypeOf<"small" | "large">();
+}
+
+// @ignore は入力型からも除外される
+{
+  expectTypeOf<GassmaMemberUse>().not.toHaveProperty("secret");
+}
+
+// @map: 入力もコード上のフィールド名で渡す
+{
+  expectTypeOf<GassmaMemberUse["firstName"]>().toEqualTypeOf<string>();
+  expectTypeOf<GassmaMemberUse>().not.toHaveProperty("名前");
+}
+
+// createMany の data は Use の配列
+{
+  const r = client.User.createMany({
+    data: [{ email: "a@example.com", score: 0 }],
+  });
+  expectTypeOf<typeof r>().toEqualTypeOf<{ count: number }>();
+}


### PR DESCRIPTION
## Summary

網羅的型テスト整備の**第1弾（スカラー型）**。PR #87 で修正した `@default` の nullable バグと同種の問題が他の属性でも潜んでいないか、片っ端から検証しました。

**結果: すべて Green**（新たなバグは検出されず、型生成が正しいことを確認）。

## fixture 拡充

既存モデル（User / Post / Profile / Tag / Category）は**一切変更せず**、未カバー属性を検証するモデルのみ追加しました。

```prisma
enum Role   { ADMIN  USER  MODERATOR }
enum Status { active @map("ACTIVE")  archived @map("ARCHIVED") }

model Member {
  id        Int      @id @default(autoincrement())
  role      Role
  status    Status
  firstName String   @map("名前")
  secret    String   @ignore
  /// @gassma.replaceType "small", "large"
  size      String
  updatedAt DateTime @updatedAt
  createdAt DateTime @default(now())

  @@map("メンバー一覧")
}

model AuditLog {
  id      Int    @id @default(autoincrement())
  message String

  @@ignore
}
```

## 追加テスト

### `types/read/scalar.test-d.ts`（結果型）

| 検証軸 | 期待 |
|---|---|
| `@default` 付き必須 | `id: number` / `isActive: boolean` / `createdAt: Date`（**非null**） |
| nullable（`Type?`） | `name: string \| null` / `age: number \| null` |
| 必須（`@default` なし） | `email: string` |
| Prisma 型マッピング | `String→string` / `Boolean→boolean` / `Int→number` |
| `@gassma.addType` | `score: number \| boolean` / `rating: number \| string \| boolean \| null` |
| `@gassma.replaceType` | `size: "small" \| "large"`（string を含まない） |
| enum | `role: "ADMIN" \| "USER" \| "MODERATOR"` |
| enum + `@map` | `status: "ACTIVE" \| "ARCHIVED"` |
| `@updatedAt` | `updatedAt: Date`（非null） |
| `@map` | `firstName` でアクセス、`名前` は型に出ない |
| `@ignore` | `secret` が結果型から除外 |
| `@@ignore` | `AuditLog` がクライアントから除外 |
| `@@map` | `client.Member` でアクセス、`メンバー一覧` は出ない |
| findFirst / findMany / findFirstOrThrow | いずれも同じ結果型 |

### `types/write/inputScalar.test-d.ts`（入力型）

| 検証軸 | 期待 |
|---|---|
| `@default` 付き | `"id"?: number`（省略可） |
| `@updatedAt` | `"updatedAt"?: Date`（省略可） |
| nullable | `"name"?: string \| null`（省略可・null 可） |
| 必須（`@default` なし） | `"email": string`（**省略不可**、`undefined` を含まない） |
| enum / replaceType | 入力型でもリテラルユニオン |
| `@ignore` / `@map` | 入力型からも除外 / コード上の名前で渡す |
| `createMany` | 戻り値 `{ count: number }` |

## テストが空振りしていないことの検証

`expectTypeOf` が実際に型を検査していることを確認するため、**意図的に型を壊して Red になること**をチェックしました。

```ts
expectTypeOf<R["isActive"]>().toEqualTypeOf<string>();  // わざと boolean → string
// → TypeCheckError: Type 'string' does not satisfy the constraint
//    '"Expected string, Actual boolean"'  ✅ EXIT=1
```

## Test plan

- [x] `npm run test:types`: 97 ファイル 495 テスト + Type Errors なし
- [x] 意図的に型を壊して Red になることを検証（空振りでない）
- [x] `npm run typecheck` / `npm run lint` / `npm run build`: すべて OK
- [x] 既存テスト（include / omit / write）は fixture 追加後も全て Green（非破壊）

## 次以降の予定

網羅的型テストの軸ごとに PR を分けて進めます。

| 次 | 軸 |
|---|---|
| 2 | **select**（スカラー / relation込み / ネスト / 未指定時） |
| 3 | **write 系の入出力**（include 以外: data 入力型、部分更新、NumberOperation、戻り値） |
| 4 | **クエリ引数**（where / orderBy / cursor / distinct） |
| 5 | **集計系**（count / aggregate / groupBy） |
| 6 | **globalOmit** の網羅 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>