### PR TITLE
fix: allow relations in nested select (deep nesting via FindSelect)

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaFindSelect.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindSelect.test.ts
@@ -39,7 +39,8 @@ describe("getOneGassmaFindSelect", () => {
 
     expect(result).toContain('"id"?: true;');
     expect(result).toContain('"posts"?: true | {');
-    expect(result).toContain("select?: GassmaTestPostSelect");
+    expect(result).toContain("select?: GassmaTestPostFindSelect");
+    expect(result).not.toContain("select?: GassmaTestPostSelect;");
     expect(result).toContain("where?: GassmaTestPostWhereUse");
     expect(result).toContain("orderBy?: GassmaTestPostOrderBy");
     expect(result).toContain("include?: GassmaTestPostInclude");

--- a/src/__test__/generate/typeGenerate/gassmaInclude.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaInclude.test.ts
@@ -43,7 +43,7 @@ describe("getOneGassmaInclude", () => {
     const result = getOneGassmaInclude("", "User", relations);
 
     expect(result).toContain(
-      '"posts"?: true | { select?: GassmaPostSelect; omit?: GassmaPostOmit; where?: GassmaPostWhereUse; orderBy?: GassmaPostOrderBy; take?: number; skip?: number; include?: GassmaPostInclude; _count?: GassmaPostCountValue };',
+      '"posts"?: true | { select?: GassmaPostFindSelect; omit?: GassmaPostOmit; where?: GassmaPostWhereUse; orderBy?: GassmaPostOrderBy; take?: number; skip?: number; include?: GassmaPostInclude; _count?: GassmaPostCountValue };',
     );
   });
 
@@ -87,7 +87,7 @@ describe("getOneGassmaInclude", () => {
     const result = getOneGassmaInclude("Test", "User", relations);
 
     expect(result).toContain("export type GassmaTestUserInclude");
-    expect(result).toContain("GassmaTestPostSelect");
+    expect(result).toContain("GassmaTestPostFindSelect");
     expect(result).toContain("GassmaTestPostWhereUse");
   });
 });

--- a/src/__test__/types/read/include.test-d.ts
+++ b/src/__test__/types/read/include.test-d.ts
@@ -76,6 +76,22 @@ declare const client: GassmaClient;
   expectTypeOf<U["posts"][number]>().not.toHaveProperty("id");
 }
 
+// include 内の深いネスト select: posts -> tags
+{
+  const u = client.User.findFirst({
+    where: { id: 1 },
+    include: {
+      posts: { select: { tags: { select: { name: true } } } },
+    },
+  });
+  type U = NonNullable<typeof u>;
+  expectTypeOf<U["id"]>().toEqualTypeOf<number>();
+  type P = U["posts"][number];
+  expectTypeOf<P>().not.toHaveProperty("title");
+  expectTypeOf<P["tags"][number]["name"]>().toEqualTypeOf<string>();
+  expectTypeOf<P["tags"][number]>().not.toHaveProperty("id");
+}
+
 // include の _count
 {
   const u = client.User.findFirst({

--- a/src/__test__/types/read/select.test-d.ts
+++ b/src/__test__/types/read/select.test-d.ts
@@ -79,6 +79,95 @@ declare const client: GassmaClient;
   expectTypeOf<R["_count"]["posts"]>().toEqualTypeOf<number>();
 }
 
+// 深いネスト select（reference の findMany 例相当）: posts -> tags
+{
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: {
+      posts: {
+        select: {
+          title: true,
+          tags: { select: { name: true } },
+        },
+      },
+    },
+  });
+  type R = typeof r;
+  expectTypeOf<R>().not.toHaveProperty("email");
+  type P = R["posts"][number];
+  expectTypeOf<P["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<P["tags"]>().toBeArray();
+  expectTypeOf<P>().not.toHaveProperty("id");
+  expectTypeOf<P>().not.toHaveProperty("content");
+  expectTypeOf<P>().not.toHaveProperty("author");
+  expectTypeOf<P["tags"][number]["name"]>().toEqualTypeOf<string>();
+  expectTypeOf<P["tags"][number]>().not.toHaveProperty("id");
+}
+
+// ネスト select 内の relation true: 対象の全スカラー（manyToOne は | null）
+{
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: { posts: { select: { author: true } } },
+  });
+  type P = (typeof r)["posts"][number];
+  expectTypeOf<P>().not.toHaveProperty("title");
+  expectTypeOf<P["author"]>().toBeNullable();
+  type A = NonNullable<P["author"]>;
+  expectTypeOf<keyof A>().toEqualTypeOf<
+    | "id"
+    | "email"
+    | "name"
+    | "age"
+    | "isActive"
+    | "score"
+    | "rating"
+    | "createdAt"
+  >();
+  expectTypeOf<A["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<A["name"]>().toEqualTypeOf<string | null>();
+}
+
+// 3階層の深いネスト select: posts -> tags -> posts
+{
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: {
+      posts: {
+        select: {
+          tags: {
+            select: {
+              posts: { select: { title: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+  type P = (typeof r)["posts"][number];
+  expectTypeOf<P>().not.toHaveProperty("title");
+  type T = P["tags"][number];
+  expectTypeOf<T>().not.toHaveProperty("name");
+  type PP = T["posts"][number];
+  expectTypeOf<keyof PP>().toEqualTypeOf<"title">();
+  expectTypeOf<PP["title"]>().toEqualTypeOf<string>();
+}
+
+// 深いネスト select でも存在しないキーは拒否される
+{
+  void client.User.findFirstOrThrow({
+    where: {},
+    select: {
+      posts: {
+        select: {
+          // @ts-expect-error 存在しないキーは指定できない
+          nonexistent: true,
+        },
+      },
+    },
+  });
+}
+
 // self-relation の select
 {
   const r = client.Category.findFirstOrThrow({

--- a/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
+++ b/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
@@ -13,7 +13,7 @@ const getOneGassmaInclude = (
   const fields = Object.keys(modelRelations).reduce((pre, relationName) => {
     const targetModel = modelRelations[relationName].to;
     const target = `Gassma${schemaName}${targetModel}`;
-    const optionsType = `{ select?: ${target}Select; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; include?: ${target}Include; _count?: ${target}CountValue }`;
+    const optionsType = `{ select?: ${target}FindSelect; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; include?: ${target}Include; _count?: ${target}CountValue }`;
     return `${pre}  "${relationName}"?: true | ${optionsType};\n`;
   }, "");
 

--- a/src/generate/typeGenerate/gassmaSelect/oneGassmaFindSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect/oneGassmaFindSelect.ts
@@ -24,7 +24,7 @@ const getOneGassmaFindSelect = (
     relationFields = Object.keys(modelRelations).reduce((pre, relationName) => {
       const targetModel = modelRelations[relationName].to;
       const target = `Gassma${schemaName}${targetModel}`;
-      const optionsType = `{ select?: ${target}Select; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; include?: ${target}Include; _count?: ${target}CountValue }`;
+      const optionsType = `{ select?: ${target}FindSelect; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; include?: ${target}Include; _count?: ${target}CountValue }`;
       return `${pre}  "${relationName}"?: true | ${optionsType};\n`;
     }, "");
   }


### PR DESCRIPTION
## 概要

nested select（リレーションオプション内の `select`）が **scalar 限定**だったため、reference（`findMany.md`「深いネストも対応」）の**深いネスト select が型で通らない**バグを修正しました。

`#88/#89` の Fable レビューで残っていた finding ③（select 深いネスト）への対応です。

## 依存

⚠️ **本体 PR akahoshi1421/gassma#133 のマージが前提**です。#133 が nested の `rel: true` 形式リレーションを runtime で解決するようにするため、本 PR の型（nested `rel: true` → 対象の全 scalar オブジェクト）が真実になります。**#133 を先にマージしてください。**

## 原因と修正

relation の `optionsType` が `select?: ${target}Select`（scalar 限定）でした。これを **`select?: ${target}FindSelect`**（リレーションキーを含む）に変更（`oneGassmaFindSelect.ts` / `oneGassmaInclude.ts` の2箇所・各1行）。

- これで nested select が任意深度でリレーションを選択可能に（`posts: { select: { tags: { select: { name: true } } } }`）。
- `FindResult` は `SelectOf<S[K]>` + `relationBranch` で**既に再帰解決する構造**のため変更不要。ブロックしていたのは args 側の scalar 限定制約だけ。
- 循環参照（`UserFindSelect ↔ PostFindSelect`）は property 経由の named 参照で TS 許容（`tsc --noEmit` + 単体 strict チェックで確認）。
- scalar 限定の `Select` は残置（write 系 top-level select 用。**未変更**）。

## テスト（TDD: Red → Green）

- object 形式の深いネスト（2〜3階層、選外キー不在も検証）。
- nested `rel: true` 形式（`keyof` 完全一致で対象の全 scalar・`| null` を検証）。
- include 内 nested select の深いネスト。
- 深いネスト内の誤キー拒否（`@ts-expect-error`、空振りなし実証）。
- runtime **540** / type-level **20 ファイル・型エラー0** / `tsc --noEmit` clean / biome clean。既存 select/include/globalOmit 型テストを維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja