### PR TITLE
feat: GassmaConfigEnvError and typed env() overload (Prisma parity)

### DIFF
--- a/src/__test__/config/env.test.ts
+++ b/src/__test__/config/env.test.ts
@@ -1,5 +1,30 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { env } from "../../config/env";
+import * as configEntry from "../../config/defineConfig";
+import { GassmaConfigEnvError } from "../../error/mainError";
+
+describe("GassmaConfigEnvError", () => {
+  it("should have a Prisma-style message", () => {
+    const error = new GassmaConfigEnvError("DATABASE_URL");
+    expect(error.message).toBe(
+      "Cannot resolve environment variable: DATABASE_URL.",
+    );
+  });
+
+  it("should have the class name as error.name", () => {
+    const error = new GassmaConfigEnvError("DATABASE_URL");
+    expect(error.name).toBe("GassmaConfigEnvError");
+  });
+
+  it("should be an instance of Error", () => {
+    const error = new GassmaConfigEnvError("DATABASE_URL");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("should be exported from the gassma/config entry", () => {
+    expect(configEntry.GassmaConfigEnvError).toBe(GassmaConfigEnvError);
+  });
+});
 
 describe("env", () => {
   const originalEnv = process.env;
@@ -17,17 +42,19 @@ describe("env", () => {
     expect(env("TEST_URL")).toBe("https://example.com");
   });
 
-  it("should throw if the environment variable is not set", () => {
+  it("should throw GassmaConfigEnvError if the environment variable is not set", () => {
     delete process.env.MISSING_VAR;
+    expect(() => env("MISSING_VAR")).toThrow(GassmaConfigEnvError);
     expect(() => env("MISSING_VAR")).toThrow(
-      'Environment variable "MISSING_VAR" is not set',
+      "Cannot resolve environment variable: MISSING_VAR.",
     );
   });
 
-  it("should throw if the environment variable is empty string", () => {
+  it("should throw GassmaConfigEnvError if the environment variable is empty string", () => {
     process.env.EMPTY_VAR = "";
+    expect(() => env("EMPTY_VAR")).toThrow(GassmaConfigEnvError);
     expect(() => env("EMPTY_VAR")).toThrow(
-      'Environment variable "EMPTY_VAR" is not set',
+      "Cannot resolve environment variable: EMPTY_VAR.",
     );
   });
 });

--- a/src/__test__/types/config/env.test-d.ts
+++ b/src/__test__/types/config/env.test-d.ts
@@ -1,0 +1,20 @@
+import { expectTypeOf } from "vitest";
+import { env } from "../../../config/env";
+
+type Env = {
+  DATABASE_URL: string;
+  OPTIONAL_URL?: string;
+  PORT: number;
+};
+
+expectTypeOf(env("ANY_NAME")).toEqualTypeOf<string>();
+
+expectTypeOf(env<Env>("DATABASE_URL")).toEqualTypeOf<string>();
+
+expectTypeOf(env<Env>("OPTIONAL_URL")).toEqualTypeOf<string>();
+
+// @ts-expect-error Env に無いキーは受け付けない
+env<Env>("NOT_A_KEY");
+
+// @ts-expect-error 値が string | undefined でないキーは受け付けない
+env<Env>("PORT");

--- a/src/config/defineConfig.ts
+++ b/src/config/defineConfig.ts
@@ -11,4 +11,5 @@ const defineConfig = (config: GassmaConfig): GassmaConfig => {
 
 export { defineConfig };
 export { env } from "./env";
+export { GassmaConfigEnvError } from "../error/mainError";
 export type { GassmaConfig };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,9 +1,17 @@
-const env = (name: string): string => {
+import { GassmaConfigEnvError } from "../error/mainError";
+
+type EnvKey<Env> = keyof {
+  [K in keyof Env as Env[K] extends string | undefined ? K : never]: Env[K];
+};
+
+function env(name: string): string;
+function env<Env>(name: EnvKey<Env> & string): string;
+function env(name: string): string {
   const value = process.env[name];
   if (!value) {
-    throw new Error(`Environment variable "${name}" is not set`);
+    throw new GassmaConfigEnvError(name);
   }
   return value;
-};
+}
 
 export { env };

--- a/src/error/mainError.ts
+++ b/src/error/mainError.ts
@@ -32,9 +32,17 @@ class ConfigFileNotFoundError extends Error {
   }
 }
 
+class GassmaConfigEnvError extends Error {
+  constructor(name: string) {
+    super(`Cannot resolve environment variable: ${name}.`);
+    this.name = "GassmaConfigEnvError";
+  }
+}
+
 export {
   ArgumentError,
   NoModelsError,
   NoDatasourceUrlError,
   ConfigFileNotFoundError,
+  GassmaConfigEnvError,
 };


### PR DESCRIPTION
## 概要

`env()` の Prisma 完全整合(config 拡張シリーズ P4)。`@prisma/config` **実物**の実装・型定義を読み取り、同形にしました。

- **`GassmaConfigEnvError`** 新設: message 文言(`Cannot resolve environment variable: ${name}.`)・`error.name` とも Prisma の `PrismaConfigEnvError` と同一構造。素 throw を置換し、Prisma 同様に `gassma/config` エントリから export。
- **型オーバーロード**: `env<Env>(name: EnvKey<Env> & string)` を Prisma と同形で追加(EnvKey は非公開 mapped type)。型付き環境変数インターフェースで補完が効き、非 string 値キーは型エラー。**tsup ビルド後の d.ts が Prisma の d.ts と同形**になることも確認済み。

## テスト(TDD 4サイクル・全て Red 実測 → Green)

- 値テスト + throw の新期待、型テスト(expectTypeOf 3 + `@ts-expect-error` 2: 非キー拒否・number 値キー拒否)。
- unit **589** / `test:types` 型エラー0 / `tsc --noEmit` clean / biome clean。

## 補足

- 変更は env 系に閉じており **loadConfig.ts 不触** → 並行の config 系ブランチ(P1/P2/P3/P5)と競合しません。**マージ順自由**です。
- 既存 `mainError.ts` の他エラーは旧スタイル(`this.name` 未設定)のままで、改修はスコープ外として温存(ファイル内スタイル混在は既知)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja