### PR TITLE
fix: aggregate/groupBy _count type is number (drop | null)

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaAggregateField.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaAggregateField.test.ts
@@ -9,9 +9,17 @@ describe("getOneGassmaAggregateField", () => {
     );
   });
 
-  it("should map _count, _avg and _sum keys to number | null", () => {
+  it("should map _count keys to number without null", () => {
     const result = getOneGassmaAggregateField("", "User");
-    expect(result).toContain('K extends "_count" | "_avg" | "_sum"');
+    expect(result).toContain('K extends "_count"');
+    expect(result).toContain(
+      "{ [P in keyof T as T[P] extends true ? P : never]: number }",
+    );
+  });
+
+  it("should map _avg and _sum keys to number | null", () => {
+    const result = getOneGassmaAggregateField("", "User");
+    expect(result).toContain('K extends "_avg" | "_sum"');
     expect(result).toContain(
       "{ [P in keyof T as T[P] extends true ? P : never]: number | null }",
     );

--- a/src/__test__/types/aggregate/aggregate.test-d.ts
+++ b/src/__test__/types/aggregate/aggregate.test-d.ts
@@ -20,7 +20,7 @@ declare const client: GassmaClient;
   expectTypeOf<typeof r>().toHaveProperty("_avg");
 }
 
-// aggregate: _avg / _sum は数値、_count は number
+// aggregate: _avg / _sum は 0件時 null、_count は 0件時も 0（Prisma 準拠）
 {
   const r = client.User.aggregate({
     where: {},
@@ -30,11 +30,9 @@ declare const client: GassmaClient;
     _max: { age: true },
     _count: { id: true },
   });
-  // 0件ヒット時に null を返すため、集計値は | null（本体実装に一致）
   expectTypeOf<(typeof r)["_avg"]["age"]>().toEqualTypeOf<number | null>();
   expectTypeOf<(typeof r)["_sum"]["age"]>().toEqualTypeOf<number | null>();
-  // _count も 0件時 null（本体挙動。Prisma は 0 だが本体差異は別タスク）
-  expectTypeOf<(typeof r)["_count"]["id"]>().toEqualTypeOf<number | null>();
+  expectTypeOf<(typeof r)["_count"]["id"]>().toEqualTypeOf<number>();
 }
 
 // aggregate: _min / _max は元のフィールド型 | null

--- a/src/__test__/types/aggregate/groupBy.test-d.ts
+++ b/src/__test__/types/aggregate/groupBy.test-d.ts
@@ -34,9 +34,7 @@ declare const client: GassmaClient;
   expectTypeOf<(typeof r)[number]["_avg"]["age"]>().toEqualTypeOf<
     number | null
   >();
-  expectTypeOf<(typeof r)[number]["_count"]["id"]>().toEqualTypeOf<
-    number | null
-  >();
+  expectTypeOf<(typeof r)[number]["_count"]["id"]>().toEqualTypeOf<number>();
 }
 
 // groupBy: having を受け付ける

--- a/src/generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField.ts
+++ b/src/generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField.ts
@@ -2,13 +2,15 @@ const getOneGassmaAggregateField = (schemaName: string, sheetName: string) => {
   return `
 export type Gassma${schemaName}${sheetName}AggregateField<T, K extends string> = T extends undefined
   ? never
-  : K extends "_count" | "_avg" | "_sum"
-    ? { [P in keyof T as T[P] extends true ? P : never]: number | null }
-    : {
-        [P in keyof T as T[P] extends true
-          ? P & keyof Gassma${schemaName}${sheetName}AggregateBaseReturn
-          : never]: Gassma${schemaName}${sheetName}AggregateBaseReturn[P & keyof Gassma${schemaName}${sheetName}AggregateBaseReturn] | null;
-      };
+  : K extends "_count"
+    ? { [P in keyof T as T[P] extends true ? P : never]: number }
+    : K extends "_avg" | "_sum"
+      ? { [P in keyof T as T[P] extends true ? P : never]: number | null }
+      : {
+          [P in keyof T as T[P] extends true
+            ? P & keyof Gassma${schemaName}${sheetName}AggregateBaseReturn
+            : never]: Gassma${schemaName}${sheetName}AggregateBaseReturn[P & keyof Gassma${schemaName}${sheetName}AggregateBaseReturn] | null;
+        };
 `;
 };
 


### PR DESCRIPTION
## 概要

aggregate / groupBy の **`_count` 生成型から `| null` を外し `number`** にしました（残タスク1の cli 側）。

## 依存

⚠️ **本体 PR akahoshi1421/gassma#134 のマージが前提**です。本体が `_count` を0件ヒット時 `0` 返却（Prisma パリティ）に修正したため、cli の暫定 `number | null`（本体の旧挙動に合わせていた）を外せます。**#134 を先にマージしてください。**

## 修正

`oneGassmaAggregateField.ts` の一括分岐 `_count | _avg | _sum → number | null` を分割:

```diff
- : K extends "_count" | "_avg" | "_sum"
-   ? { ...: number | null }
+ : K extends "_count"
+   ? { ...: number }
+   : K extends "_avg" | "_sum"
+     ? { ...: number | null }
```

- `_avg` / `_sum` は **`number | null` 維持**（Prisma も0件時 null）。`_min` / `_max`（フィールド型 `| null`）も維持。
- groupBy は同じ `AggregateField` に委譲しているため、この1箇所で aggregate / groupBy 両方に反映。
- リレーション件数の `_count`（select/include の CountResult）は別系統・未変更。

## テスト（TDD: Red → Green）

- 生成側ユニットテストを `_count → number` / `_avg・_sum → number | null` の2テストに分割。
- 型テスト（aggregate / groupBy）の `_count` assert を `number` に更新、暫定コメント（「本体差異は別タスク」）を削除。
- runtime **541** / type-level **20 ファイル・型エラー0** / `tsc --noEmit` clean / biome clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja