### PR TITLE
feat: declare NestedWriteTargetNotFoundError in generated error classes

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -117,6 +117,12 @@ describe("getGassmaErrorClasses", () => {
     expect(result).toContain(
       "class NestedWriteWithoutRelationsError extends Error",
     );
+    expect(result).toContain(
+      "class NestedWriteTargetNotFoundError extends Error",
+    );
+    expect(result).toContain(
+      "constructor(sheetName: string, operation: string)",
+    );
   });
 
   it("should include orderBy errors", () => {

--- a/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -127,6 +127,11 @@ const errorClassDefinitions: ErrorClassDef[] = [
   },
   { name: "NestedWriteWithoutRelationsError", extends: "Error", params: "" },
   {
+    name: "NestedWriteTargetNotFoundError",
+    extends: "Error",
+    params: "sheetName: string, operation: string",
+  },
+  {
     name: "RelationOrderByUnsupportedTypeError",
     extends: "Error",
     params: "relationName: string, relationType: string",


### PR DESCRIPTION
## 概要

本体 gassma **#141**(非FK側 oneToOne nested write の Prisma 準拠化)で新設された **`NestedWriteTargetNotFoundError`**(非FK側の nested update/delete で子行が不在のとき throw、P2025 準拠)を、生成 d.ts の `Gassma` namespace エラークラス宣言に追随しました。

## 依存

⚠️ **本体 PR akahoshi1421/gassma#141 のマージが前提**です(#141 を先にマージしてください)。

## 変更(2ファイルのみ)

- `errorClassDefinitions.ts`: 本体の実クラス(`constructor(sheetName: string, operation: string)`)に合わせ、export 順どおり `NestedWriteWithoutRelationsError` の直後に追加。
- 生成側ユニットテストに toContain 2件追加(TDD Red→Green)。

生成結果:

```ts
class NestedWriteTargetNotFoundError extends Error {
  constructor(sheetName: string, operation: string);
}
```

なお `ownsFk` 自体は cli の `extractRelations` が既に出力済みのため、relations JSON 側の追随は不要です(本体対応だけで生成 client は再生成不要で即効)。

## テスト

runtime **552** / `npm run test:types` 型エラー0 / `tsc --noEmit` clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja