### PR TITLE
fix: クエリ引数の網羅テスト + Fable レビューで発見した2バグ修正（orderBy 配列 / is・isNot null）

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
@@ -53,7 +53,7 @@ describe("getOneGassmaWhereUse", () => {
     const result = getOneGassmaWhereUse(sheetContent, "", "Post", relations);
 
     expect(result).toContain(
-      '"author"?: { is?: GassmaUserWhereUse; isNot?: GassmaUserWhereUse }',
+      '"author"?: { is?: GassmaUserWhereUse | null; isNot?: GassmaUserWhereUse | null }',
     );
   });
 
@@ -72,7 +72,7 @@ describe("getOneGassmaWhereUse", () => {
     const result = getOneGassmaWhereUse(sheetContent, "", "User", relations);
 
     expect(result).toContain(
-      '"profile"?: { is?: GassmaProfileWhereUse; isNot?: GassmaProfileWhereUse }',
+      '"profile"?: { is?: GassmaProfileWhereUse | null; isNot?: GassmaProfileWhereUse | null }',
     );
   });
 

--- a/src/__test__/types/query/orderByCursorDistinct.test-d.ts
+++ b/src/__test__/types/query/orderByCursorDistinct.test-d.ts
@@ -1,0 +1,75 @@
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// orderBy: asc / desc
+{
+  client.User.findMany({ where: {}, orderBy: { id: "asc" } });
+  client.User.findMany({ where: {}, orderBy: { email: "desc" } });
+}
+
+// orderBy: SortOrderInput（nulls 制御）
+{
+  client.User.findMany({
+    where: {},
+    orderBy: { name: { sort: "asc", nulls: "last" } },
+  });
+  client.User.findMany({
+    where: {},
+    orderBy: { age: { sort: "desc", nulls: "first" } },
+  });
+}
+
+// orderBy: relation フィールドでソート
+{
+  client.User.findMany({
+    where: {},
+    orderBy: { posts: { _count: "desc" } },
+  });
+  client.Post.findMany({
+    where: {},
+    orderBy: { author: { email: "asc" } },
+  });
+}
+
+// orderBy: _count でソート
+{
+  client.User.findMany({
+    where: {},
+    orderBy: { _count: { posts: "desc" } },
+  });
+}
+
+// orderBy: 不正な方向は拒否
+{
+  // @ts-expect-error "ascending" は無効（asc | desc のみ）
+  client.User.findMany({ where: {}, orderBy: { id: "ascending" } });
+}
+
+// cursor: Partial<Use>（任意のフィールドで指定可）
+{
+  client.User.findMany({ where: {}, cursor: { id: 1 } });
+  client.User.findMany({ where: {}, cursor: { email: "a@example.com" } });
+  // 複数フィールドも可
+  client.User.findMany({
+    where: {},
+    cursor: { id: 1, email: "a@example.com" },
+  });
+}
+
+// distinct: フィールド名（単一 / 配列）
+{
+  client.User.findMany({ where: {}, distinct: "email" });
+  client.User.findMany({ where: {}, distinct: ["email", "name"] });
+}
+
+// distinct: 存在しないフィールドは拒否
+{
+  // @ts-expect-error "nonexistent" は User のフィールドでない
+  client.User.findMany({ where: {}, distinct: "nonexistent" });
+}
+
+// take / skip: number
+{
+  client.User.findMany({ where: {}, take: 10, skip: 5 });
+}

--- a/src/__test__/types/query/orderByCursorDistinct.test-d.ts
+++ b/src/__test__/types/query/orderByCursorDistinct.test-d.ts
@@ -40,6 +40,19 @@ declare const client: GassmaClient;
   });
 }
 
+// orderBy: 配列形式（複数キーソート）
+{
+  client.User.findMany({
+    where: {},
+    orderBy: [{ id: "asc" }, { email: "desc" }],
+  });
+  // relation ソートとの併用も配列で
+  client.User.findMany({
+    where: {},
+    orderBy: [{ posts: { _count: "desc" } }, { name: "asc" }],
+  });
+}
+
 // orderBy: 不正な方向は拒否
 {
   // @ts-expect-error "ascending" は無効（asc | desc のみ）

--- a/src/__test__/types/query/where.test-d.ts
+++ b/src/__test__/types/query/where.test-d.ts
@@ -70,6 +70,60 @@ declare const client: GassmaClient;
   });
 }
 
+// where: is / isNot に null（FK が null のレコード検索）
+{
+  client.User.findMany({ where: { profile: { is: null } } });
+  client.User.findMany({ where: { profile: { isNot: null } } });
+  client.Post.findMany({ where: { author: { is: null } } });
+}
+
+// where: nullable フィールドの FilterConditions で null を使える
+{
+  client.User.findMany({ where: { name: { equals: null } } });
+  client.User.findMany({ where: { name: { not: null } } });
+  client.User.findMany({ where: { age: { equals: null } } });
+}
+
+// where: 非 nullable フィールドの equals に null は不可
+{
+  // @ts-expect-error email は非 nullable なので equals: null 不可
+  client.User.findMany({ where: { email: { equals: null } } });
+}
+
+// where: not / in / notIn に FieldRef は使えない（fields.md の制約）
+{
+  // @ts-expect-error not に FieldRef は使用不可
+  client.User.findMany({ where: { id: { not: client.User.fields.age } } });
+  // @ts-expect-error in に FieldRef は使用不可
+  client.User.findMany({ where: { id: { in: [client.User.fields.age] } } });
+}
+
+// where: enum / addType / Date フィールドのフィルタ
+{
+  client.Member.findMany({
+    where: { role: "ADMIN", status: { in: ["ACTIVE"] } },
+  });
+  // @ts-expect-error enum にないリテラルは不可
+  client.Member.findMany({ where: { role: "SUPERADMIN" } });
+  // @ts-expect-error @ignore された secret は where に存在しない
+  client.Member.findMany({ where: { secret: "x" } });
+  client.User.findMany({ where: { createdAt: { lte: new Date() } } });
+}
+
+// where: NOT は配列でも可、OR は配列のみ
+{
+  client.User.findMany({ where: { NOT: [{ id: 1 }, { id: 2 }] } });
+  // @ts-expect-error OR は配列のみ（AND / NOT と異なる）
+  client.User.findMany({ where: { OR: { id: 1 } } });
+}
+
+// where: relation filter の深いネスト
+{
+  client.User.findMany({
+    where: { posts: { some: { author: { is: { email: "a@example.com" } } } } },
+  });
+}
+
 // where: relation の single filter に list filter は使えない
 {
   // @ts-expect-error profile は oneToOne なので some は使えない

--- a/src/__test__/types/query/where.test-d.ts
+++ b/src/__test__/types/query/where.test-d.ts
@@ -1,0 +1,97 @@
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// where: フィールドに直接値を渡せる
+{
+  client.User.findMany({ where: { id: 1, email: "a@example.com" } });
+}
+
+// where: FilterConditions を渡せる（数値: 比較演算子）
+{
+  client.User.findMany({ where: { id: { gte: 1, lt: 100 } } });
+  client.User.findMany({ where: { id: { in: [1, 2, 3], notIn: [4] } } });
+  client.User.findMany({ where: { id: { equals: 1, not: 2 } } });
+}
+
+// where: 文字列マッチ + mode
+{
+  client.User.findMany({
+    where: { email: { contains: "example", mode: "insensitive" } },
+  });
+  client.User.findMany({
+    where: { email: { startsWith: "a", endsWith: "z" } },
+  });
+}
+
+// where: nullable フィールドは null を直接渡せる
+{
+  client.User.findMany({ where: { name: null } });
+  client.User.findMany({ where: { age: null } });
+}
+
+// where: 非 nullable フィールドに null は渡せない
+{
+  // @ts-expect-error email は非 nullable なので null 不可
+  client.User.findMany({ where: { email: null } });
+}
+
+// where: AND / OR / NOT
+{
+  client.User.findMany({
+    where: {
+      AND: [{ id: 1 }, { email: "a@example.com" }],
+    },
+  });
+  client.User.findMany({ where: { OR: [{ id: 1 }, { id: 2 }] } });
+  client.User.findMany({ where: { NOT: { id: 1 } } });
+  // AND は配列でも単体でも可
+  client.User.findMany({ where: { AND: { id: 1 } } });
+}
+
+// where: relation filter（oneToMany → some / every / none）
+{
+  client.User.findMany({
+    where: { posts: { some: { published: true } } },
+  });
+  client.User.findMany({ where: { posts: { every: {} } } });
+  client.User.findMany({ where: { posts: { none: { published: false } } } });
+}
+
+// where: relation filter（oneToOne / manyToOne → is / isNot）
+{
+  client.User.findMany({
+    where: { profile: { is: { bio: "hello" } } },
+  });
+  client.User.findMany({ where: { profile: { isNot: {} } } });
+
+  client.Post.findMany({
+    where: { author: { is: { email: "a@example.com" } } },
+  });
+}
+
+// where: relation の single filter に list filter は使えない
+{
+  // @ts-expect-error profile は oneToOne なので some は使えない
+  client.User.findMany({ where: { profile: { some: {} } } });
+}
+
+// where: FieldRef を equals / 比較に使える
+{
+  client.User.findMany({
+    where: { id: { equals: client.User.fields.age } },
+  });
+  client.Post.findMany({
+    where: { authorId: { gt: client.Post.fields.id } },
+  });
+}
+
+// where は count / delete / update でも同じ型
+{
+  client.User.count({ where: { id: { gte: 1 } } });
+  client.User.deleteMany({ where: { posts: { some: {} } } });
+  client.User.updateMany({
+    where: { name: null },
+    data: { isActive: false },
+  });
+}

--- a/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
+++ b/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
@@ -2,7 +2,7 @@ const getOneGassmaAggregateData = (schemaName: string, sheetName: string) => {
   return `
 export type Gassma${schemaName}${sheetName}AggregateData = {
   where?: Gassma${schemaName}${sheetName}WhereUse;
-  orderBy?: Gassma${schemaName}${sheetName}OrderBy;
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[];
   take?: number;
   skip?: number;
   cursor?: Partial<Gassma${schemaName}${sheetName}Use>;

--- a/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
+++ b/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
@@ -2,7 +2,7 @@ const getOneGassmaCountData = (schemaName: string, sheetName: string) => {
   return `
 export type Gassma${schemaName}${sheetName}CountData = {
   where?: Gassma${schemaName}${sheetName}WhereUse;
-  orderBy?: Gassma${schemaName}${sheetName}OrderBy;
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[];
   take?: number;
   skip?: number;
   cursor?: Partial<Gassma${schemaName}${sheetName}Use>;

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -30,7 +30,7 @@ const getOneGassmaFindData = (
 
   return `\nexport type Gassma${schemaName}${sheetName}FindData = {
   where?: Gassma${schemaName}${sheetName}WhereUse;
-  orderBy?: Gassma${schemaName}${sheetName}OrderBy;
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[];
   take?: number;
   skip?: number;
   distinct?: ${distinctData}(${distinctArrayData})[];

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindFirstData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindFirstData.ts
@@ -4,7 +4,7 @@ const getOneGassmaFindFirstData = (schemaName: string, sheetName: string) => {
 
   return `\nexport type Gassma${schemaName}${sheetName}FindFirstData = {
   where?: Gassma${schemaName}${sheetName}WhereUse;
-  orderBy?: Gassma${schemaName}${sheetName}OrderBy;
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[];
   include?: Gassma${schemaName}${sheetName}Include;
   cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
   _count?: Gassma${schemaName}${sheetName}CountValue;

--- a/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
@@ -19,7 +19,7 @@ const getRelationFields = (
     const targetWhere = `Gassma${schemaName}${rel.to}WhereUse`;
     const filterType = isListRelation(rel.type)
       ? `{ some?: ${targetWhere}; every?: ${targetWhere}; none?: ${targetWhere} }`
-      : `{ is?: ${targetWhere}; isNot?: ${targetWhere} }`;
+      : `{ is?: ${targetWhere} | null; isNot?: ${targetWhere} | null }`;
 
     return `${pre}  "${relationName}"?: ${filterType};\n`;
   }, "");


### PR DESCRIPTION
## Summary

網羅的型テスト整備の**第4弾（クエリ引数）**。当初「バグなし」としていましたが、**Fable レビューで生成型のバグ2件を発見・修正**しました。

### 経緯・教訓
最初の版は**生成型の現状を基準にテストを書いた**ため、生成型自体が間違っている箇所は素通りしていました。本来は **reference と本体 gassma の手書き型を正**として照合すべきで、Fable がそれを指摘。是正して2バグを TDD（Red→Green）で修正しました。

## 🔧 バグ1: `orderBy` が配列形式（複数キーソート）を受け付けない
- reference（findMany.md）は `orderBy: [{...}, {...}]` を明記（配列が本則）、本体型も `OrderBy | OrderBy[]`、**生成型のみ `OrderBy`**
- 修正: `oneGassmaFindData` / `FindFirstData` / `CountData` / `AggregateData` の4ファイルを `OrderBy | OrderBy[]` に

## 🔧 バグ2: relation single filter の `is` / `isNot` に null を渡せない
- reference（whereリレーションフィルタ.md）は `is: null` / `isNot: null`（FK が null のレコード検索）に独立節、本体型も `WhereUse | null`、**生成型のみ null なし**
- 修正: `oneGassmaWhereUse` を `is?: WhereUse | null; isNot?: WhereUse | null` に

## 追加テスト
- where.test-d.ts: 直接値 / FilterConditions / 文字列マッチ+mode / nullable の null / **非nullable の null 拒否** / AND・OR・NOT / relation filter(some/every/none/is/isNot) / **is・isNot null** / **nullable の equals・not: null** / **FieldRef 制約(not/in/notIn 不可)** / **enum・@ignore・Date の where** / **NOT配列・OR単体拒否** / **深いネスト** / FieldRef / count・delete・update 共通
- orderByCursorDistinct.test-d.ts: asc・desc / SortOrderInput / relation・_count ソート / 無効方向拒否 / **配列形式** / cursor / distinct(単一・配列) / 存在しないフィールド拒否 / take・skip

## Test plan
- [x] Red 確認（orderBy 配列・is/isNot null が修正前は型エラー）
- [x] reference・本体手書き型と生成型を一致させた
- [x] `npm run test:types`: 102 ファイル 496 テスト + Type Errors なし
- [x] 単体テスト（whereUse の is/isNot）追従
- [x] `@ts-expect-error` の空振りチェック（外すと Red）
- [x] `npm run typecheck` / `lint` / `build`: すべて OK

## 残（Fable 指摘・別途）
- to-many のフィールドソート / to-one の _count ソートが型を通る（実行時エラー仕様）→ **仕様確認要**
- cursor が `Partial<Use>` で非ユニークも通る → **仕様確認要**
- `updateManyAndReturn` の globalOmit 欠落 → **globalOmit 軸の PR で修正**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>