### PR TITLE
fix: extract enum-value @default (was silently dropped)

### DIFF
--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -113,6 +113,21 @@ describe("generateClientJs", () => {
     expect(result).toContain("defaults: testDefaults");
   });
 
+  it("should embed enum defaults as mapped static string values", () => {
+    const defaults: DefaultsConfig = {
+      Member: {
+        role: { kind: "static", value: "ADMIN" },
+        status: { kind: "static", value: "ACTIVE" },
+      },
+    };
+
+    const result = generateClientJs({}, "Test", defaults);
+
+    expect(result).toContain('"role": "ADMIN"');
+    expect(result).toContain('"status": "ACTIVE"');
+    expect(result).toContain("defaults: testDefaults");
+  });
+
   it("should embed now() as () => new Date()", () => {
     const defaults: DefaultsConfig = {
       User: { createdAt: { kind: "function", name: "now" } },

--- a/src/__test__/generate/read/extractDefaults.test.ts
+++ b/src/__test__/generate/read/extractDefaults.test.ts
@@ -135,4 +135,78 @@ model User {
       User: { role: { kind: "static", value: "USER" } },
     });
   });
+
+  it("should extract enum default as member name when enum has no @map", () => {
+    const schema = `
+enum Role {
+  ADMIN
+  USER
+}
+
+model Member {
+  id   Int  @id
+  role Role @default(ADMIN)
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      Member: { role: { kind: "static", value: "ADMIN" } },
+    });
+  });
+
+  it("should extract enum default as mapped value when enum member has @map", () => {
+    const schema = `
+enum Status {
+  active   @map("ACTIVE")
+  archived @map("ARCHIVED")
+}
+
+model Member {
+  id     Int    @id
+  status Status @default(active)
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      Member: { status: { kind: "static", value: "ACTIVE" } },
+    });
+  });
+
+  it("should extract enum default on optional field", () => {
+    const schema = `
+enum Role {
+  ADMIN
+  USER
+}
+
+model Member {
+  id   Int   @id
+  role Role? @default(USER)
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({
+      Member: { role: { kind: "static", value: "USER" } },
+    });
+  });
+
+  it("should skip path default that does not reference a known enum member", () => {
+    const schema = `
+enum Role {
+  ADMIN
+  USER
+}
+
+model Member {
+  id   Int  @id
+  role Role @default(UNKNOWN)
+}
+`;
+    const result = extractDefaults(schema);
+
+    expect(result).toEqual({});
+  });
 });

--- a/src/__test__/types/fixtures/schema.prisma
+++ b/src/__test__/types/fixtures/schema.prisma
@@ -86,8 +86,8 @@ enum Status {
 /// enum・@updatedAt・@map・@@map・@ignore・replaceType の検証用
 model Member {
   id        Int      @id @default(autoincrement())
-  role      Role
-  status    Status
+  role      Role     @default(USER)
+  status    Status   @default(active)
   firstName String   @map("名前")
   secret    String   @ignore
   /// @gassma.replaceType "small", "large"

--- a/src/__test__/types/write/inputScalar.test-d.ts
+++ b/src/__test__/types/write/inputScalar.test-d.ts
@@ -46,15 +46,26 @@ declare const client: GassmaClient;
   >();
 }
 
-// enum / replaceType は入力型でもリテラルユニオン
+// enum / replaceType は入力型でもリテラルユニオン（enum @default あり → 省略可）
 {
   expectTypeOf<GassmaMemberUse["role"]>().toEqualTypeOf<
-    "ADMIN" | "USER" | "MODERATOR"
+    "ADMIN" | "USER" | "MODERATOR" | undefined
   >();
   expectTypeOf<GassmaMemberUse["status"]>().toEqualTypeOf<
-    "ACTIVE" | "ARCHIVED"
+    "ACTIVE" | "ARCHIVED" | undefined
   >();
   expectTypeOf<GassmaMemberUse["size"]>().toEqualTypeOf<"small" | "large">();
+}
+
+// enum @default: create で role / status を省略でき、結果は非 null
+{
+  const r = client.Member.create({
+    data: { firstName: "田中", size: "small" },
+  });
+  expectTypeOf<(typeof r)["role"]>().toEqualTypeOf<
+    "ADMIN" | "USER" | "MODERATOR"
+  >();
+  expectTypeOf<(typeof r)["status"]>().toEqualTypeOf<"ACTIVE" | "ARCHIVED">();
 }
 
 // @ignore は入力型からも除外される

--- a/src/generate/read/extractDefaults.ts
+++ b/src/generate/read/extractDefaults.ts
@@ -1,5 +1,8 @@
 import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import type { FieldDeclaration } from "@loancrate/prisma-schema-parser";
 import { findDefaultFieldAttribute } from "@loancrate/prisma-schema-parser/dist/attributes";
+import { extractEnums } from "./extractEnums";
+import type { EnumsConfig } from "./extractEnums";
 
 type StaticDefault = {
   kind: "static";
@@ -21,8 +24,31 @@ type DefaultsConfig = {
 
 const SKIP_FUNCTIONS = ["autoincrement"];
 
+const resolveFieldTypeName = (field: FieldDeclaration): string | undefined => {
+  const { type } = field;
+  if (type.kind === "list") return undefined;
+  const baseType =
+    type.kind === "optional" || type.kind === "required" ? type.type : type;
+  if (baseType.kind === "unsupported") return undefined;
+  return baseType.name.value;
+};
+
+const resolveEnumValue = (
+  field: FieldDeclaration,
+  valueName: string,
+  enums: EnumsConfig,
+): string | undefined => {
+  const typeName = resolveFieldTypeName(field);
+  if (!typeName) return undefined;
+  const entries = enums[typeName];
+  if (!entries) return undefined;
+  const entry = entries.find((e) => e.name === valueName);
+  return entry?.value;
+};
+
 const extractDefaults = (schemaText: string): DefaultsConfig => {
   const ast = parsePrismaSchema(schemaText);
+  const enums = extractEnums(schemaText);
   const result: DefaultsConfig = {};
 
   ast.declarations.forEach((decl) => {
@@ -43,6 +69,13 @@ const extractDefaults = (schemaText: string): DefaultsConfig => {
           kind: "static",
           value: expr.value,
         };
+        return;
+      }
+
+      if (expr.kind === "path") {
+        const value = resolveEnumValue(member, expr.value[0], enums);
+        if (value === undefined) return;
+        modelDefaults[member.name.value] = { kind: "static", value };
         return;
       }
 


### PR DESCRIPTION
## 概要

enum 値の `@default`（`@default(ADMIN)` / `@default(active)`）が**生成される runtime defaults に反映されない**バグを修正しました。

`#88` の Fable レビューで確定した enum @default 抽出漏れ（finding ②）への対応です。

## 根本原因

`extractDefaults.ts` は default 式の `literal` と `functionCall` しか処理せず、enum 値参照（パーサでは `PathExpression`, `kind: "path"`）を**黙って捨てて**いました。その結果:

- runtime defaults JS に enum default が乗らず、**未指定 create 時に本体が null を格納**。
- 一方で型は非 null を約束（`extractOptionalFields` が `@default` の存在で omittable 判定し Use は `"role"?`、CreateReturn は非 null）。
- → **型（非 null）と runtime（null）が乖離**。

## 修正

`expr.kind === "path"` を処理し、参照された enum member を **runtime 格納値（@map 適用後）** に解決して static default として出力します。

- `@default(active)`（`active @map("ACTIVE")`）→ `"ACTIVE"`
- `@default(USER)`（@map 無し）→ `"USER"`
- 解決は `EnumsConfig`（`extractEnums`）経由。`extractDefaults` が内部で `extractEnums` を呼ぶ（`prismaReader` の既存前例に倣う）ため、呼び出し元の配線変更は不要。
- `as` 不使用（kind narrowing のみ）。

裏取り: パーサ AST は enum 値参照＝`PathExpression`、格納値＝@map 後（reference『型ファイルの動的生成.md』「型定義には @map の値が使用されます」と一致）。本体に enum 変換層は無く defaults を verbatim 適用。

## テスト

- `extractDefaults`: @map 無し→member 名、@map 有り→@map 値、optional、未知 path スキップ。
- `generateClientJs`: runtime defaults に `"role": "..."` / `"status": "..."` が正しい値で乗ることを検証。
- 型テスト（回帰）: Member を role/status 省略で create でき、結果が非 null であること。
- fixture: `Member.role @default(USER)` / `status @default(active)`（`prisma validate` OK）。
- runtime **540** / type-level **20 ファイル・型エラー0** / `tsc --noEmit` clean。

## 補足（本 PR では変更しない）

reference『型ファイルの動的生成.md』の「`@default()` → 生成 JS」変換表に **enum 値参照の行が無い**（doc の穴）。`@default(ADMIN)` → `"ADMIN"`、`@default(active)` → `"ACTIVE"` の追記を別途推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)