### PR TITLE
fix: deleteMany の where を任意に修正 + write 系入出力の網羅テスト

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaDeleteData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteData.test.ts
@@ -16,4 +16,9 @@ describe("getGassmaDeleteData", () => {
   it("should produce empty string for empty sheet list", () => {
     expect(getGassmaDeleteData([], "")).toBe("");
   });
+
+  it("should make where optional (deleteMany without where targets all rows)", () => {
+    const result = getGassmaDeleteData(["User"], "");
+    expect(result).toContain("where?: GassmaUserWhereUse;");
+  });
 });

--- a/src/__test__/generate/typeGenerate/gassmaDeleteManyData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaDeleteManyData.test.ts
@@ -8,10 +8,10 @@ describe("getOneGassmaDeleteData", () => {
     expect(result).toContain("export type GassmaUserDeleteData");
   });
 
-  it("should include where property", () => {
+  it("should have optional where property (deleteMany without where targets all rows)", () => {
     const result = getOneGassmaDeleteData("", "User");
 
-    expect(result).toContain("where: GassmaUserWhereUse;");
+    expect(result).toContain("where?: GassmaUserWhereUse;");
   });
 
   it("should include limit property", () => {

--- a/src/__test__/types/write/inputData.test-d.ts
+++ b/src/__test__/types/write/inputData.test-d.ts
@@ -1,0 +1,74 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// create: 必須（@default なし）だけ渡せば作れる。@default / nullable は省略可
+{
+  client.User.create({ data: { email: "a@example.com", score: 0 } });
+
+  // @ts-expect-error email（必須）が無いと型エラー
+  client.User.create({ data: { score: 0 } });
+}
+
+// update の data: 全フィールドが部分更新可（Partial）
+{
+  // 1フィールドだけの更新が通る
+  client.User.update({ where: { id: 1 }, data: { name: "x" } });
+  // 空 data も型上は許容（Partial）
+  client.User.update({ where: { id: 1 }, data: {} });
+}
+
+// update の数値フィールドは NumberOperation を受け付ける
+{
+  client.Post.update({
+    where: { id: 1 },
+    data: { authorId: { increment: 1 } },
+  });
+  client.Post.update({
+    where: { id: 1 },
+    data: { authorId: { decrement: 2 } },
+  });
+  // 直接値も渡せる
+  client.Post.update({ where: { id: 1 }, data: { authorId: 5 } });
+}
+
+// updateMany は where 省略可、limit を受け付ける
+{
+  client.User.updateMany({ data: { isActive: false } });
+  client.User.updateMany({
+    where: { id: 1 },
+    data: { isActive: false },
+    limit: 3,
+  });
+}
+
+// upsert は where / create / update をすべて要求する
+{
+  client.User.upsert({
+    where: { id: 1 },
+    create: { email: "a@example.com", score: 0 },
+    update: { name: "x" },
+  });
+
+  // @ts-expect-error create が無い
+  client.User.upsert({ where: { id: 1 }, update: { name: "x" } });
+}
+
+// delete / deleteMany の where
+{
+  client.User.delete({ where: { id: 1 } });
+  client.User.deleteMany({ where: { id: 1 } });
+  // deleteMany は where 省略可（全件）
+  client.User.deleteMany({});
+}
+
+// createMany の data は配列
+{
+  client.User.createMany({
+    data: [
+      { email: "a@example.com", score: 0 },
+      { email: "b@example.com", score: 1 },
+    ],
+  });
+}

--- a/src/__test__/types/write/result.test-d.ts
+++ b/src/__test__/types/write/result.test-d.ts
@@ -1,0 +1,95 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// create: 単一・null なし。全スカラーを持つ
+{
+  const r = client.User.create({
+    data: { email: "a@example.com", score: 0 },
+  });
+  expectTypeOf<typeof r>().not.toBeNullable();
+  expectTypeOf<(typeof r)["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<(typeof r)["isActive"]>().toEqualTypeOf<boolean>();
+}
+
+// upsert: 単一・null なし
+{
+  const r = client.User.upsert({
+    where: { id: 1 },
+    create: { email: "a@example.com", score: 0 },
+    update: { name: "x" },
+  });
+  expectTypeOf<typeof r>().not.toBeNullable();
+  expectTypeOf<(typeof r)["email"]>().toEqualTypeOf<string>();
+}
+
+// update: 単一 | null
+{
+  const r = client.User.update({ where: { id: 1 }, data: { name: "x" } });
+  expectTypeOf<typeof r>().toBeNullable();
+  expectTypeOf<NonNullable<typeof r>["email"]>().toEqualTypeOf<string>();
+}
+
+// delete: 単一 | null
+{
+  const r = client.User.delete({ where: { id: 1 } });
+  expectTypeOf<typeof r>().toBeNullable();
+  expectTypeOf<NonNullable<typeof r>["email"]>().toEqualTypeOf<string>();
+}
+
+// createMany / updateMany / deleteMany: { count: number }
+{
+  const cm = client.User.createMany({
+    data: [{ email: "a@example.com", score: 0 }],
+  });
+  expectTypeOf<typeof cm>().toEqualTypeOf<{ count: number }>();
+
+  const um = client.User.updateMany({ data: { isActive: false } });
+  expectTypeOf<typeof um>().toEqualTypeOf<{ count: number }>();
+
+  const dm = client.User.deleteMany({ where: {} });
+  expectTypeOf<typeof dm>().toEqualTypeOf<{ count: number }>();
+}
+
+// createManyAndReturn: 配列。select / omit / include が効く
+{
+  const r = client.User.createManyAndReturn({
+    data: [{ email: "a@example.com", score: 0 }],
+  });
+  expectTypeOf<typeof r>().toBeArray();
+  expectTypeOf<(typeof r)[number]["email"]>().toEqualTypeOf<string>();
+
+  // select が効く
+  const s = client.User.createManyAndReturn({
+    data: [{ email: "a@example.com", score: 0 }],
+    select: { id: true },
+  });
+  expectTypeOf<(typeof s)[number]["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof s)[number]>().not.toHaveProperty("email");
+}
+
+// updateManyAndReturn: DefaultFindResult 配列（全フィールド）
+{
+  const r = client.User.updateManyAndReturn({ data: { isActive: false } });
+  expectTypeOf<typeof r>().toBeArray();
+  expectTypeOf<(typeof r)[number]["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<(typeof r)[number]["isActive"]>().toEqualTypeOf<boolean>();
+}
+
+// select / omit は create / update / upsert / delete の戻り値にも効く
+{
+  const c = client.User.create({
+    data: { email: "a@example.com", score: 0 },
+    select: { id: true },
+  });
+  expectTypeOf<(typeof c)["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<typeof c>().not.toHaveProperty("email");
+
+  const u = client.User.update({
+    where: { id: 1 },
+    data: { name: "x" },
+    omit: { email: true },
+  });
+  expectTypeOf<NonNullable<typeof u>>().not.toHaveProperty("email");
+}

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
@@ -1,7 +1,7 @@
 const getOneGassmaDeleteData = (schemaName: string, sheetName: string) => {
   return `
 export type Gassma${schemaName}${sheetName}DeleteData = {
-  where: Gassma${schemaName}${sheetName}WhereUse;
+  where?: Gassma${schemaName}${sheetName}WhereUse;
   limit?: number;
 };
 `;


### PR DESCRIPTION
## 問題

網羅的型テスト整備の**第3弾（write 系入出力）**。**バグを1件発見・修正**しました。

`deleteMany` の `where` が**必須**になっていました。

```ts
client.User.deleteMany({});  // ❌ 修正前: Property 'where' is missing but required
```

## 原因

- reference（`delteMany.md`）は「**where は省略可、書かない場合は全ての行が対象**」と明記
- ランタイム（gassma 本体 `deleteMany`）も `deleteData.where ?? {}` で where 省略＝全件に対応
- **なのに生成型（`DeleteData`）だけ `where` が必須**になっていた
- `UpdateData` / `CountData` / `FindData` など他の複数系はすべて `where?`（任意）で、**`DeleteData` だけ不整合**

これは reference・ランタイム・他の型のすべてと食い違う明確なバグでした。

## 修正

- `oneGassmaDeleteData`: `where` → `where?`（任意）
- **`delete`（単数）の `DeleteSingleData` は `where` 必須のまま** — 1件を特定するため必須が正しく、こちらは変更なし

| メソッド | where | 判定 |
|---|---|---|
| `delete`（単数） | 必須 | ✅ 正しい（変更なし） |
| `deleteMany` | ~~必須~~ → **任意** | 🔧 修正 |

## 追加テスト

### `types/write/inputData.test-d.ts`（入力型）
- create: 必須フィールドだけで作れる / 必須欠落は `@ts-expect-error`
- update: `Partial` 部分更新（1フィールド / 空 data）
- **NumberOperation**: `{ increment }` / `{ decrement }` / 直接値
- updateMany: where 省略可 / limit
- upsert: where/create/update すべて要求 / create 欠落は `@ts-expect-error`
- **deleteMany: where 省略可**（本 PR の修正箇所）
- createMany: data 配列

### `types/write/result.test-d.ts`（戻り値型）
| メソッド | 戻り値 |
|---|---|
| create / upsert | 単一・**非null** |
| update / delete | 単一・**`| null`** |
| createMany / updateMany / deleteMany | `{ count: number }` |
| createManyAndReturn | 配列（select 反映） |
| updateManyAndReturn | `DefaultFindResult[]`（全フィールド） |
| create/update の select・omit | 戻り値に反映 |

## Test plan

- [x] Red 確認: 修正前は `deleteMany({})` が `where is missing but required` エラー
- [x] reference（省略可）・ランタイム実装（`where ?? {}`）と型を一致させた
- [x] `npm run test:types`: 100 ファイル 496 テスト + Type Errors なし
- [x] `delete`（単数）は where 必須のままであることを生成型で確認
- [x] `npm run typecheck` / `npm run lint` / `npm run build`: すべて OK

## 進捗

| PR | 軸 | 結果 |
|---|---|---|
| #87 | @default nullable | 修正 |
| #88 | スカラー型 | バグなし |
| #89 | select | バグ1件修正 |
| **本PR** | **write 系入出力** | **バグ1件修正（deleteMany where）** |
| 次 | クエリ引数（where / orderBy / cursor / distinct） | |
| | 集計系（count / aggregate / groupBy） | |
| | globalOmit | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>