### PR TITLE
feat: add --config <path> to all config-loading commands (Prisma parity)

### DIFF
--- a/src/__test__/command/configFlag.test.ts
+++ b/src/__test__/command/configFlag.test.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const projectRoot = path.resolve(__dirname, "../../..");
+const tsxCli = path.join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const commandTs = path.join(projectRoot, "src", "command.ts");
+
+describe("gassma generate --config (e2e)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "gassma-cli-e2e-")),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it(
+    "should generate using a schema resolved against the config file directory",
+    { timeout: 120_000 },
+    () => {
+      const confDir = path.join(tmpDir, "conf");
+      fs.mkdirSync(path.join(confDir, "schemas"), { recursive: true });
+      fs.writeFileSync(
+        path.join(confDir, "schemas", "main.prisma"),
+        `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`,
+      );
+      fs.writeFileSync(
+        path.join(confDir, "custom.config.ts"),
+        `export default { schema: "schemas/main.prisma" };`,
+      );
+
+      execFileSync(
+        process.execPath,
+        [tsxCli, commandTs, "generate", "--config", "conf/custom.config.ts"],
+        { cwd: tmpDir, stdio: "pipe" },
+      );
+
+      const outDir = path.join(tmpDir, "generated");
+      expect(fs.existsSync(path.join(outDir, "mainClient.d.ts"))).toBe(true);
+      expect(fs.existsSync(path.join(outDir, "mainClient.js"))).toBe(true);
+    },
+  );
+});

--- a/src/__test__/config/loadConfig.test.ts
+++ b/src/__test__/config/loadConfig.test.ts
@@ -3,15 +3,16 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { loadConfig } from "../../config/loadConfig";
+import { ConfigFileNotFoundError } from "../../error/mainError";
 
 describe("loadConfig", () => {
   let tmpDir: string;
   let originalCwd: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-config-"));
     originalCwd = process.cwd();
-    process.chdir(tmpDir);
+    process.chdir(fs.mkdtempSync(path.join(os.tmpdir(), "gassma-config-")));
+    tmpDir = process.cwd();
   });
 
   afterEach(() => {
@@ -19,43 +20,96 @@ describe("loadConfig", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("should return undefined when no gassma.config.ts exists", () => {
-    const config = loadConfig();
-    expect(config).toBeUndefined();
-  });
+  describe("default config path", () => {
+    it("should return undefined when no gassma.config.ts exists", () => {
+      const loaded = loadConfig();
+      expect(loaded).toBeUndefined();
+    });
 
-  it("should load schema from gassma.config.ts", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "gassma.config.ts"),
-      `export default { schema: "gassma/test.prisma" };`,
-    );
+    it("should load schema from gassma.config.ts", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma.config.ts"),
+        `export default { schema: "gassma/test.prisma" };`,
+      );
 
-    const config = loadConfig();
-    expect(config).toEqual({ schema: "gassma/test.prisma" });
-  });
+      const loaded = loadConfig();
+      expect(loaded?.config).toEqual({ schema: "gassma/test.prisma" });
+    });
 
-  it("should load config with defineConfig", () => {
-    const defineConfigPath = path.resolve(
-      __dirname,
-      "../../config/defineConfig",
-    );
-    fs.writeFileSync(
-      path.join(tmpDir, "gassma.config.ts"),
-      `import { defineConfig } from "${defineConfigPath}";
+    it("should keep the config file path in the result", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma.config.ts"),
+        `export default { schema: "gassma/test.prisma" };`,
+      );
+
+      const loaded = loadConfig();
+      expect(loaded?.filePath).toBe(path.join(tmpDir, "gassma.config.ts"));
+    });
+
+    it("should load config with defineConfig", () => {
+      const defineConfigPath = path.resolve(
+        __dirname,
+        "../../config/defineConfig",
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma.config.ts"),
+        `import { defineConfig } from "${defineConfigPath}";
 export default defineConfig({ schema: "gassma/schema.prisma" });`,
-    );
+      );
 
-    const config = loadConfig();
-    expect(config).toEqual({ schema: "gassma/schema.prisma" });
+      const loaded = loadConfig();
+      expect(loaded?.config).toEqual({ schema: "gassma/schema.prisma" });
+    });
+
+    it("should return config without schema when schema is not specified", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma.config.ts"),
+        `export default {};`,
+      );
+
+      const loaded = loadConfig();
+      expect(loaded?.config).toEqual({});
+    });
   });
 
-  it("should return config without schema when schema is not specified", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "gassma.config.ts"),
-      `export default {};`,
-    );
+  describe("explicit config path", () => {
+    it("should load a relative config path resolved from cwd", () => {
+      const dir = path.join(tmpDir, "conf");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "custom.config.ts"),
+        `export default { schema: "schemas" };`,
+      );
 
-    const config = loadConfig();
-    expect(config).toEqual({});
+      const loaded = loadConfig("conf/custom.config.ts");
+      expect(loaded?.config).toEqual({ schema: "schemas" });
+      expect(loaded?.filePath).toBe(
+        path.join(tmpDir, "conf", "custom.config.ts"),
+      );
+    });
+
+    it("should load an absolute config path", () => {
+      const filePath = path.join(tmpDir, "my.config.ts");
+      fs.writeFileSync(filePath, `export default { schema: "gassma" };`);
+
+      const loaded = loadConfig(filePath);
+      expect(loaded?.config).toEqual({ schema: "gassma" });
+      expect(loaded?.filePath).toBe(filePath);
+    });
+
+    it("should throw ConfigFileNotFoundError when the explicit path does not exist", () => {
+      expect(() => loadConfig("conf/missing.config.ts")).toThrow(
+        ConfigFileNotFoundError,
+      );
+      expect(() => loadConfig("conf/missing.config.ts")).toThrow(
+        /GASsmaConfigFileNotFoundError/,
+      );
+    });
+
+    it("should include the resolved path in the not-found error message", () => {
+      expect(() => loadConfig("conf/missing.config.ts")).toThrow(
+        path.join(tmpDir, "conf", "missing.config.ts"),
+      );
+    });
   });
 });

--- a/src/__test__/config/resolveSchemaFiles.test.ts
+++ b/src/__test__/config/resolveSchemaFiles.test.ts
@@ -3,15 +3,16 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { resolveSchemaFiles } from "../../config/resolveSchemaFiles";
+import { ConfigFileNotFoundError } from "../../error/mainError";
 
 describe("resolveSchemaFiles", () => {
   let tmpDir: string;
   let originalCwd: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-resolve-"));
     originalCwd = process.cwd();
-    process.chdir(tmpDir);
+    process.chdir(fs.mkdtempSync(path.join(os.tmpdir(), "gassma-resolve-")));
+    tmpDir = process.cwd();
   });
 
   afterEach(() => {
@@ -49,7 +50,9 @@ describe("resolveSchemaFiles", () => {
 
       const files = resolveSchemaFiles({});
       expect(files).toHaveLength(1);
-      expect(files[0].filePath).toBe(path.join("custom", "schema.prisma"));
+      expect(files[0].filePath).toBe(
+        path.join(tmpDir, "custom", "schema.prisma"),
+      );
     });
 
     it("should resolve directory from gassma.config.ts", () => {
@@ -78,6 +81,90 @@ describe("resolveSchemaFiles", () => {
       const files = resolveSchemaFiles({ schema: "gassma/override.prisma" });
       expect(files).toHaveLength(1);
       expect(files[0].displayName).toBe("override.prisma");
+    });
+  });
+
+  describe("--config option", () => {
+    it("should resolve a relative schema file against the config file directory", () => {
+      const confDir = path.join(tmpDir, "conf");
+      fs.mkdirSync(path.join(confDir, "schemas"), { recursive: true });
+      fs.writeFileSync(path.join(confDir, "schemas", "main.prisma"), "content");
+      fs.writeFileSync(
+        path.join(confDir, "custom.config.ts"),
+        `export default { schema: "schemas/main.prisma" };`,
+      );
+
+      const files = resolveSchemaFiles({ config: "conf/custom.config.ts" });
+      expect(files).toHaveLength(1);
+      expect(files[0].filePath).toBe(
+        path.join(confDir, "schemas", "main.prisma"),
+      );
+    });
+
+    it("should resolve a relative schema directory against the config file directory", () => {
+      const confDir = path.join(tmpDir, "conf");
+      fs.mkdirSync(path.join(confDir, "schemas"), { recursive: true });
+      fs.writeFileSync(path.join(confDir, "schemas", "a.prisma"), "content");
+      fs.writeFileSync(path.join(confDir, "schemas", "b.prisma"), "content");
+      fs.writeFileSync(
+        path.join(confDir, "custom.config.ts"),
+        `export default { schema: "schemas" };`,
+      );
+
+      const files = resolveSchemaFiles({ config: "conf/custom.config.ts" });
+      expect(files).toHaveLength(2);
+    });
+
+    it("should use an absolute schema path in the config as is", () => {
+      const schemaDir = path.join(tmpDir, "elsewhere");
+      fs.mkdirSync(schemaDir, { recursive: true });
+      fs.writeFileSync(path.join(schemaDir, "schema.prisma"), "content");
+      const confDir = path.join(tmpDir, "conf");
+      fs.mkdirSync(confDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(confDir, "custom.config.ts"),
+        `export default { schema: ${JSON.stringify(schemaDir)} };`,
+      );
+
+      const files = resolveSchemaFiles({ config: "conf/custom.config.ts" });
+      expect(files).toHaveLength(1);
+      expect(files[0].filePath).toBe(path.join(schemaDir, "schema.prisma"));
+    });
+
+    it("--schema should override the schema in --config", () => {
+      const dir = path.join(tmpDir, "gassma");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "override.prisma"), "content");
+      fs.writeFileSync(
+        path.join(tmpDir, "custom.config.ts"),
+        `export default { schema: "other/schema.prisma" };`,
+      );
+
+      const files = resolveSchemaFiles({
+        schema: "gassma/override.prisma",
+        config: "custom.config.ts",
+      });
+      expect(files).toHaveLength(1);
+      expect(files[0].displayName).toBe("override.prisma");
+    });
+
+    it("should throw ConfigFileNotFoundError when --config does not exist", () => {
+      expect(() =>
+        resolveSchemaFiles({ config: "conf/missing.config.ts" }),
+      ).toThrow(ConfigFileNotFoundError);
+    });
+
+    it("should throw for a missing --config even when --schema is given", () => {
+      const dir = path.join(tmpDir, "gassma");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "test.prisma"), "content");
+
+      expect(() =>
+        resolveSchemaFiles({
+          schema: "gassma/test.prisma",
+          config: "conf/missing.config.ts",
+        }),
+      ).toThrow(ConfigFileNotFoundError);
     });
   });
 

--- a/src/__test__/format/formatCommand.test.ts
+++ b/src/__test__/format/formatCommand.test.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import { format } from "../../format/formatCommand";
+import { ConfigFileNotFoundError } from "../../error/mainError";
 
 describe("format", () => {
   let tmpDir: string;
@@ -79,6 +80,34 @@ describe("format", () => {
       fs.mkdirSync(dir, { recursive: true });
 
       await expect(format()).rejects.toThrow("No .prisma files found");
+    });
+  });
+
+  describe("with --config", () => {
+    it("should format a schema resolved against the config file directory", async () => {
+      const confDir = path.join(tmpDir, "conf");
+      fs.mkdirSync(path.join(confDir, "schemas"), { recursive: true });
+      const schemaPath = path.join(confDir, "schemas", "main.prisma");
+      fs.writeFileSync(
+        schemaPath,
+        "model User {\nid Int @id\nname    String\n}\n",
+      );
+      fs.writeFileSync(
+        path.join(confDir, "custom.config.ts"),
+        `export default { schema: "schemas" };`,
+      );
+
+      await format({ config: "conf/custom.config.ts" });
+
+      expect(fs.readFileSync(schemaPath, "utf-8")).toBe(
+        "model User {\n  id   Int    @id\n  name String\n}\n",
+      );
+    });
+
+    it("should throw ConfigFileNotFoundError when --config does not exist", async () => {
+      await expect(
+        format({ config: "conf/missing.config.ts" }),
+      ).rejects.toThrow(ConfigFileNotFoundError);
     });
   });
 

--- a/src/__test__/generate/configOption.test.ts
+++ b/src/__test__/generate/configOption.test.ts
@@ -1,0 +1,84 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { generate } from "../../generate/generate";
+import { ConfigFileNotFoundError } from "../../error/mainError";
+
+const schemaText = (outDir: string) => `generator client {
+  provider = "prisma-client-js"
+  output   = "${outDir}"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+
+describe("generate with --config", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let confDir: string;
+  let outDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(fs.mkdtempSync(path.join(os.tmpdir(), "gassma-gen-config-")));
+    tmpDir = process.cwd();
+    confDir = path.join(tmpDir, "conf");
+    outDir = path.join(tmpDir, "generated");
+    fs.mkdirSync(path.join(confDir, "schemas"), { recursive: true });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should generate from a schema resolved against the config file directory", () => {
+    fs.writeFileSync(
+      path.join(confDir, "schemas", "main.prisma"),
+      schemaText(outDir),
+    );
+    fs.writeFileSync(
+      path.join(confDir, "custom.config.ts"),
+      `export default { schema: "schemas/main.prisma" };`,
+    );
+
+    generate({ config: "conf/custom.config.ts" });
+
+    expect(fs.existsSync(path.join(outDir, "mainClient.d.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, "mainClient.js"))).toBe(true);
+  });
+
+  it("should use datasource.url from the config given by --config", () => {
+    fs.writeFileSync(
+      path.join(confDir, "schemas", "main.prisma"),
+      schemaText(outDir),
+    );
+    fs.writeFileSync(
+      path.join(confDir, "custom.config.ts"),
+      `export default {
+  schema: "schemas/main.prisma",
+  datasource: { url: "configSheetId123" },
+};`,
+    );
+
+    generate({ config: "conf/custom.config.ts" });
+
+    const clientJs = fs.readFileSync(
+      path.join(outDir, "mainClient.js"),
+      "utf-8",
+    );
+    expect(clientJs).toContain(`id: "configSheetId123"`);
+  });
+
+  it("should throw ConfigFileNotFoundError when --config does not exist", () => {
+    expect(() => generate({ config: "conf/missing.config.ts" })).toThrow(
+      ConfigFileNotFoundError,
+    );
+  });
+});

--- a/src/__test__/generate/watchGenerate.test.ts
+++ b/src/__test__/generate/watchGenerate.test.ts
@@ -54,6 +54,18 @@ describe("watchGenerate", () => {
     expect(mockGenerate).toHaveBeenCalledWith({ schema: "custom/path.prisma" });
     expect(mockResolveSchemaFiles).toHaveBeenCalledWith({
       schema: "custom/path.prisma",
+      config: undefined,
+    });
+  });
+
+  it("should pass config option to generate and resolveSchemaFiles", () => {
+    watchGenerate({ config: "conf/custom.config.ts" });
+    expect(mockGenerate).toHaveBeenCalledWith({
+      config: "conf/custom.config.ts",
+    });
+    expect(mockResolveSchemaFiles).toHaveBeenCalledWith({
+      schema: undefined,
+      config: "conf/custom.config.ts",
     });
   });
 

--- a/src/__test__/studio/resolveStudioUrl.test.ts
+++ b/src/__test__/studio/resolveStudioUrl.test.ts
@@ -88,4 +88,21 @@ describe("resolveStudioUrl", () => {
     expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
     expect(() => resolveStudioUrl()).toThrow(/GASsmaNoDatasourceUrlError/);
   });
+
+  it("should resolve from a config given by the config option", () => {
+    const confDir = path.join(tmpDir, "conf");
+    fs.mkdirSync(path.join(confDir, "schemas"), { recursive: true });
+    fs.writeFileSync(
+      path.join(confDir, "schemas", "main.prisma"),
+      SCHEMA_WITHOUT_URL,
+    );
+    fs.writeFileSync(
+      path.join(confDir, "custom.config.ts"),
+      `export default { schema: "schemas", datasource: { url: "configId789" } };`,
+    );
+
+    expect(resolveStudioUrl({ config: "conf/custom.config.ts" })).toBe(
+      "https://docs.google.com/spreadsheets/d/configId789/edit",
+    );
+  });
 });

--- a/src/__test__/studio/studioCommand.test.ts
+++ b/src/__test__/studio/studioCommand.test.ts
@@ -23,4 +23,16 @@ describe("studioCommand", () => {
     expect(log).toHaveBeenCalledWith(`🚀 Opening ${URL}`);
     expect(openBrowser).toHaveBeenCalledWith(URL);
   });
+
+  it("should pass the config option to resolveStudioUrl", async () => {
+    vi.mocked(resolveStudioUrl).mockReturnValue(URL);
+    vi.mocked(openBrowser).mockResolvedValue(undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await studioCommand({ config: "conf/custom.config.ts" });
+
+    expect(resolveStudioUrl).toHaveBeenCalledWith({
+      config: "conf/custom.config.ts",
+    });
+  });
 });

--- a/src/__test__/validate/validateCommand.test.ts
+++ b/src/__test__/validate/validateCommand.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { validate } from "../../validate/validateCommand";
+import { ConfigFileNotFoundError } from "../../error/mainError";
+
+const VALID_SCHEMA = `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+
+describe("validate with --config", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(fs.mkdtempSync(path.join(os.tmpdir(), "gassma-validate-")));
+    tmpDir = process.cwd();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should validate a schema resolved against the config file directory", () => {
+    const confDir = path.join(tmpDir, "conf");
+    fs.mkdirSync(path.join(confDir, "schemas"), { recursive: true });
+    fs.writeFileSync(
+      path.join(confDir, "schemas", "main.prisma"),
+      VALID_SCHEMA,
+    );
+    fs.writeFileSync(
+      path.join(confDir, "custom.config.ts"),
+      `export default { schema: "schemas" };`,
+    );
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    validate({ config: "conf/custom.config.ts" });
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("is valid"));
+  });
+
+  it("should throw ConfigFileNotFoundError when --config does not exist", () => {
+    expect(() => validate({ config: "conf/missing.config.ts" })).toThrow(
+      ConfigFileNotFoundError,
+    );
+  });
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -20,12 +20,13 @@ program
   .command("generate")
   .description("Generate type definitions from .prisma files")
   .option("--schema <path>", "Path to a specific .prisma file to generate")
+  .option("--config <path>", "Custom path to your GASsma config file")
   .option("--watch", "Watch for changes and regenerate automatically")
   .action((options) => {
     if (options.watch) {
-      watchGenerate({ schema: options.schema });
+      watchGenerate({ schema: options.schema, config: options.config });
     } else {
-      generate({ schema: options.schema });
+      generate({ schema: options.schema, config: options.config });
     }
   });
 
@@ -33,19 +34,22 @@ program
   .command("validate")
   .description("Validate .prisma files in the gassma directory")
   .option("--schema <path>", "Path to a specific .prisma file to validate")
+  .option("--config <path>", "Custom path to your GASsma config file")
   .action((options) => {
-    validate({ schema: options.schema });
+    validate({ schema: options.schema, config: options.config });
   });
 
 program
   .command("format")
   .description("Format .prisma files in the gassma directory")
   .option("--schema <path>", "Path to a specific .prisma file to format")
+  .option("--config <path>", "Custom path to your GASsma config file")
   .option("--check", "Check if files are formatted without modifying them")
   .action(async (options) => {
     const result = await format({
       schema: options.schema,
       check: options.check,
+      config: options.config,
     });
     if (options.check && !result) {
       console.error("Some files are not formatted.");
@@ -65,8 +69,9 @@ program
 program
   .command("studio")
   .description("Open the datasource spreadsheet in your default browser")
-  .action(async () => {
-    await studioCommand();
+  .option("--config <path>", "Custom path to your GASsma config file")
+  .action(async (options) => {
+    await studioCommand({ config: options.config });
   });
 
 program

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,22 +1,30 @@
 import fs from "fs";
 import path from "path";
 import { createJiti } from "jiti";
+import { ConfigFileNotFoundError } from "../error/mainError";
 import type { GassmaConfig } from "./defineConfig";
 
 const CONFIG_FILE_NAME = "gassma.config.ts";
 
-const loadConfig = (): GassmaConfig | undefined => {
-  const configPath = path.resolve(process.cwd(), CONFIG_FILE_NAME);
+type LoadedConfig = {
+  config: GassmaConfig;
+  filePath: string;
+};
 
-  if (!fs.existsSync(configPath)) {
-    return undefined;
+const loadConfig = (configPath?: string): LoadedConfig | undefined => {
+  const filePath = path.resolve(process.cwd(), configPath ?? CONFIG_FILE_NAME);
+
+  if (!fs.existsSync(filePath)) {
+    if (configPath === undefined) return undefined;
+    throw new ConfigFileNotFoundError(filePath);
   }
 
-  const jiti = createJiti(configPath);
-  const mod = jiti(configPath);
-  const config = (mod.default ?? mod) as GassmaConfig;
+  const jiti = createJiti(filePath);
+  const mod = jiti(filePath);
+  const config: GassmaConfig = mod.default ?? mod;
 
-  return config;
+  return { config, filePath };
 };
 
 export { loadConfig };
+export type { LoadedConfig };

--- a/src/config/resolveSchemaFiles.ts
+++ b/src/config/resolveSchemaFiles.ts
@@ -2,9 +2,11 @@ import fs from "fs";
 import path from "path";
 import { parseSchemaPath } from "../generate/parseSchemaPath";
 import { loadConfig } from "./loadConfig";
+import type { LoadedConfig } from "./loadConfig";
 
 type SchemaOptions = {
   schema?: string;
+  config?: string;
 };
 
 type SchemaFile = {
@@ -13,16 +15,26 @@ type SchemaFile = {
 };
 
 const resolveSchemaFiles = (options: SchemaOptions): SchemaFile[] => {
+  const loaded = loadConfigIfNeeded(options);
+
   if (options.schema) {
     return resolveFromSchemaOption(options.schema);
   }
 
-  const config = loadConfig();
-  if (config?.schema) {
-    return resolveFromConfigSchema(config.schema);
+  if (loaded?.config.schema) {
+    return resolveFromConfigSchema(
+      path.resolve(path.dirname(loaded.filePath), loaded.config.schema),
+    );
   }
 
   return resolveFromDefaultDir();
+};
+
+const loadConfigIfNeeded = (
+  options: SchemaOptions,
+): LoadedConfig | undefined => {
+  if (options.config === undefined && options.schema) return undefined;
+  return loadConfig(options.config);
 };
 
 const resolveFromSchemaOption = (schema: string): SchemaFile[] => {

--- a/src/error/mainError.ts
+++ b/src/error/mainError.ts
@@ -24,4 +24,17 @@ class NoDatasourceUrlError extends Error {
   }
 }
 
-export { ArgumentError, NoModelsError, NoDatasourceUrlError };
+class ConfigFileNotFoundError extends Error {
+  constructor(configPath: string) {
+    super(
+      `GASsmaConfigFileNotFoundError: config file not found at ${configPath}`,
+    );
+  }
+}
+
+export {
+  ArgumentError,
+  NoModelsError,
+  NoDatasourceUrlError,
+  ConfigFileNotFoundError,
+};

--- a/src/format/formatCommand.ts
+++ b/src/format/formatCommand.ts
@@ -6,10 +6,14 @@ import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
 type FormatOptions = {
   schema?: string;
   check?: boolean;
+  config?: string;
 };
 
 async function format(options?: FormatOptions): Promise<boolean> {
-  const files = resolveSchemaFiles({ schema: options?.schema });
+  const files = resolveSchemaFiles({
+    schema: options?.schema,
+    config: options?.config,
+  });
   const schemas: [string, string][] = files.map(({ filePath }) => [
     path.basename(filePath),
     fs.readFileSync(filePath, "utf-8"),

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -27,14 +27,18 @@ import { jsWriter } from "./jsWriter";
 
 type GenerateOptions = {
   schema?: string;
+  config?: string;
 };
 
 function generate(options?: GenerateOptions) {
-  const allFiles = resolveSchemaFiles({ schema: options?.schema });
+  const allFiles = resolveSchemaFiles({
+    schema: options?.schema,
+    config: options?.config,
+  });
   const baseDir = findBaseDir(allFiles.map((f) => f.filePath));
   const files = filterOutputFiles(allFiles, baseDir);
-  const config = loadConfig();
-  const datasourceUrl = extractSpreadsheetId(config?.datasource?.url);
+  const loaded = loadConfig(options?.config);
+  const datasourceUrl = extractSpreadsheetId(loaded?.config.datasource?.url);
 
   console.log(
     `📁 Found ${files.length} .prisma file(s) in ${path.basename(baseDir)} directory`,

--- a/src/generate/watchGenerate.ts
+++ b/src/generate/watchGenerate.ts
@@ -7,7 +7,10 @@ import type { GenerateOptions } from "./generate";
 const watchGenerate = (options?: GenerateOptions): (() => void) => {
   generate(options);
 
-  const files = resolveSchemaFiles({ schema: options?.schema });
+  const files = resolveSchemaFiles({
+    schema: options?.schema,
+    config: options?.config,
+  });
   const dirs = [...new Set(files.map((f) => path.dirname(f.filePath)))];
 
   console.log(`\n👀 Watching ${dirs.join(", ")} for changes...`);

--- a/src/studio/resolveStudioUrl.ts
+++ b/src/studio/resolveStudioUrl.ts
@@ -5,11 +5,16 @@ import { mergeSchemaFiles } from "../generate/mergeSchemaFiles";
 import { extractDatasourceUrl } from "../generate/read/extractDatasourceUrl";
 import { buildSpreadsheetUrl } from "./buildSpreadsheetUrl";
 
-const resolveStudioUrl = (): string => {
-  const files = resolveSchemaFiles({});
+type StudioUrlOptions = {
+  config?: string;
+};
+
+const resolveStudioUrl = (options?: StudioUrlOptions): string => {
+  const files = resolveSchemaFiles({ config: options?.config });
   const schemaText = mergeSchemaFiles(files.map((f) => f.filePath));
-  const config = loadConfig();
-  const urlOrId = extractDatasourceUrl(schemaText) ?? config?.datasource?.url;
+  const loaded = loadConfig(options?.config);
+  const urlOrId =
+    extractDatasourceUrl(schemaText) ?? loaded?.config.datasource?.url;
 
   if (urlOrId === undefined || urlOrId === null) {
     throw new NoDatasourceUrlError();
@@ -19,3 +24,4 @@ const resolveStudioUrl = (): string => {
 };
 
 export { resolveStudioUrl };
+export type { StudioUrlOptions };

--- a/src/studio/studioCommand.ts
+++ b/src/studio/studioCommand.ts
@@ -1,8 +1,9 @@
 import { openBrowser } from "./openBrowser";
 import { resolveStudioUrl } from "./resolveStudioUrl";
+import type { StudioUrlOptions } from "./resolveStudioUrl";
 
-const studioCommand = async (): Promise<void> => {
-  const url = resolveStudioUrl();
+const studioCommand = async (options?: StudioUrlOptions): Promise<void> => {
+  const url = resolveStudioUrl(options);
   console.log(`🚀 Opening ${url}`);
   await openBrowser(url);
 };

--- a/src/validate/validateCommand.ts
+++ b/src/validate/validateCommand.ts
@@ -6,10 +6,14 @@ import { mergeSchemaFiles } from "../generate/mergeSchemaFiles";
 
 type ValidateOptions = {
   schema?: string;
+  config?: string;
 };
 
 function validate(options?: ValidateOptions) {
-  const allFiles = resolveSchemaFiles({ schema: options?.schema });
+  const allFiles = resolveSchemaFiles({
+    schema: options?.schema,
+    config: options?.config,
+  });
   const baseDir =
     allFiles.length > 0 ? path.dirname(allFiles[0].filePath) : ".";
   const files = filterOutputFiles(allFiles, baseDir);


### PR DESCRIPTION
## 概要

config 拡張シリーズ **P1(本命)**: 全 config 利用コマンドに `--config <path>` を追加し、config 内パスの解決基準を Prisma と同じ「config ファイル位置基準」にしました。

```bash
npx gassma generate --config ./packages/app/gassma.config.ts
npx gassma validate --config ./packages/app/gassma.config.ts
```

## 仕様(Prisma 準拠)

| 項目 | 挙動 |
|---|---|
| `--config` 対象 | **generate(--watch 含む)/ validate / format / studio**。init(config を作る側)と version は対象外 — Prisma CLI の実サーフェスと同じ |
| `--config` のパス | cwd 基準で解決。**指定ファイル不在は `GASsmaConfigFileNotFoundError`**(解決済み絶対パス入り)。未指定は従来のサイレントなデフォルト探索 |
| `config.schema` | **config ファイルのディレクトリ基準**で絶対化(Prisma の transformPathsInConfigToAbsolute 相当)。デフォルト(cwd の config)では基準=cwd のため**既存挙動は完全不変** |
| `--schema` フラグ | 従来通り cwd 基準・`config.schema` より優先(Prisma と同じ非対称) |
| `datasource.url` | パスでないため不変 |

内部 API: `loadConfig` が `{ config, filePath }` を返す形に(公開 API `defineConfig`/`GassmaConfig` は不変)。既存の `as GassmaConfig` キャストを1箇所削減。

## テスト(TDD 5サイクル・各 Red 実測)

+22件(loadConfig 明示パス/不在エラー/従来デフォルト、config 位置基準の schema 解決、各コマンド配線、**tsx spawn の e2e** で `--config` 実動作 + 生成 JS への datasource.url 反映)。dist ビルド版でも generate/validate/format/--help 表示/不在エラー/従来デフォルト非回帰を手動確認済み。

- unit **607** / `test:types` 型エラー0 / `tsc --noEmit` clean / biome clean。

## マージ順

config 系5ブランチ(P1〜P5)のうち**本 PR を最初にマージ推奨**(#105/#107 等 loadConfig を触る他 PR は、本 PR マージ後に私が rebase して追随します)。#106(env)は独立・順不同。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja