### PR TITLE
fix: select 内の relation が結果型に反映されないバグを修正 + 網羅テスト

### DIFF
--- a/src/__test__/types/read/select.test-d.ts
+++ b/src/__test__/types/read/select.test-d.ts
@@ -1,0 +1,101 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// select スカラーのみ: 指定したキーだけが結果型に出る
+{
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: { id: true, email: true },
+  });
+  type R = typeof r;
+  expectTypeOf<R["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<R["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<R>().not.toHaveProperty("name");
+  expectTypeOf<R>().not.toHaveProperty("posts");
+}
+
+// select で relation を true 指定: 結果型に relation が出る（oneToMany → 配列）
+{
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: { id: true, posts: true },
+  });
+  type R = typeof r;
+  expectTypeOf<R["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<R["posts"]>().toBeArray();
+  expectTypeOf<R["posts"][number]["title"]>().toEqualTypeOf<string>();
+  // select していないスカラーは出ない
+  expectTypeOf<R>().not.toHaveProperty("email");
+}
+
+// select で oneToOne relation: 単一 | null
+{
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: { profile: true },
+  });
+  type R = typeof r;
+  expectTypeOf<R["profile"]>().toBeNullable();
+  expectTypeOf<NonNullable<R["profile"]>["bio"]>().toEqualTypeOf<string>();
+}
+
+// select で manyToOne relation: 単一 | null
+{
+  const r = client.Post.findFirstOrThrow({
+    where: {},
+    select: { id: true, author: true },
+  });
+  type R = typeof r;
+  expectTypeOf<R["author"]>().toBeNullable();
+  expectTypeOf<NonNullable<R["author"]>["email"]>().toEqualTypeOf<string>();
+}
+
+// select 内の relation に select（ネスト）: relation 先も絞られる
+{
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: {
+      id: true,
+      posts: { select: { title: true } },
+    },
+  });
+  type R = typeof r;
+  expectTypeOf<R["posts"][number]["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<R["posts"][number]>().not.toHaveProperty("content");
+}
+
+// select + _count
+{
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: {
+      id: true,
+      _count: { select: { posts: true } },
+    },
+  });
+  type R = typeof r;
+  expectTypeOf<R["_count"]["posts"]>().toEqualTypeOf<number>();
+}
+
+// self-relation の select
+{
+  const r = client.Category.findFirstOrThrow({
+    where: {},
+    select: { name: true, children: true },
+  });
+  type R = typeof r;
+  expectTypeOf<R["children"]>().toBeArray();
+  expectTypeOf<R["children"][number]["name"]>().toEqualTypeOf<string>();
+}
+
+// findMany でも select が効く
+{
+  const rs = client.User.findMany({
+    where: {},
+    select: { id: true, posts: true },
+  });
+  expectTypeOf<(typeof rs)[number]["posts"]>().toBeArray();
+  expectTypeOf<(typeof rs)[number]>().not.toHaveProperty("email");
+}

--- a/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -10,10 +10,30 @@ const getOneGassmaFindResult = (
   const modelRelations = relations?.[sheetName] ?? {};
   const relNames = Object.keys(modelRelations);
 
+  const relKeyUnion =
+    relNames.length > 0
+      ? `${relNames.map((r) => `"${r}"`).join(" | ")} | "_count"`
+      : `"_count"`;
+
+  const relationBranch = (source: string) =>
+    relNames
+      .map((relationName) => {
+        const def = modelRelations[relationName];
+        const targetFR = `${prefix}${def.to}FindResult`;
+        const inner = `${targetFR}<Gassma.SelectOf<${source}[K]>, Gassma.IncludeOf<${source}[K]>, Gassma.OmitOf<${source}[K]>, {}>`;
+        const isList = def.type === "oneToMany" || def.type === "manyToMany";
+        const result = isList ? `${inner}[]` : `${inner} | null`;
+        return `          K extends "${relationName}" ? ${result} :`;
+      })
+      .join("\n");
+
   const selectResult = `{
-      [K in keyof S as S[K] extends true
-        ? K & keyof ${self}DefaultFindResult
-        : never]: ${self}DefaultFindResult[K & keyof ${self}DefaultFindResult];
+      [K in keyof S as S[K] extends false | undefined
+        ? never
+        : K & (keyof ${self}DefaultFindResult | ${relKeyUnion})]:
+${relationBranch("S")}
+          K extends "_count" ? Gassma.CountResult<S[K]> :
+          ${self}DefaultFindResult[K & keyof ${self}DefaultFindResult];
     }`;
 
   const omitResult = `{
@@ -22,25 +42,11 @@ const getOneGassmaFindResult = (
         : K]: ${self}DefaultFindResult[K];
     }`;
 
-  const baseResult = `(S extends ${self}Select
+  const baseResult = `(S extends ${self}FindSelect
   ? ${selectResult}
   : ${omitResult})`;
 
-  const includeBranches = relNames
-    .map((relationName) => {
-      const def = modelRelations[relationName];
-      const targetFR = `${prefix}${def.to}FindResult`;
-      const inner = `${targetFR}<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, {}>`;
-      const isList = def.type === "oneToMany" || def.type === "manyToMany";
-      const result = isList ? `${inner}[]` : `${inner} | null`;
-      return `          K extends "${relationName}" ? ${result} :`;
-    })
-    .join("\n");
-
-  const relKeyUnion =
-    relNames.length > 0
-      ? `${relNames.map((r) => `"${r}"`).join(" | ")} | "_count"`
-      : `"_count"`;
+  const includeBranches = relationBranch("I");
 
   const includePart = `(I extends undefined
     ? {}


### PR DESCRIPTION
## 問題

網羅的型テスト整備の**第2弾（select）**。**バグを1件発見・修正**しました。

トップレベルの `select` に relation を含めると、その relation が**結果型から消えていました**。

```ts
const r = client.User.findFirstOrThrow({
  where: {},
  select: { id: true, posts: true },
});
r.posts;  // ❌ 修正前: Property 'posts' does not exist
```

これは gassma-test に `as Record<string, unknown>` が 20 件残っていた原因そのものです（select 内 relation の型が取れないため手動キャストしていた）。

## 原因

2つの問題が重なっていました。

1. **`FindResult` の select 分岐**が
   ```ts
   [K in keyof S as S[K] extends true ? K & keyof DefaultFindResult : never]
   ```
   となっており、relation キー（`posts`）は `DefaultFindResult`（スカラーのみ）に無いため `never` に落ちて消えていた。

2. **select 判定が `Select`（スカラーのみの型）** だったため、relation のみの select（`select: { profile: true }`）は `S extends Select` を満たせず **omit 分岐**に落ちていた。

## 修正

- **select 分岐に relation ブランチと `_count` ブランチを追加**。include 側と共通の `relationBranch(source)` ヘルパーに切り出し、`S`（select）/ `I`（include）の両方を同じロジックで解決
- **select 判定を `Select` → `FindSelect`（relation を含む型）に変更**

```ts
// 修正後の select 分岐（概念）
{
  [K in keyof S as S[K] extends false | undefined
    ? never
    : K & (keyof DefaultFindResult | RelationKeys | "_count")]:
      K extends "posts" ? PostFindResult<SelectOf<S[K]>, ...>[] :
      K extends "profile" ? ProfileFindResult<...> | null :
      K extends "_count" ? CountResult<S[K]> :
      DefaultFindResult[K & keyof DefaultFindResult];
}
```

## 追加テスト `types/read/select.test-d.ts`

| 検証 | 期待 |
|---|---|
| スカラーのみ | 指定キーだけ、他は出ない |
| relation（true） | oneToMany → 配列、要素の型も正しい |
| oneToOne relation | `Profile \| null` |
| manyToOne relation | `User \| null` |
| ネスト（select 内 select） | relation 先も絞られる |
| select + `_count` | `_count.posts: number` |
| self-relation | `children` が配列 |
| findMany | select が効く |

## Test plan

- [x] Red 確認: 修正前は relation（posts/profile/author/children）と `_count` がすべて `does not exist` エラー
- [x] `npm run test:types`: 98 ファイル 495 テスト + Type Errors なし
- [x] **omit 分岐が非破壊**であることを生成型で直接検証（`omit: { email: true }` で email が消え、他は残る）
- [x] 単体テスト `gassmaFindResult.test.ts`（8）追従
- [x] `npm run typecheck` / `npm run lint` / `npm run build`: すべて OK

## 波及

この修正により **gassma-test の `as` 20 件が除去可能**になります（別 PR で対応予定）。

## 次以降

| 次 | 軸 |
|---|---|
| 3 | write 系の入出力（include 以外） |
| 4 | クエリ引数（where / orderBy / cursor / distinct） |
| 5 | 集計系（count / aggregate / groupBy） |
| 6 | globalOmit |
| — | gassma-test の `as` 除去（本 PR の波及） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>