### PR TITLE
feat: error when a schema defines no models (generate/validate)

### DIFF
--- a/src/__test__/generate/noModels.test.ts
+++ b/src/__test__/generate/noModels.test.ts
@@ -1,0 +1,105 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { generate } from "../../generate/generate";
+import { NoModelsError } from "../../error/mainError";
+
+const generatorBlock = (outDir: string) => `generator client {
+  provider = "prisma-client-js"
+  output   = "${outDir}"
+}`;
+
+const datasourceBlock = `datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}`;
+
+const userModel = `model User {
+  id   Int    @id
+  name String
+}`;
+
+describe("generate with no models", () => {
+  let tmpDir: string;
+  let schemaDir: string;
+  let outDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-no-models-"));
+    schemaDir = path.join(tmpDir, "gassma");
+    outDir = path.join(tmpDir, "generated");
+    fs.mkdirSync(schemaDir);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should throw NoModelsError for a generator and datasource only schema", () => {
+    const schemaPath = path.join(schemaDir, "schema.prisma");
+    fs.writeFileSync(
+      schemaPath,
+      `${generatorBlock(outDir)}\n\n${datasourceBlock}\n`,
+    );
+
+    expect(() => generate({ schema: schemaPath })).toThrow(NoModelsError);
+    expect(fs.existsSync(outDir)).toBe(false);
+  });
+
+  it("should throw NoModelsError for an enum only schema", () => {
+    const schemaPath = path.join(schemaDir, "schema.prisma");
+    fs.writeFileSync(
+      schemaPath,
+      `${generatorBlock(outDir)}\n\nenum Role {\n  USER\n  ADMIN\n}\n`,
+    );
+
+    expect(() => generate({ schema: schemaPath })).toThrow(NoModelsError);
+    expect(fs.existsSync(outDir)).toBe(false);
+  });
+
+  it("should include the schema location in the error message", () => {
+    const schemaPath = path.join(schemaDir, "schema.prisma");
+    fs.writeFileSync(schemaPath, `${generatorBlock(outDir)}\n`);
+
+    expect(() => generate({ schema: schemaPath })).toThrow(
+      path.resolve(schemaPath),
+    );
+  });
+
+  it("should generate successfully when a model exists", () => {
+    const schemaPath = path.join(schemaDir, "schema.prisma");
+    fs.writeFileSync(schemaPath, `${generatorBlock(outDir)}\n\n${userModel}\n`);
+
+    expect(() => generate({ schema: schemaPath })).not.toThrow();
+    expect(fs.existsSync(path.join(outDir, "schemaClient.d.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, "schemaClient.js"))).toBe(true);
+  });
+
+  it("should throw NoModelsError when no file in a multi-file schema has models", () => {
+    fs.writeFileSync(
+      path.join(schemaDir, "main.prisma"),
+      `${generatorBlock(outDir)}\n\n${datasourceBlock}\n`,
+    );
+    fs.writeFileSync(
+      path.join(schemaDir, "enums.prisma"),
+      "enum Role {\n  USER\n  ADMIN\n}\n",
+    );
+
+    expect(() => generate({ schema: schemaDir })).toThrow(NoModelsError);
+    expect(fs.existsSync(outDir)).toBe(false);
+  });
+
+  it("should generate successfully when one file in a multi-file schema has a model", () => {
+    fs.writeFileSync(
+      path.join(schemaDir, "main.prisma"),
+      `${generatorBlock(outDir)}\n\n${datasourceBlock}\n`,
+    );
+    fs.writeFileSync(path.join(schemaDir, "user.prisma"), `${userModel}\n`);
+
+    expect(() => generate({ schema: schemaDir })).not.toThrow();
+    expect(fs.existsSync(path.join(outDir, "gassmaClient.d.ts"))).toBe(true);
+  });
+});

--- a/src/__test__/generate/read/countModels.test.ts
+++ b/src/__test__/generate/read/countModels.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { countModels } from "../../../generate/read/countModels";
+
+describe("countModels", () => {
+  it("should return 0 for a schema with only generator and datasource", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+`;
+    expect(countModels(schema)).toBe(0);
+  });
+
+  it("should return 0 for a schema with only enums", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+`;
+    expect(countModels(schema)).toBe(0);
+  });
+
+  it("should count model declarations", () => {
+    const schema = `
+model User {
+  id   Int    @id
+  name String
+}
+
+model Post {
+  id    Int    @id
+  title String
+}
+`;
+    expect(countModels(schema)).toBe(2);
+  });
+
+  it("should exclude models with @@ignore", () => {
+    const schema = `
+model User {
+  id Int @id
+
+  @@ignore
+}
+`;
+    expect(countModels(schema)).toBe(0);
+  });
+});

