### PR TITLE
fix: having _count/_avg/_sum use numeric filter conditions

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -22,6 +22,18 @@ describe("getGassmaCommonTypes", () => {
     expect(result).toContain('nulls?: "first" | "last"');
   });
 
+  it("should generate generic FilterConditions type", () => {
+    expect(result).toContain("type FilterConditions<T> =");
+    expect(result).toContain("equals?: T | FieldRef");
+    expect(result).toContain("not?: T");
+    expect(result).toContain("in?: T[]");
+    expect(result).toContain("notIn?: T[]");
+    expect(result).toContain("lt?: T | FieldRef");
+    expect(result).toContain("lte?: T | FieldRef");
+    expect(result).toContain("gt?: T | FieldRef");
+    expect(result).toContain("gte?: T | FieldRef");
+  });
+
   it("should generate ManyReturn types", () => {
     expect(result).toContain("type ManyReturn =");
     expect(result).toContain("count: number");

--- a/src/__test__/generate/typeGenerate/gassmaHavingCore.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaHavingCore.test.ts
@@ -20,6 +20,21 @@ describe("getOneGassmaHavingCore", () => {
     expect(result).toContain("} & GassmaUseridFilterConditions;");
   });
 
+  it("should use numeric FilterConditions for _avg / _count / _sum", () => {
+    const result = getOneGassmaHavingCore({ name: ["a"] }, "", "User");
+    expect(result).toContain("_avg?: Gassma.FilterConditions<number>;");
+    expect(result).toContain("_count?: Gassma.FilterConditions<number>;");
+    expect(result).toContain("_sum?: Gassma.FilterConditions<number>;");
+  });
+
+  it("should keep field FilterConditions for _min / _max", () => {
+    const result = getOneGassmaHavingCore({ name: ["a"] }, "", "User");
+    expect(result).toContain("_max?: GassmaUsernameFilterConditions;");
+    expect(result).toContain("_min?: GassmaUsernameFilterConditions;");
+    expect(result).not.toContain("_max?: Gassma.FilterConditions<number>;");
+    expect(result).not.toContain("_min?: Gassma.FilterConditions<number>;");
+  });
+
   it("should prepend schemaName", () => {
     const result = getOneGassmaHavingCore({ id: [1] }, "Test", "User");
     expect(result).toContain("GassmaTestUseridHavingCore");

--- a/src/__test__/types/aggregate/groupBy.test-d.ts
+++ b/src/__test__/types/aggregate/groupBy.test-d.ts
@@ -46,6 +46,55 @@ declare const client: GassmaClient;
   });
 }
 
+// groupBy: having の _count / _avg / _sum は数値 Filter（フィールド型に依らない）
+{
+  client.User.groupBy({
+    by: ["email"],
+    having: { email: { _count: { gt: 2 } } },
+  });
+  client.User.groupBy({
+    by: ["email"],
+    having: { email: { _avg: { gte: 1 }, _sum: { lt: 10 } } },
+  });
+}
+
+// groupBy: having の _count / _avg / _sum に文字列は拒否
+{
+  client.User.groupBy({
+    by: ["email"],
+    // @ts-expect-error _count は数値 Filter（string は不可）
+    having: { email: { _count: { gt: "x" } } },
+  });
+  client.User.groupBy({
+    by: ["email"],
+    // @ts-expect-error _avg は数値 Filter（string は不可）
+    having: { email: { _avg: { gte: "x" } } },
+  });
+  client.User.groupBy({
+    by: ["email"],
+    // @ts-expect-error _sum は数値 Filter（string は不可）
+    having: { email: { _sum: { lt: "x" } } },
+  });
+}
+
+// groupBy: having の _min / _max はフィールド型 Filter のまま
+{
+  client.User.groupBy({
+    by: ["email"],
+    having: { email: { _min: { equals: "a@b.com" }, _max: { gt: "a" } } },
+  });
+  client.User.groupBy({
+    by: ["email"],
+    // @ts-expect-error _min は email のフィールド型 Filter（number は不可）
+    having: { email: { _min: { equals: 5 } } },
+  });
+  client.User.groupBy({
+    by: ["email"],
+    // @ts-expect-error _max は email のフィールド型 Filter（number は不可）
+    having: { email: { _max: { gt: 5 } } },
+  });
+}
+
 // groupBy: by に存在しないフィールドは拒否
 {
   // @ts-expect-error "nonexistent" は User のフィールドでない

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -13,6 +13,21 @@ const getGassmaCommonTypes = () => {
     nulls?: "first" | "last";
   };
 
+  type FilterConditions<T> = {
+    equals?: T | FieldRef;
+    not?: T;
+    in?: T[];
+    notIn?: T[];
+    lt?: T | FieldRef;
+    lte?: T | FieldRef;
+    gt?: T | FieldRef;
+    gte?: T | FieldRef;
+    contains?: string | FieldRef;
+    startsWith?: string | FieldRef;
+    endsWith?: string | FieldRef;
+    mode?: "default" | "insensitive";
+  };
+
   type TrueKeys<T> = { [K in keyof T]: T[K] extends true ? K : never }[keyof T];
   type FalseKeys<T> = { [K in keyof T]: T[K] extends false ? K : never }[keyof T];
   type ResolveOmitKeys<GO, QO> = Exclude<TrueKeys<GO>, FalseKeys<QO>> | TrueKeys<QO>;

--- a/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
+++ b/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
@@ -10,11 +10,11 @@ const getOneGassmaHavingCore = (
 
     const oneHavingCoreType = `
 export type Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}HavingCore = {
-  _avg?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-  _count?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+  _avg?: Gassma.FilterConditions<number>;
+  _count?: Gassma.FilterConditions<number>;
   _max?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
   _min?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-  _sum?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+  _sum?: Gassma.FilterConditions<number>;
 } & Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
 `;
 


### PR DESCRIPTION
## 概要

生成型 `having` の **`_count`/`_avg`/`_sum` フィルタがフィールド自身の型の FilterConditions に束縛されていた**バグを、数値フィルタに修正しました（残タスク2の cli 側）。

例: `having: { email: { _count: { gt: 2 } } }` は実行時（数値比較）にも Prisma 的にも正当なのに、生成型が email の文字列 Filter を要求して弾いていました — 「型エラーになる実害」の本体はこの per-field HavingCore でした。

## 依存

⚠️ **本体 PR akahoshi1421/gassma#135 のマージが前提**（本体 `HavingCore` の同種修正 + Prisma 実測裏取り）。**#135 を先にマージしてください。**

## 修正

- `gassmaCommonTypes.ts`: 汎用 `Gassma.FilterConditions<T>` を追加（既存の per-field FilterConditions と同一形状）。
- `oneGassmaHavingCore.ts`: `_avg`/`_count`/`_sum` → `Gassma.FilterConditions<number>`。`_min`/`_max` はフィールド型のまま。

```diff
export type GassmaUseremailHavingCore = {
-  _avg?: GassmaUseremailFilterConditions;
-  _count?: GassmaUseremailFilterConditions;
+  _avg?: Gassma.FilterConditions<number>;
+  _count?: Gassma.FilterConditions<number>;
   _max?: GassmaUseremailFilterConditions;
   _min?: GassmaUseremailFilterConditions;
-  _sum?: GassmaUseremailFilterConditions;
+  _sum?: Gassma.FilterConditions<number>;
} & GassmaUseremailFilterConditions;
```

## テスト（TDD: Red → Green 実証）

- 生成側ユニットテスト: `_avg`/`_count`/`_sum` が数値・`_min`/`_max` がフィールド型のまま、汎用 `FilterConditions<T>` の出力。
- 型テスト（groupBy）: 文字列フィールドへの `_count`/`_avg`/`_sum` having の正例、数値フィルタへの文字列拒否（`@ts-expect-error` 3件、修正前に unused directive で空振りでないことを実証）、`_min`/`_max` の維持。
- runtime **544** / type-level **20 ファイル・型エラー0** / `tsc --noEmit` clean / biome clean。

## 補足（スコープ外・別判断）

Prisma は having の `_avg`/`_sum` を**数値フィールド限定**にしています（本体 PR #135 の実測）。gassma は全フィールドで許容し、非数値は実行時 throw。フィールド単位の制限（aggregate 入力の NumberSelect 相当）は仕様判断が要るため本 PR では触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja