### PR TITLE
fix: globalOmit の型精度改善（updateManyAndReturn / include先 / 余剰キー拒否）+ 網羅テスト

### DIFF
--- a/src/__test__/generate/generator.test.ts
+++ b/src/__test__/generate/generator.test.ts
@@ -26,10 +26,10 @@ describe("generater", () => {
       "export type GassmaSheet<O extends GassmaGlobalOmitConfig = {}> = {",
     );
     expect(result).toContain(
-      '"User": GassmaUserController<O extends { "User": infer UO } ? UO extends GassmaUserOmit ? UO : {} : {}>;',
+      '"User": GassmaUserController<O extends { "User": infer UO } ? UO extends GassmaUserOmit ? UO : {} : {}, O>;',
     );
     expect(result).toContain(
-      '"Post": GassmaPostController<O extends { "Post": infer UO } ? UO extends GassmaPostOmit ? UO : {} : {}>;',
+      '"Post": GassmaPostController<O extends { "Post": infer UO } ? UO extends GassmaPostOmit ? UO : {} : {}, O>;',
     );
   });
 

--- a/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -18,9 +18,17 @@ describe("generateClientDts", () => {
     const result = generateClientDts("Hoge");
 
     expect(result).toContain(
-      "export interface GassmaClient<O extends GassmaHogeGlobalOmitConfig = {}> extends GassmaHogeSheet<O>",
+      "export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, GassmaHogeGlobalOmitConfig> = {}> extends GassmaHogeSheet<O>",
     );
     expect(result).not.toContain("readonly sheets");
+  });
+
+  it("should constrain class type parameter with StrictGlobalOmit to reject unknown keys", () => {
+    const result = generateClientDts("Hoge");
+
+    expect(result).toContain(
+      "export declare class GassmaClient<O extends Gassma.StrictGlobalOmit<O, GassmaHogeGlobalOmitConfig> = {}>",
+    );
   });
 
   it("should work with different schema names", () => {
@@ -29,7 +37,7 @@ describe("generateClientDts", () => {
     expect(result).toContain("export declare class GassmaClient");
     expect(result).toContain("options?: GassmaFugaClientOptions");
     expect(result).toContain(
-      "export interface GassmaClient<O extends GassmaFugaGlobalOmitConfig = {}> extends GassmaFugaSheet<O>",
+      "export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, GassmaFugaGlobalOmitConfig> = {}> extends GassmaFugaSheet<O>",
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -4,9 +4,9 @@ import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaCon
 describe("getOneGassmaController", () => {
   const result = getOneGassmaController("", "User");
 
-  it("should generate controller class declaration", () => {
+  it("should generate controller class declaration with GO and full omit config O", () => {
     expect(result).toContain(
-      "export declare class GassmaUserController<GO extends GassmaUserOmit = {}>",
+      "export declare class GassmaUserController<GO extends GassmaUserOmit = {}, O = {}>",
     );
   });
 
@@ -36,13 +36,13 @@ describe("getOneGassmaController", () => {
 
   it("should have generic delete method with model-specific type", () => {
     expect(result).toContain(
-      'delete<T extends GassmaUserDeleteSingleData>(deleteData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO> | null',
+      'delete<T extends GassmaUserDeleteSingleData>(deleteData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O> | null',
     );
   });
 
   it("should have generic upsert method with model-specific type", () => {
     expect(result).toContain(
-      'upsert<T extends GassmaUserUpsertSingleData>(upsertData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO>',
+      'upsert<T extends GassmaUserUpsertSingleData>(upsertData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O>',
     );
   });
 
@@ -54,7 +54,7 @@ describe("getOneGassmaController", () => {
 
   it("should include updateManyAndReturn method with globalOmit applied", () => {
     expect(result).toContain(
-      "updateManyAndReturn(updateData: GassmaUserUpdateData): GassmaUserFindResult<undefined, undefined, undefined, GO>[]",
+      "updateManyAndReturn(updateData: GassmaUserUpdateData): GassmaUserFindResult<undefined, undefined, undefined, GO, O>[]",
     );
   });
 
@@ -70,13 +70,13 @@ describe("getOneGassmaController", () => {
 
   it("should have generic create method with FindResult return", () => {
     expect(result).toContain(
-      'create<T extends GassmaUserCreateData>(createdData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO>',
+      'create<T extends GassmaUserCreateData>(createdData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O>',
     );
   });
 
   it("should have generic update method with model-specific type", () => {
     expect(result).toContain(
-      'update<T extends GassmaUserUpdateSingleData>(updateData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO> | null',
+      'update<T extends GassmaUserUpdateSingleData>(updateData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O> | null',
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -52,9 +52,9 @@ describe("getOneGassmaController", () => {
     );
   });
 
-  it("should include updateManyAndReturn method", () => {
+  it("should include updateManyAndReturn method with globalOmit applied", () => {
     expect(result).toContain(
-      "updateManyAndReturn(updateData: GassmaUserUpdateData): GassmaUserDefaultFindResult[]",
+      "updateManyAndReturn(updateData: GassmaUserUpdateData): GassmaUserFindResult<undefined, undefined, undefined, GO>[]",
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaFindResult.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindResult.test.ts
@@ -3,10 +3,10 @@ import { getOneGassmaFindResult } from "../../../generate/typeGenerate/gassmaFin
 import type { RelationsConfig } from "../../../generate/read/extractRelations";
 
 describe("getOneGassmaFindResult", () => {
-  it("should generate FindResult with 4 type parameters <S, I, QO, GO>", () => {
+  it("should generate FindResult with 5 type parameters <S, I, QO, GO, O>", () => {
     const result = getOneGassmaFindResult("", "User");
     expect(result).toContain(
-      "export type GassmaUserFindResult<S, I = undefined, QO = undefined, GO = {}>",
+      "export type GassmaUserFindResult<S, I = undefined, QO = undefined, GO = {}, O = {}>",
     );
   });
 
@@ -23,7 +23,7 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, {}>[]',
+      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O>[]',
     );
   });
 
@@ -40,7 +40,7 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "profile" ? GassmaProfileFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, {}> | null',
+      'K extends "profile" ? GassmaProfileFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Profile": infer TO } ? TO extends GassmaProfileOmit ? TO : {} : {}, O> | null',
     );
   });
 
@@ -57,7 +57,24 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "Post", relations);
     expect(result).toContain(
-      'K extends "author" ? GassmaUserFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, {}> | null',
+      'K extends "author" ? GassmaUserFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "User": infer TO } ? TO extends GassmaUserOmit ? TO : {} : {}, O> | null',
+    );
+  });
+
+  it("should pass target model globalOmit and full config to select-relation branches", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+    const result = getOneGassmaFindResult("", "User", relations);
+    expect(result).toContain(
+      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<S[K]>, Gassma.IncludeOf<S[K]>, Gassma.OmitOf<S[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O>[]',
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaMain.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaMain.test.ts
@@ -31,6 +31,14 @@ describe("getGassmaMain", () => {
     expect(result).toContain("omit?: O");
   });
 
+  it("should constrain GassmaClientOptions omit with StrictGlobalOmit to reject unknown keys", () => {
+    const result = getGassmaMain(["User", "Post"], "Test");
+
+    expect(result).toContain(
+      "export type GassmaTestClientOptions<O extends Gassma.StrictGlobalOmit<O, GassmaTestGlobalOmitConfig> = {}>",
+    );
+  });
+
   it("should generate GassmaGlobalOmitConfig with model-specific omit", () => {
     const result = getGassmaMain(["User", "Post"], "Test");
 
@@ -60,6 +68,13 @@ describe("getGassmaMain", () => {
     expect(result).toContain("type NumberOperation =");
     expect(result).toContain("type ManyReturn =");
     expect(result).toContain("type SortOrderInput =");
+  });
+
+  it("should include ExactKeys and StrictGlobalOmit in common types", () => {
+    const result = getGassmaMain(["User"], "");
+
+    expect(result).toContain("type ExactKeys<T, Shape> =");
+    expect(result).toContain("type StrictGlobalOmit<O, Config> =");
   });
 
   it("should exclude common types when includeCommon is false", () => {

--- a/src/__test__/generate/typeGenerate/gassmaSheet.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaSheet.test.ts
@@ -9,10 +9,10 @@ describe("getGassmaSheet", () => {
       "export type GassmaSheet<O extends GassmaGlobalOmitConfig = {}> = {",
     );
     expect(result).toContain(
-      '"User": GassmaUserController<O extends { "User": infer UO } ? UO extends GassmaUserOmit ? UO : {} : {}>;',
+      '"User": GassmaUserController<O extends { "User": infer UO } ? UO extends GassmaUserOmit ? UO : {} : {}, O>;',
     );
     expect(result).toContain(
-      '"Post": GassmaPostController<O extends { "Post": infer UO } ? UO extends GassmaPostOmit ? UO : {} : {}>;',
+      '"Post": GassmaPostController<O extends { "Post": infer UO } ? UO extends GassmaPostOmit ? UO : {} : {}, O>;',
     );
     expect(result).toContain("};");
   });
@@ -21,7 +21,7 @@ describe("getGassmaSheet", () => {
     const result = getGassmaSheet(["my-sheet"], "");
 
     expect(result).toContain(
-      '"my-sheet": GassmamysheetController<O extends { "my-sheet": infer UO } ? UO extends GassmamysheetOmit ? UO : {} : {}>;',
+      '"my-sheet": GassmamysheetController<O extends { "my-sheet": infer UO } ? UO extends GassmamysheetOmit ? UO : {} : {}, O>;',
     );
   });
 

--- a/src/__test__/types/read/globalOmit.test-d.ts
+++ b/src/__test__/types/read/globalOmit.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from "vitest";
-import type { GassmaClient } from "../__generated__/client";
+import { GassmaClient } from "../__generated__/client";
 
 declare const client: GassmaClient;
 declare const clientOmit: GassmaClient<{
@@ -9,6 +9,41 @@ declare const clientOmit: GassmaClient<{
 
 // @ts-expect-error モデルに存在しないフィールドのみの globalOmit 設定は拒否される
 declare const badOmitClient: GassmaClient<{ User: { nonexistent: true } }>;
+
+// @ts-expect-error 既知フィールドと混在していても未知フィールドは拒否される
+declare const mixedBadOmitClient: GassmaClient<{
+  User: { email: true; typo: true };
+}>;
+
+// @ts-expect-error 未知モデル名は既知モデルと混在していても拒否される
+declare const unknownModelOmitClient: GassmaClient<{
+  User: { email: true };
+  Nope: { id: true };
+}>;
+
+// 既知フィールドのみの設定は通る（true / false / 混在・複数モデル・空）
+declare const okOmitTrue: GassmaClient<{ User: { email: true } }>;
+declare const okOmitFalse: GassmaClient<{ User: { email: false } }>;
+declare const okOmitMixed: GassmaClient<{
+  User: { email: true; name: false };
+}>;
+declare const okOmitMultiModel: GassmaClient<{
+  User: { email: true };
+  Post: { content: true };
+}>;
+declare const okOmitEmptyModel: GassmaClient<{ User: {} }>;
+declare const okOmitEmpty: GassmaClient<{}>;
+
+// コンストラクタの型推論経路でも同様に判定される
+{
+  const okCtor = new GassmaClient({ omit: { User: { email: true } } });
+  okCtor;
+  const ngCtor = new GassmaClient({
+    // @ts-expect-error コンストラクタの omit でも未知フィールドは拒否される
+    omit: { User: { email: true, typo: true } },
+  });
+  ngCtor;
+}
 
 // 複数モデル同時指定: 各モデルへ独立に適用される
 {
@@ -153,9 +188,9 @@ declare const badOmitClient: GassmaClient<{ User: { nonexistent: true } }>;
   expectTypeOf<P["id"]>().toEqualTypeOf<number>();
 }
 
-// include と併用してもトップレベルにはグローバル omit が効く
-// NOTE: ランタイムは include 先にも各モデルの globalOmit を適用するが、
-// 生成型は未反映（要設計判断のため本テストでは include 先を検証しない）
+// include 先レコードにも関連モデル自身の globalOmit が効く
+// （ランタイムは include 先を関連モデルの findMany で取得するため、
+//   関連モデルの globalOmit がそのまま適用される）
 {
   const u = clientOmit.User.findFirst({
     where: { id: 1 },
@@ -164,7 +199,66 @@ declare const badOmitClient: GassmaClient<{ User: { nonexistent: true } }>;
   type U = NonNullable<typeof u>;
   expectTypeOf<U>().not.toHaveProperty("email");
   expectTypeOf<U["posts"]>().toBeArray();
-  expectTypeOf<U["posts"][number]["title"]>().toEqualTypeOf<string>();
+  type P = U["posts"][number];
+  expectTypeOf<P>().not.toHaveProperty("content");
+  expectTypeOf<P["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<P["id"]>().toEqualTypeOf<number>();
+}
+
+// 複数モデル globalOmit + include: 各 include 先へ独立に効く
+{
+  const p = clientOmit.Post.findFirst({
+    where: { id: 1 },
+    include: { author: true, tags: true },
+  });
+  type P = NonNullable<typeof p>;
+  expectTypeOf<P>().not.toHaveProperty("content");
+  type A = NonNullable<P["author"]>;
+  expectTypeOf<A>().not.toHaveProperty("email");
+  expectTypeOf<A["name"]>().toEqualTypeOf<string | null>();
+  expectTypeOf<P["tags"][number]["name"]>().toEqualTypeOf<string>();
+}
+
+// globalOmit 未設定モデルの include 先には影響しない
+{
+  const u = client.User.findFirst({
+    where: { id: 1 },
+    include: { posts: true },
+  });
+  type P = NonNullable<typeof u>["posts"][number];
+  expectTypeOf<P["content"]>().toEqualTypeOf<string | number | null>();
+}
+
+// ネスト include: 2段先のモデルにも各モデルの globalOmit が効く
+declare const clientOmitNested: GassmaClient<{
+  Post: { published: true };
+  Tag: { name: true };
+}>;
+{
+  const u = clientOmitNested.User.findFirst({
+    where: { id: 1 },
+    include: { posts: { include: { tags: true } } },
+  });
+  type U = NonNullable<typeof u>;
+  expectTypeOf<U["email"]>().toEqualTypeOf<string>();
+  type P = U["posts"][number];
+  expectTypeOf<P>().not.toHaveProperty("published");
+  expectTypeOf<P["content"]>().toEqualTypeOf<string | number | null>();
+  type T = P["tags"][number];
+  expectTypeOf<T>().not.toHaveProperty("name");
+  expectTypeOf<T["id"]>().toEqualTypeOf<number>();
+}
+
+// include-level omit は include 先の globalOmit へ追加でマージされる
+{
+  const u = clientOmit.User.findFirst({
+    where: { id: 1 },
+    include: { posts: { omit: { title: true } } },
+  });
+  type P = NonNullable<typeof u>["posts"][number];
+  expectTypeOf<P>().not.toHaveProperty("content");
+  expectTypeOf<P>().not.toHaveProperty("title");
+  expectTypeOf<P["id"]>().toEqualTypeOf<number>();
 }
 
 // aggregate / groupBy / count には効かない（本体は集計結果に omit を適用しない）

--- a/src/__test__/types/read/globalOmit.test-d.ts
+++ b/src/__test__/types/read/globalOmit.test-d.ts
@@ -36,13 +36,11 @@ declare const okOmitEmpty: GassmaClient<{}>;
 
 // コンストラクタの型推論経路でも同様に判定される
 {
-  const okCtor = new GassmaClient({ omit: { User: { email: true } } });
-  okCtor;
-  const ngCtor = new GassmaClient({
+  void new GassmaClient({ omit: { User: { email: true } } });
+  void new GassmaClient({
     // @ts-expect-error コンストラクタの omit でも未知フィールドは拒否される
     omit: { User: { email: true, typo: true } },
   });
-  ngCtor;
 }
 
 // 複数モデル同時指定: 各モデルへ独立に適用される

--- a/src/__test__/types/read/globalOmit.test-d.ts
+++ b/src/__test__/types/read/globalOmit.test-d.ts
@@ -1,0 +1,180 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+declare const clientOmit: GassmaClient<{
+  User: { email: true };
+  Post: { content: true };
+}>;
+
+// @ts-expect-error モデルに存在しないフィールドのみの globalOmit 設定は拒否される
+declare const badOmitClient: GassmaClient<{ User: { nonexistent: true } }>;
+
+// 複数モデル同時指定: 各モデルへ独立に適用される
+{
+  const u = clientOmit.User.findFirst({ where: { id: 1 } });
+  type U = NonNullable<typeof u>;
+  expectTypeOf<U>().not.toHaveProperty("email");
+  expectTypeOf<U["name"]>().toEqualTypeOf<string | null>();
+
+  const p = clientOmit.Post.findFirst({ where: { id: 1 } });
+  type P = NonNullable<typeof p>;
+  expectTypeOf<P>().not.toHaveProperty("content");
+  expectTypeOf<P["title"]>().toEqualTypeOf<string>();
+}
+
+// 指定していないモデルには影響しない
+{
+  const t = clientOmit.Tag.findFirst({ where: { id: 1 } });
+  expectTypeOf<NonNullable<typeof t>["name"]>().toEqualTypeOf<string>();
+}
+
+// 入力側（where / data）には影響しない: 除外フィールドも条件・更新値に使える
+{
+  clientOmit.User.findFirst({ where: { email: "a@example.com" } });
+  clientOmit.User.update({
+    where: { id: 1 },
+    data: { email: "b@example.com" },
+  });
+}
+
+// create の戻り値に効く
+{
+  const r = clientOmit.User.create({
+    data: { email: "a@example.com", score: 0 },
+  });
+  expectTypeOf<typeof r>().not.toHaveProperty("email");
+  expectTypeOf<(typeof r)["name"]>().toEqualTypeOf<string | null>();
+}
+
+// update の戻り値に効く
+{
+  const r = clientOmit.User.update({ where: { id: 1 }, data: { name: "x" } });
+  expectTypeOf<NonNullable<typeof r>>().not.toHaveProperty("email");
+}
+
+// upsert の戻り値に効く
+{
+  const r = clientOmit.User.upsert({
+    where: { id: 1 },
+    create: { email: "a@example.com", score: 0 },
+    update: { name: "x" },
+  });
+  expectTypeOf<typeof r>().not.toHaveProperty("email");
+}
+
+// delete の戻り値に効く
+{
+  const r = clientOmit.User.delete({ where: { id: 1 } });
+  expectTypeOf<NonNullable<typeof r>>().not.toHaveProperty("email");
+}
+
+// createManyAndReturn の戻り値に効く
+{
+  const r = clientOmit.User.createManyAndReturn({
+    data: [{ email: "a@example.com", score: 0 }],
+  });
+  expectTypeOf<(typeof r)[number]>().not.toHaveProperty("email");
+  expectTypeOf<(typeof r)[number]["id"]>().toEqualTypeOf<number>();
+}
+
+// updateManyAndReturn の戻り値に効く（複数モデルとも）
+{
+  const r = clientOmit.User.updateManyAndReturn({ data: { isActive: false } });
+  expectTypeOf<typeof r>().toBeArray();
+  expectTypeOf<(typeof r)[number]>().not.toHaveProperty("email");
+  expectTypeOf<(typeof r)[number]["isActive"]>().toEqualTypeOf<boolean>();
+
+  const p = clientOmit.Post.updateManyAndReturn({ data: { published: true } });
+  expectTypeOf<(typeof p)[number]>().not.toHaveProperty("content");
+  expectTypeOf<(typeof p)[number]["title"]>().toEqualTypeOf<string>();
+}
+
+// updateManyAndReturn: 除外フィールドへのアクセスはエラー
+{
+  const r = clientOmit.User.updateManyAndReturn({ data: { isActive: false } });
+  // @ts-expect-error email はグローバル omit で除外される
+  r[0].email;
+}
+
+// globalOmit なしの client では updateManyAndReturn は全フィールドを返す
+{
+  const r = client.User.updateManyAndReturn({ data: { isActive: false } });
+  expectTypeOf<(typeof r)[number]["email"]>().toEqualTypeOf<string>();
+}
+
+// createMany / updateMany / deleteMany（{ count } 戻り）には影響しない
+{
+  const cm = clientOmit.User.createMany({
+    data: [{ email: "a@example.com", score: 0 }],
+  });
+  expectTypeOf<typeof cm>().toEqualTypeOf<{ count: number }>();
+
+  const um = clientOmit.User.updateMany({ data: { isActive: false } });
+  expectTypeOf<typeof um>().toEqualTypeOf<{ count: number }>();
+
+  const dm = clientOmit.User.deleteMany({ where: {} });
+  expectTypeOf<typeof dm>().toEqualTypeOf<{ count: number }>();
+}
+
+// select 指定時はグローバル omit を無視（write 系）
+{
+  const d = clientOmit.User.delete({
+    where: { id: 1 },
+    select: { email: true },
+  });
+  expectTypeOf<NonNullable<typeof d>["email"]>().toEqualTypeOf<string>();
+
+  const cs = clientOmit.User.createManyAndReturn({
+    data: [{ email: "a@example.com", score: 0 }],
+    select: { email: true },
+  });
+  expectTypeOf<(typeof cs)[number]["email"]>().toEqualTypeOf<string>();
+}
+
+// クエリ omit: false で解除・true で追加除外（write 系）
+{
+  const r = clientOmit.User.update({
+    where: { id: 1 },
+    data: { name: "x" },
+    omit: { email: false, name: true },
+  });
+  type R = NonNullable<typeof r>;
+  expectTypeOf<R["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<R>().not.toHaveProperty("name");
+}
+
+// クエリ omit: true でグローバル omit に追加除外（read 系・複数モデル）
+{
+  const p = clientOmit.Post.findMany({ where: {}, omit: { title: true } });
+  type P = (typeof p)[number];
+  expectTypeOf<P>().not.toHaveProperty("content");
+  expectTypeOf<P>().not.toHaveProperty("title");
+  expectTypeOf<P["id"]>().toEqualTypeOf<number>();
+}
+
+// include と併用してもトップレベルにはグローバル omit が効く
+// NOTE: ランタイムは include 先にも各モデルの globalOmit を適用するが、
+// 生成型は未反映（要設計判断のため本テストでは include 先を検証しない）
+{
+  const u = clientOmit.User.findFirst({
+    where: { id: 1 },
+    include: { posts: true },
+  });
+  type U = NonNullable<typeof u>;
+  expectTypeOf<U>().not.toHaveProperty("email");
+  expectTypeOf<U["posts"]>().toBeArray();
+  expectTypeOf<U["posts"][number]["title"]>().toEqualTypeOf<string>();
+}
+
+// aggregate / groupBy / count には効かない（本体は集計結果に omit を適用しない）
+{
+  const a = clientOmit.User.aggregate({ _min: { email: true } });
+  expectTypeOf<(typeof a)["_min"]["email"]>().toEqualTypeOf<string | null>();
+
+  const g = clientOmit.User.groupBy({ by: ["email"] });
+  expectTypeOf<(typeof g)[number]["email"]>().toEqualTypeOf<string>();
+
+  const c = clientOmit.User.count({});
+  expectTypeOf<typeof c>().toEqualTypeOf<number>();
+}

--- a/src/generate/jsGenerate/generateClientDts.ts
+++ b/src/generate/jsGenerate/generateClientDts.ts
@@ -1,8 +1,8 @@
 import type { EnumsConfig } from "../read/extractEnums";
 
 const generateClientDts = (schemaName: string, enums?: EnumsConfig): string => {
-  let result = `export interface GassmaClient<O extends Gassma${schemaName}GlobalOmitConfig = {}> extends Gassma${schemaName}Sheet<O> {}
-export declare class GassmaClient<O extends Gassma${schemaName}GlobalOmitConfig = {}> {
+  let result = `export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> extends Gassma${schemaName}Sheet<O> {}
+export declare class GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> {
   constructor(options?: Gassma${schemaName}ClientOptions<O>);
 }
 `;

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -17,6 +17,13 @@ const getGassmaCommonTypes = () => {
   type FalseKeys<T> = { [K in keyof T]: T[K] extends false ? K : never }[keyof T];
   type ResolveOmitKeys<GO, QO> = Exclude<TrueKeys<GO>, FalseKeys<QO>> | TrueKeys<QO>;
 
+  type ExactKeys<T, Shape> = Shape & { [K in Exclude<keyof T, keyof Shape>]?: never };
+  type StrictGlobalOmit<O, Config> = Config & {
+    [K in keyof O]?: K extends keyof Config
+      ? ExactKeys<NonNullable<O[K]>, NonNullable<Config[K]>>
+      : never;
+  };
+
   type SelectOf<X> = X extends { select: infer S } ? S : undefined;
   type IncludeOf<X> = X extends { include: infer I } ? I : undefined;
   type OmitOf<X> = X extends { omit: infer O } ? O : undefined;

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -18,7 +18,7 @@ export declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma
   findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO>[];
   update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): ${fr}<T["select"], T["include"], T["omit"], GO> | null;
   updateMany(updateData: Gassma${schemaName}${sheetName}UpdateData): UpdateManyReturn;
-  updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): Gassma${schemaName}${sheetName}DefaultFindResult[];
+  updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): ${fr}<undefined, undefined, undefined, GO>[];
   upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): ${fr}<T["select"], T["include"], T["omit"], GO>;
   delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): ${fr}<T["select"], T["include"], T["omit"], GO> | null;
   deleteMany(deleteData: Gassma${schemaName}${sheetName}DeleteData): DeleteManyReturn;

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -1,7 +1,7 @@
 const getOneGassmaController = (schemaName: string, sheetName: string) => {
   const fr = `Gassma${schemaName}${sheetName}FindResult`;
   return `
-export declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma${schemaName}${sheetName}Omit = {}> {
+export declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma${schemaName}${sheetName}Omit = {}, O = {}> {
   constructor(sheetName: string, id?: string);
 
   readonly fields: Record<string, Gassma.FieldRef>;
@@ -11,16 +11,16 @@ export declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma
     endColumnNumber: number
   ): void;
   createMany(createdData: Gassma${schemaName}${sheetName}CreateManyData): CreateManyReturn;
-  createManyAndReturn<T extends Gassma${schemaName}${sheetName}CreateManyAndReturnData>(createdData: T): ${fr}<T["select"], T["include"], T["omit"], GO>[];
-  create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): ${fr}<T["select"], T["include"], T["omit"], GO>;
-  findFirst<T extends Gassma${schemaName}${sheetName}FindFirstData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO> | null;
-  findFirstOrThrow<T extends Gassma${schemaName}${sheetName}FindFirstData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO>;
-  findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO>[];
-  update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): ${fr}<T["select"], T["include"], T["omit"], GO> | null;
+  createManyAndReturn<T extends Gassma${schemaName}${sheetName}CreateManyAndReturnData>(createdData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>[];
+  create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>;
+  findFirst<T extends Gassma${schemaName}${sheetName}FindFirstData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O> | null;
+  findFirstOrThrow<T extends Gassma${schemaName}${sheetName}FindFirstData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>;
+  findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>[];
+  update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O> | null;
   updateMany(updateData: Gassma${schemaName}${sheetName}UpdateData): UpdateManyReturn;
-  updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): ${fr}<undefined, undefined, undefined, GO>[];
-  upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): ${fr}<T["select"], T["include"], T["omit"], GO>;
-  delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): ${fr}<T["select"], T["include"], T["omit"], GO> | null;
+  updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): ${fr}<undefined, undefined, undefined, GO, O>[];
+  upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>;
+  delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O> | null;
   deleteMany(deleteData: Gassma${schemaName}${sheetName}DeleteData): DeleteManyReturn;
   aggregate<T extends Gassma${schemaName}${sheetName}AggregateData>(aggregateData: T): Gassma${schemaName}${sheetName}AggregateResult<T>;
   count(coutData: Gassma${schemaName}${sheetName}CountData): number;

--- a/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -20,7 +20,8 @@ const getOneGassmaFindResult = (
       .map((relationName) => {
         const def = modelRelations[relationName];
         const targetFR = `${prefix}${def.to}FindResult`;
-        const inner = `${targetFR}<Gassma.SelectOf<${source}[K]>, Gassma.IncludeOf<${source}[K]>, Gassma.OmitOf<${source}[K]>, {}>`;
+        const targetGO = `O extends { "${def.to}": infer TO } ? TO extends ${prefix}${def.to}Omit ? TO : {} : {}`;
+        const inner = `${targetFR}<Gassma.SelectOf<${source}[K]>, Gassma.IncludeOf<${source}[K]>, Gassma.OmitOf<${source}[K]>, ${targetGO}, O>`;
         const isList = def.type === "oneToMany" || def.type === "manyToMany";
         const result = isList ? `${inner}[]` : `${inner} | null`;
         return `          K extends "${relationName}" ? ${result} :`;
@@ -58,7 +59,7 @@ ${includeBranches}
       })`;
 
   return `
-export type ${self}FindResult<S, I = undefined, QO = undefined, GO = {}> = ${baseResult} &
+export type ${self}FindResult<S, I = undefined, QO = undefined, GO = {}, O = {}> = ${baseResult} &
   ${includePart};
 `;
 };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -23,7 +23,7 @@ const getGassmaGlobalOmitConfig = (
 };
 
 const getGassmaClientOptions = (schemaName: string) => {
-  return `export type Gassma${schemaName}ClientOptions<O extends Gassma${schemaName}GlobalOmitConfig = {}> = {
+  return `export type Gassma${schemaName}ClientOptions<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> = {
   id?: string;
   relations?: Gassma.RelationsConfig;
   omit?: O;

--- a/src/generate/typeGenerate/gassmaSheet.ts
+++ b/src/generate/typeGenerate/gassmaSheet.ts
@@ -4,7 +4,7 @@ const getGassmaSheet = (sheetNames: string[], schemaName: string) => {
   const sheetTypeDeclare = sheetNames.reduce((pre, current) => {
     const clean = getRemovedCantUseVarChar(current);
 
-    return `${pre}  "${current}": Gassma${schemaName}${clean}Controller<O extends { "${current}": infer UO } ? UO extends Gassma${schemaName}${clean}Omit ? UO : {} : {}>;\n`;
+    return `${pre}  "${current}": Gassma${schemaName}${clean}Controller<O extends { "${current}": infer UO } ? UO extends Gassma${schemaName}${clean}Omit ? UO : {} : {}, O>;\n`;
   }, `export type Gassma${schemaName}Sheet<O extends Gassma${schemaName}GlobalOmitConfig = {}> = {\n`);
 
   return sheetTypeDeclare + "};\n";


### PR DESCRIPTION
## Summary

網羅的型テスト整備の**最終軸（globalOmit）**。Fable レビューで判明した globalOmit 関連の型バグ3件を修正し、網羅テストを追加。reference・本体実挙動を正として TDD で修正。**公開型シェイプの変更を含むが、後方互換を実シナリオで検証済み**。

## 🔧 修正1: `updateManyAndReturn` が globalOmit を無視
- 生成型は `DefaultFindResult[]`（GO 不使用）、本体は `applyOmitToResult(stripped, this.globalOmit)` で適用、reference も `updateManyAndReturn → ✅`。`createManyAndReturn` は反映済みなのにここだけ不整合
- `oneGassmaController.ts` の戻り値を `FindResult<undefined, undefined, undefined, GO>[]` に

## 🔧 修正2: include 先リレーションに globalOmit が型反映されない
- 本体はランタイムで include 先にも**関連モデル自身の globalOmit** を適用（resolver → 関連モデル controller の findMany → findManyRaw で resolveGlobalOmit）。**ネストも再帰適用**
- 生成型は FindResult の include ブランチで GO を `{}` 固定していたため未反映
- **設計**: FindResult に第5型引数 `O`（全モデル分の GlobalOmitConfig）を追加し、各リレーション先に `O[モデル名]` を GO として渡す。O 自体も再帰スレッディングでネスト先に伝播。Controller に第2型引数 O、GassmaSheet が client の O を配布
- **後方互換**: 全型引数デフォルト `{}` 付き末尾追加。globalOmit 未使用なら従来と同型（実シナリオで検証: `new GassmaClient()` の include 先が壊れない）

```ts
const co = new GassmaClient({ omit: { Post: { content: true } } });
const u = co.User.findFirst({ include: { posts: true } });
u.posts[0].content;  // ✅ 修正後: 型エラー（include 先でも content が消える）
```

## 🔧 修正3: GlobalOmitConfig の余剰（未知）キー拒否が「全キー未知の場合のみ」
- 各モデルの Omit が全 optional の weak type で、既知キー混在時に未知キーが素通り（`{ email: true, typo: true }` の `typo` が通ってしまう）
- `gassmaCommonTypes` に `ExactKeys` / `StrictGlobalOmit` を追加、`GassmaClient` / `GassmaClientOptions` の制約を F-bounded な Exact 検査に。モデル名レベルの未知キーも拒否、コンストラクタ推論経路でも拒否
- `true | false` 両受け・空設定・複数モデルの正常系は非破壊

## 追加テスト `types/read/globalOmit.test-d.ts`
- 複数モデル同時 / 入力側非影響 / write 系戻り値（**updateManyAndReturn** 含む）/ `{count}`系非影響 / select 無効化 / クエリ omit の false 解除・true 追加 / 集計系非影響
- **include 先反映**（単一 / 複数モデル / **ネスト2段**）
- **余剰キー拒否**（フィールド / モデル名 / コンストラクタ経路、`@ts-expect-error`）

## Test plan
- [x] Red 確認（各バグとも修正前は型と実挙動が乖離）
- [x] reference・本体実挙動・本体単体テストを正として照合
- [x] `npm run test:types`: 106 ファイル 512 テスト + Type Errors なし
- [x] **後方互換を実シナリオで独立検証**（globalOmit なしで include 先が壊れない / あり で消える / 余剰キー拒否）
- [x] `@ts-expect-error` の空振りチェック（外すと Red）
- [x] `npm run typecheck` / `lint` / `format:check` / `build`: すべて OK

## Fable が報告した本体側の乖離（tasks.md に本体タスクとして記録済み）
- create/update 等の「include + クエリ omit 併用」で globalOmit マージ漏れ・`omit:{field:false}` が解除でなく除外に。reference と矛盾 → **本体修正が必要**
- include 内 select で globalOmit 対象を指定するとランタイムは undefined（型は reference のトップレベル規則に準拠）
- FK フィールド自体を globalOmit すると resolver がグルーピングできず include 結果が空になる恐れ（型では防御不能）

## 網羅テスト整備 完了（全7軸）
| 軸 | 結果 |
|---|---|
| @default / スカラー / select / write / クエリ引数 / 集計系 / globalOmit | **バグ計10件修正** + 本体タスク3件切り出し |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>