--- a/src/__test__/validate/validate.test.ts
+++ b/src/__test__/validate/validate.test.ts
@@ -55,6 +55,46 @@ model User {
     );
   });
 
+  it("should return error when the schema has no models", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ type: "noModels" }),
+    );
+  });
+
+  it("should return error when the schema has only enums", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ type: "noModels" }),
+    );
+  });
+
   it("should return error when no generator block exists", () => {
     const schema = `
 model User {

--- a/src/error/mainError.ts
+++ b/src/error/mainError.ts
@@ -4,4 +4,14 @@ class ArgumentError extends Error {
   }
 }
 
-export { ArgumentError };
+class NoModelsError extends Error {
+  constructor(schemaLocation: string) {
+    super(
+      `GASsmaNoModelsError: You don't have any models defined in ${schemaLocation}, so nothing will be generated.\n` +
+        "You can define a model like this:\n\n" +
+        "model User {\n  id   Int    @id\n  name String\n}",
+    );
+  }
+}
+
+export { ArgumentError, NoModelsError };

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -14,7 +14,9 @@ import { extractMap } from "./read/extractMap";
 import { extractMapSheets } from "./read/extractMapSheets";
 import { extractEnums } from "./read/extractEnums";
 import { extractDatasourceUrl } from "./read/extractDatasourceUrl";
+import { countModels } from "./read/countModels";
 import { prismaReader } from "./read/prismaReader";
+import { NoModelsError } from "../error/mainError";
 import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
 import { filterOutputFiles } from "../config/filterOutputFiles";
 import { loadConfig } from "../config/loadConfig";
@@ -40,6 +42,11 @@ function generate(options?: GenerateOptions) {
   files.forEach((f) => console.log(`  📄 ${f.displayName}`));
 
   const schemaText = mergeSchemaFiles(files.map((f) => f.filePath));
+  if (countModels(schemaText) === 0) {
+    const location = files.length === 1 ? files[0].filePath : baseDir;
+    throw new NoModelsError(path.resolve(location));
+  }
+
   const schemaName = deriveSchemaName(baseDir, files);
   const schemaDatasourceUrl = extractDatasourceUrl(schemaText);
   const resolvedUrl = extractSpreadsheetId(

--- a/src/generate/read/countModels.ts
+++ b/src/generate/read/countModels.ts
@@ -1,0 +1,24 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+
+type PrismaAst = ReturnType<typeof parsePrismaSchema>;
+
+function hasModelIgnoreAttribute(decl: {
+  members?: ReadonlyArray<{ kind: string; path?: { value: string[] } }>;
+}): boolean {
+  return (decl.members ?? []).some(
+    (member) =>
+      member.kind === "blockAttribute" && member.path?.value[0] === "ignore",
+  );
+}
+
+function countModelsInAst(ast: PrismaAst): number {
+  return ast.declarations.filter(
+    (decl) => decl.kind === "model" && !hasModelIgnoreAttribute(decl),
+  ).length;
+}
+
+function countModels(schemaText: string): number {
+  return countModelsInAst(parsePrismaSchema(schemaText));
+}
+
+export { countModels, countModelsInAst, hasModelIgnoreAttribute };

--- a/src/generate/read/prismaReader.ts
+++ b/src/generate/read/prismaReader.ts
@@ -4,6 +4,7 @@ import { mapPrismaType } from "./mapPrismaType";
 import { isScalarField } from "./isScalarField";
 import { extractAddTypes, extractReplaceTypes } from "./extractAddTypes";
 import { extractEnums } from "./extractEnums";
+import { hasModelIgnoreAttribute } from "./countModels";
 
 function prismaReader(
   schemaText: string,
@@ -59,15 +60,6 @@ function prismaReader(
   });
 
   return result;
-}
-
-function hasModelIgnoreAttribute(decl: {
-  members?: ReadonlyArray<{ kind: string; path?: { value: string[] } }>;
-}): boolean {
-  return (decl.members ?? []).some(
-    (member) =>
-      member.kind === "blockAttribute" && member.path?.value[0] === "ignore",
-  );
 }
 
 function hasIgnoreAttribute(

--- a/src/validate/validate.ts
+++ b/src/validate/validate.ts
@@ -1,7 +1,8 @@
 import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import { countModelsInAst } from "../generate/read/countModels";
 
 type ValidationError = {
-  type: "syntax" | "missingGenerator" | "missingOutput";
+  type: "syntax" | "missingGenerator" | "missingOutput" | "noModels";
   message: string;
 };
 
@@ -39,6 +40,14 @@ const validateSchema = (schemaText: string): ValidationResult => {
       errors.push({
         type: "missingGenerator",
         message: "No generator block found. A generator block is required.",
+      });
+    }
+
+    if (countModelsInAst(ast) === 0) {
+      errors.push({
+        type: "noModels",
+        message:
+          "You don't have any models defined in your schema, so nothing will be generated. At least one model is required.",
       });
     }
   } catch (e) {


### PR DESCRIPTION
## 概要

スキーマに**モデル定義が0個のとき `generate` / `validate` をエラー**にしました（Prisma パリティ）。

## 背景

現状 gassma-cli は generator/datasource/enum のみ（モデル0）の .prisma でも **generate が成功し空クライアントを黙って生成**していました（実測 EXIT=0）。`model` キーワードのタイポ等でモデルが消えても気づけません。Prisma は逆にモデル0で generate をエラーにします（`--allow-no-models` で明示許可）。

gassma には **`--allow-no-models` フラグは付けず**、モデル0は常にエラーにします（不要とユーザー合意済み）。

## 変更

- **`countModels` / `countModelsInAst`（新規）**: モデル数カウント。prismaReader の `@@ignore` 除外と同一セマンティクス（＝生成 client が空になるスキーマがエラー条件）。prismaReader の重複ヘルパーも集約（挙動不変）。
- **generate**: `mergeSchemaFiles` 直後・出力書き込み前に `NoModelsError` を throw。
- **validate**: parse 成功後に `"noModels"` エラーを push。
- **`NoModelsError`**: 既存 `ArgumentError` の流儀（`GASsma...Error:` プレフィックス、クラス名にプレフィックスなし）に準拠。generate 側メッセージはスキーマの絶対パスを含む。
- **判定単位**: 1回の generate/validate 呼び出し（マルチファイルは統合後の合計、別ディレクトリ別 client は別呼び出し）。

## テスト（TDD: Red → Green）

- `countModels.test.ts`（4）: generator+datasource のみ→0 / enum のみ→0 / モデル2個→2 / `@@ignore` 除外
- `noModels.test.ts`（6）: モデル0で throw かつ出力なし / メッセージにパス / モデル有りは生成成功 / マルチファイル合計0で throw / 1ファイルにモデル有りで成功
- `validate.test.ts`（+2）: datasource のみ・enum のみ→ `noModels` エラー
- **vitest 564/564・test:types 564 + Type Errors なし（114 ファイル）・tsc clean・build 成功・biome clean**。既存テスト非回帰。
- **bin 実挙動**: enum のみで `generate`/`validate` とも EXIT=1・エラーメッセージ・出力未生成。モデル追記で EXIT=0 復帰。

## リリース時の追記（別途・本 PR では変更せず）

reference `型ファイルの動的生成.md` の `gassma validate` チェック項目に「モデルが1つ以上定義されているか」を追加すべき。

## 補足（既存挙動踏襲）

generate のエラーは既存 `No output path found` と同じ「throw → exit 1」フローのため CLI 実行時にスタックトレースが出ます。整形するなら command.ts での catch 追加が別課題です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMKrXnx9WMRGvtxhWGtWcx