### PR TITLE
fix: restrict having _avg/_sum to numeric fields (Prisma parity)

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaHavingCore.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaHavingCore.test.ts
@@ -3,32 +3,71 @@ import { getOneGassmaHavingCore } from "../../../generate/typeGenerate/gassmaHav
 
 describe("getOneGassmaHavingCore", () => {
   it("should emit a HavingCore type per column", () => {
-    const result = getOneGassmaHavingCore({ id: [1], name: ["a"] }, "", "User");
+    const result = getOneGassmaHavingCore(
+      { id: ["number"], name: ["string"] },
+      "",
+      "User",
+    );
     expect(result).toContain("export type GassmaUseridHavingCore");
-    // Note: getRemovedCantUseVarChar removes some characters; column names appear concatenated
+    expect(result).toContain("export type GassmaUsernameHavingCore");
     expect(result).toContain("HavingCore = {");
   });
 
-  it("should include _avg / _count / _max / _min / _sum + base intersection", () => {
-    const result = getOneGassmaHavingCore({ id: [1] }, "", "User");
-    expect(result).toContain("_avg?:");
-    expect(result).toContain("_count?:");
-    expect(result).toContain("_max?:");
-    expect(result).toContain("_min?:");
-    expect(result).toContain("_sum?:");
-    expect(result).toContain("FilterConditions;");
-    expect(result).toContain("} & GassmaUseridFilterConditions;");
-  });
-
-  it("should use numeric FilterConditions for _avg / _count / _sum", () => {
-    const result = getOneGassmaHavingCore({ name: ["a"] }, "", "User");
+  it("should include _avg / _count / _sum for number columns", () => {
+    const result = getOneGassmaHavingCore({ id: ["number"] }, "", "User");
     expect(result).toContain("_avg?: Gassma.FilterConditions<number>;");
     expect(result).toContain("_count?: Gassma.FilterConditions<number>;");
     expect(result).toContain("_sum?: Gassma.FilterConditions<number>;");
+    expect(result).toContain("} & GassmaUseridFilterConditions;");
+  });
+
+  it("should omit _avg / _sum for non-number columns", () => {
+    const result = getOneGassmaHavingCore({ name: ["string"] }, "", "User");
+    expect(result).not.toContain("_avg?:");
+    expect(result).not.toContain("_sum?:");
+    expect(result).toContain("_count?: Gassma.FilterConditions<number>;");
+    expect(result).toContain("_max?: GassmaUsernameFilterConditions;");
+    expect(result).toContain("_min?: GassmaUsernameFilterConditions;");
+    expect(result).toContain("} & GassmaUsernameFilterConditions;");
+  });
+
+  it("should include _avg / _sum for addType union columns containing number", () => {
+    const result = getOneGassmaHavingCore(
+      { rating: ["number", "string", "boolean"] },
+      "",
+      "User",
+    );
+    expect(result).toContain("_avg?: Gassma.FilterConditions<number>;");
+    expect(result).toContain("_sum?: Gassma.FilterConditions<number>;");
+  });
+
+  it("should omit _avg / _sum for {{number}} literal (replaceType) columns", () => {
+    const result = getOneGassmaHavingCore({ size: ["{{number}}"] }, "", "User");
+    expect(result).not.toContain("_avg?:");
+    expect(result).not.toContain("_sum?:");
+  });
+
+  it("should decide _avg / _sum per column in a mixed sheet", () => {
+    const result = getOneGassmaHavingCore(
+      { id: ["number"], name: ["string"] },
+      "",
+      "User",
+    );
+    const blocks = result.split("export type ");
+    const idBlock = blocks.find((block) =>
+      block.startsWith("GassmaUseridHavingCore"),
+    );
+    const nameBlock = blocks.find((block) =>
+      block.startsWith("GassmaUsernameHavingCore"),
+    );
+    expect(idBlock).toContain("_avg?:");
+    expect(idBlock).toContain("_sum?:");
+    expect(nameBlock).not.toContain("_avg?:");
+    expect(nameBlock).not.toContain("_sum?:");
   });
 
   it("should keep field FilterConditions for _min / _max", () => {
-    const result = getOneGassmaHavingCore({ name: ["a"] }, "", "User");
+    const result = getOneGassmaHavingCore({ name: ["string"] }, "", "User");
     expect(result).toContain("_max?: GassmaUsernameFilterConditions;");
     expect(result).toContain("_min?: GassmaUsernameFilterConditions;");
     expect(result).not.toContain("_max?: Gassma.FilterConditions<number>;");
@@ -36,7 +75,7 @@ describe("getOneGassmaHavingCore", () => {
   });
 
   it("should prepend schemaName", () => {
-    const result = getOneGassmaHavingCore({ id: [1] }, "Test", "User");
+    const result = getOneGassmaHavingCore({ id: ["number"] }, "Test", "User");
     expect(result).toContain("GassmaTestUseridHavingCore");
   });
 

--- a/src/__test__/generate/util/isNumberColumn.test.ts
+++ b/src/__test__/generate/util/isNumberColumn.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { isNumberColumn } from "../../../generate/util/isNumberColumn";
+
+describe("isNumberColumn", () => {
+  it("should return true for a number column", () => {
+    expect(isNumberColumn(["number"])).toBe(true);
+  });
+
+  it("should return true for addType union containing number", () => {
+    expect(isNumberColumn(["number", "string", "boolean"])).toBe(true);
+  });
+
+  it("should return false for non-number columns", () => {
+    expect(isNumberColumn(["string"])).toBe(false);
+    expect(isNumberColumn(["boolean"])).toBe(false);
+    expect(isNumberColumn(["Date"])).toBe(false);
+  });
+
+  it("should return false for {{number}} literal (replaceType) columns", () => {
+    expect(isNumberColumn(["{{number}}"])).toBe(false);
+  });
+
+  it("should return false for empty type list", () => {
+    expect(isNumberColumn([])).toBe(false);
+  });
+});

--- a/src/__test__/types/aggregate/groupBy.test-d.ts
+++ b/src/__test__/types/aggregate/groupBy.test-d.ts
@@ -46,15 +46,41 @@ declare const client: GassmaClient;
   });
 }
 
-// groupBy: having の _count / _avg / _sum は数値 Filter（フィールド型に依らない）
+// groupBy: having の _count は全フィールドで使える（数値 Filter）
 {
   client.User.groupBy({
     by: ["email"],
     having: { email: { _count: { gt: 2 } } },
   });
+}
+
+// groupBy: having の _avg / _sum は数値フィールドで使える
+{
+  client.User.groupBy({
+    by: ["age"],
+    having: { age: { _avg: { gte: 1 }, _sum: { lt: 10 } } },
+  });
+}
+
+// groupBy: having の _avg / _sum は addType 複合型（number を含む）でも使える
+{
+  client.User.groupBy({
+    by: ["rating"],
+    having: { rating: { _avg: { gte: 1 }, _sum: { lt: 10 } } },
+  });
+}
+
+// groupBy: having の _avg / _sum は数値フィールド限定（Prisma パリティ）
+{
   client.User.groupBy({
     by: ["email"],
-    having: { email: { _avg: { gte: 1 }, _sum: { lt: 10 } } },
+    // @ts-expect-error _avg は数値フィールド限定（email は string）
+    having: { email: { _avg: { gte: 1 } } },
+  });
+  client.User.groupBy({
+    by: ["email"],
+    // @ts-expect-error _sum は数値フィールド限定（email は string）
+    having: { email: { _sum: { lt: 10 } } },
   });
 }
 
@@ -66,14 +92,14 @@ declare const client: GassmaClient;
     having: { email: { _count: { gt: "x" } } },
   });
   client.User.groupBy({
-    by: ["email"],
+    by: ["age"],
     // @ts-expect-error _avg は数値 Filter（string は不可）
-    having: { email: { _avg: { gte: "x" } } },
+    having: { age: { _avg: { gte: "x" } } },
   });
   client.User.groupBy({
-    by: ["email"],
+    by: ["age"],
     // @ts-expect-error _sum は数値 Filter（string は不可）
-    having: { email: { _sum: { lt: "x" } } },
+    having: { age: { _sum: { lt: "x" } } },
   });
 }
 

--- a/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
+++ b/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
@@ -1,4 +1,5 @@
 import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+import { isNumberColumn } from "../../util/isNumberColumn";
 
 const getOneGassmaHavingCore = (
   sheetContent: Record<string, unknown[]>,
@@ -7,15 +8,20 @@ const getOneGassmaHavingCore = (
 ) => {
   const oneHavingCore = Object.keys(sheetContent).reduce((pre, columnName) => {
     const removedSpaceCurrentColumnName = getRemovedCantUseVarChar(columnName);
+    const isNumber = isNumberColumn(sheetContent[columnName]);
+    const avgLine = isNumber
+      ? "  _avg?: Gassma.FilterConditions<number>;\n"
+      : "";
+    const sumLine = isNumber
+      ? "  _sum?: Gassma.FilterConditions<number>;\n"
+      : "";
 
     const oneHavingCoreType = `
 export type Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}HavingCore = {
-  _avg?: Gassma.FilterConditions<number>;
-  _count?: Gassma.FilterConditions<number>;
+${avgLine}  _count?: Gassma.FilterConditions<number>;
   _max?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
   _min?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-  _sum?: Gassma.FilterConditions<number>;
-} & Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+${sumLine}} & Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
 `;
 
     return pre + oneHavingCoreType;

--- a/src/generate/typeGenerate/gassmaSelect/oneGassmaNumberSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect/oneGassmaNumberSelect.ts
@@ -1,10 +1,12 @@
+import { isNumberColumn } from "../../util/isNumberColumn";
+
 const getOneGassmaNumberSelect = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
 ) => {
   const numberColumnNames = Object.keys(sheetContent).filter((columnName) =>
-    sheetContent[columnName].some((oneType) => oneType === "number"),
+    isNumberColumn(sheetContent[columnName]),
   );
 
   const typeName = `Gassma${schemaName}${sheetName}NumberSelect`;

--- a/src/generate/util/isNumberColumn.ts
+++ b/src/generate/util/isNumberColumn.ts
@@ -1,0 +1,4 @@
+const isNumberColumn = (columnTypes: unknown[]) =>
+  columnTypes.some((oneType) => oneType === "number");
+
+export { isNumberColumn };


### PR DESCRIPTION
## 概要

生成型 having の **`_avg`/`_sum` キーを数値フィールド限定**にしました（新規タスク3）。

PR #98 でフィルタの**値**は数値化しましたが、**キー自体は全フィールド**の HavingCore に生成されていました。Prisma は `_avg`/`_sum` を数値フィールド限定にしており（#135 実測: `StringWithAggregatesFilter` に両キーなし）、gassma 本体ランタイムも非数値フィールドでは `GassmaAggregateAvgTypeError`/`SumTypeError` を throw します — 「本体で動かないコードは型で弾く」承認済み原則による締めです。

## 修正

- 数値判定を共有 util `isNumberColumn` に抽出（列型に `number` を含むか。**aggregate 入力の `_avg`/`_sum` 制限（NumberSelect）と同一基準**になり、`oneGassmaNumberSelect` も同 util を参照するようリファクタ — 挙動不変）。
- `oneGassmaHavingCore`: 数値カラムのみ `_avg?`/`_sum?` を出力。`_count`（数値フィルタ）/`_min`/`_max`（フィールド型フィルタ）は全フィールド維持。

```ts
// email: String → _avg / _sum が消える
export type GassmaUseremailHavingCore = {
  _count?: Gassma.FilterConditions<number>;
  _max?: GassmaUseremailFilterConditions;
  _min?: GassmaUseremailFilterConditions;
} & GassmaUseremailFilterConditions;
```

境界ケース: addType 複合型（`rating: number|string|boolean` 等）→ **あり**、boolean/Date/enum/replaceType 文字列 → **なし**。数値フィールドの HavingCore はバイト一致（非破壊）。

## 破壊的変更

非数値フィールドへの `_avg`/`_sum` having はコンパイルエラーになります（実行時は元々 throw、実害なし）。

## テスト（TDD: Red → Green 実証）

- PR #98 で入れた「文字列フィールドへの `_avg`/`_sum` 正例」を負例（`@ts-expect-error`）に反転（Red 時に unused directive で空振りでないことを実証）。数値・複合型の正例、util テスト5件を追加。
- runtime **552** / type-level **型エラー0** / `tsc --noEmit` clean / biome clean。
- 本体（gassma）の HavingCore は index signature でフィールド型を持たないため対象外（変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)