### PR TITLE
feat: friendly config load errors and unknown-key warnings

### DIFF
--- a/src/__test__/config/loadConfigErrors.test.ts
+++ b/src/__test__/config/loadConfigErrors.test.ts
@@ -1,0 +1,197 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../../config/loadConfig";
+import { GassmaConfigLoadError } from "../../error/mainError";
+
+describe("loadConfig error handling", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let warnSpy: MockInstance<typeof console.warn>;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(fs.mkdtempSync(path.join(os.tmpdir(), "gassma-config-err-")));
+    tmpDir = process.cwd();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeConfig = (content: string): string => {
+    const configPath = path.join(tmpDir, "gassma.config.ts");
+    fs.writeFileSync(configPath, content);
+    return configPath;
+  };
+
+  const captureLoadError = (configPath?: string): GassmaConfigLoadError => {
+    try {
+      loadConfig(configPath);
+    } catch (error) {
+      if (error instanceof GassmaConfigLoadError) return error;
+      throw new Error(`expected GassmaConfigLoadError, got: ${String(error)}`);
+    }
+    throw new Error("expected loadConfig to throw");
+  };
+
+  describe("broken config files", () => {
+    it("should throw GassmaConfigLoadError with the file path for a syntax error", () => {
+      const configPath = writeConfig("export default { schema: ");
+
+      const error = captureLoadError();
+      expect(error.message).toContain(
+        "GASsmaConfigLoadError: Failed to load config file at",
+      );
+      expect(error.message).toContain(configPath);
+    });
+
+    it("should include the original error message for a runtime error", () => {
+      const configPath = writeConfig(
+        'throw new Error("boom in config");\nexport default {};',
+      );
+
+      const error = captureLoadError();
+      expect(error.message).toContain(configPath);
+      expect(error.message).toContain("boom in config");
+    });
+
+    it("should throw GassmaConfigLoadError for a broken explicit config path", () => {
+      const dir = path.join(tmpDir, "conf");
+      fs.mkdirSync(dir, { recursive: true });
+      const configPath = path.join(dir, "custom.config.ts");
+      fs.writeFileSync(configPath, "export default { schema: ");
+
+      const error = captureLoadError("conf/custom.config.ts");
+      expect(error.message).toContain(configPath);
+    });
+  });
+
+  describe("invalid export shapes", () => {
+    it("should throw when the default export is a string", () => {
+      const configPath = writeConfig('export default "not an object";');
+
+      const error = captureLoadError();
+      expect(error.message).toContain(configPath);
+      expect(error.message).toContain(
+        "Expected the config file to export a config object",
+      );
+      expect(error.message).toContain("a string");
+    });
+
+    it("should throw when the default export is null", () => {
+      writeConfig("export default null;");
+
+      const error = captureLoadError();
+      expect(error.message).toContain(
+        "Expected the config file to export a config object",
+      );
+      expect(error.message).toContain("null");
+    });
+
+    it("should throw when schema is not a string", () => {
+      writeConfig("export default { schema: 123 };");
+
+      const error = captureLoadError();
+      expect(error.message).toContain(
+        "Expected `schema` to be a string, but received a number",
+      );
+    });
+
+    it("should throw when datasource is not an object", () => {
+      writeConfig('export default { datasource: "https://example.com" };');
+
+      const error = captureLoadError();
+      expect(error.message).toContain(
+        "Expected `datasource` to be an object, but received a string",
+      );
+    });
+
+    it("should throw when datasource.url is not a string", () => {
+      writeConfig("export default { datasource: { url: 123 } };");
+
+      const error = captureLoadError();
+      expect(error.message).toContain(
+        "Expected `datasource.url` to be a string, but received a number",
+      );
+    });
+  });
+
+  describe("unknown keys", () => {
+    it("should warn about an unknown top-level key and still load the config", () => {
+      writeConfig(
+        'export default { schema: "gassma/a.prisma", schemna: "typo" };',
+      );
+
+      const loaded = loadConfig();
+
+      expect(loaded?.config).toEqual({ schema: "gassma/a.prisma" });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Unknown property `schemna`"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("gassma.config.ts"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Known properties are: schema, datasource"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("It will be ignored"),
+      );
+    });
+
+    it("should warn about an unknown datasource key and still load the config", () => {
+      writeConfig(
+        'export default { datasource: { url: "https://example.com", urls: "typo" } };',
+      );
+
+      const loaded = loadConfig();
+
+      expect(loaded?.config).toEqual({
+        datasource: { url: "https://example.com" },
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Unknown property `urls`"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("`datasource`"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Known properties are: url"),
+      );
+    });
+  });
+
+  describe("valid configs", () => {
+    it("should not warn for a fully valid config", () => {
+      const configPath = writeConfig(
+        'export default { schema: "gassma/a.prisma", datasource: { url: "https://example.com" } };',
+      );
+
+      const loaded = loadConfig();
+
+      expect(loaded?.config).toEqual({
+        schema: "gassma/a.prisma",
+        datasource: { url: "https://example.com" },
+      });
+      expect(loaded?.filePath).toBe(configPath);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("should load a config exported via named exports without warning", () => {
+      writeConfig('export const schema = "gassma/a.prisma";');
+
+      const loaded = loadConfig();
+
+      expect(loaded?.config).toEqual({ schema: "gassma/a.prisma" });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,9 +1,13 @@
 import fs from "fs";
 import path from "path";
 import { createJiti } from "jiti";
-import { ConfigFileNotFoundError } from "../error/mainError";
+import {
+  ConfigFileNotFoundError,
+  GassmaConfigLoadError,
+} from "../error/mainError";
 import type { GassmaConfig } from "./defineConfig";
 import { findConfigFile } from "./findConfigFile";
+import { parseConfigModule } from "./parseConfigModule";
 
 type LoadedConfig = {
   config: GassmaConfig;
@@ -25,10 +29,13 @@ const loadConfig = (configPath?: string): LoadedConfig | undefined => {
   }
 
   const jiti = createJiti(filePath);
-  const mod = jiti(filePath);
-  const config: GassmaConfig = mod.default ?? mod;
-
-  return { config, filePath };
+  try {
+    const mod: unknown = jiti(filePath);
+    return { config: parseConfigModule(mod, filePath), filePath };
+  } catch (error) {
+    if (error instanceof GassmaConfigLoadError) throw error;
+    throw new GassmaConfigLoadError(filePath, error);
+  }
 };
 
 export { loadConfig };

--- a/src/config/parseConfigModule.ts
+++ b/src/config/parseConfigModule.ts
@@ -1,0 +1,94 @@
+import { GassmaConfigLoadError } from "../error/mainError";
+import type { GassmaConfig } from "./defineConfig";
+
+const ROOT_KEYS = ["schema", "datasource"];
+const DATASOURCE_KEYS = ["url"];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const describeValue = (value: unknown): string => {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (Array.isArray(value)) return "an array";
+  return `a ${typeof value}`;
+};
+
+const resolveExported = (mod: unknown): unknown => {
+  if (!isRecord(mod)) return mod;
+  const descriptor = Object.getOwnPropertyDescriptor(mod, "default");
+  if (descriptor === undefined) return mod;
+  const exported: unknown = descriptor.value;
+  return exported;
+};
+
+const warnUnknownKeys = (
+  record: Record<string, unknown>,
+  knownKeys: string[],
+  location: string,
+): void => {
+  const unknownKeys = Object.keys(record).filter(
+    (key) => !knownKeys.includes(key) && key !== "__esModule",
+  );
+  unknownKeys.forEach((key) => {
+    console.warn(
+      `Warning: Unknown property \`${key}\` in ${location}. ` +
+        `Known properties are: ${knownKeys.join(", ")}. It will be ignored.`,
+    );
+  });
+};
+
+const readSchema = (
+  record: Record<string, unknown>,
+  configPath: string,
+): string | undefined => {
+  const value = record.schema;
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  throw new GassmaConfigLoadError(
+    configPath,
+    `Expected \`schema\` to be a string, but received ${describeValue(value)}.`,
+  );
+};
+
+const readDatasource = (
+  record: Record<string, unknown>,
+  configPath: string,
+): { url?: string } | undefined => {
+  const value = record.datasource;
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    throw new GassmaConfigLoadError(
+      configPath,
+      `Expected \`datasource\` to be an object, but received ${describeValue(value)}.`,
+    );
+  }
+  warnUnknownKeys(value, DATASOURCE_KEYS, `\`datasource\` of ${configPath}`);
+  const url = value.url;
+  if (url === undefined) return {};
+  if (typeof url === "string") return { url };
+  throw new GassmaConfigLoadError(
+    configPath,
+    `Expected \`datasource.url\` to be a string, but received ${describeValue(url)}.`,
+  );
+};
+
+const parseConfigModule = (mod: unknown, configPath: string): GassmaConfig => {
+  const exported = resolveExported(mod);
+  if (!isRecord(exported)) {
+    throw new GassmaConfigLoadError(
+      configPath,
+      `Expected the config file to export a config object, but received ${describeValue(exported)}.\n` +
+        'Example:\n  export default { schema: "gassma/schema.prisma" };',
+    );
+  }
+  warnUnknownKeys(exported, ROOT_KEYS, configPath);
+  const config: GassmaConfig = {};
+  const schema = readSchema(exported, configPath);
+  if (schema !== undefined) config.schema = schema;
+  const datasource = readDatasource(exported, configPath);
+  if (datasource !== undefined) config.datasource = datasource;
+  return config;
+};
+
+export { parseConfigModule };

--- a/src/error/mainError.ts
+++ b/src/error/mainError.ts
@@ -39,10 +39,20 @@ class GassmaConfigEnvError extends Error {
   }
 }
 
+class GassmaConfigLoadError extends Error {
+  constructor(configPath: string, reason: unknown) {
+    const detail = reason instanceof Error ? reason.message : String(reason);
+    super(
+      `GASsmaConfigLoadError: Failed to load config file at ${configPath}.\n${detail}`,
+    );
+  }
+}
+
 export {
   ArgumentError,
   NoModelsError,
   NoDatasourceUrlError,
   ConfigFileNotFoundError,
   GassmaConfigEnvError,
+  GassmaConfigLoadError,
 };


### PR DESCRIPTION
## 概要

config 拡張シリーズ P3: config ロードの失敗を分かりやすく、typo を warn で守るようにしました。従来は jiti の生エラー素通し + `as GassmaConfig` の無検証キャストでした。

## 変更

- **`GassmaConfigLoadError`** 新設: 構文/実行時エラーを「どのファイルで何が起きたか + 元エラー message」でラップ。
- **非オブジェクト export** は例付きの明確なエラー(`Expected the config file to export a config object, but received a string.` + Example)。
- **未知キー warn**(ロードは成功): トップレベル(`schema`/`datasource` 以外)と `datasource` 内(`url` 以外)を `Warning: Unknown property \`schemna\` ... It will be ignored.` 形式で指摘。戻り値からも未知キーを除外(warn 文言と整合)。
- **`as` キャスト排除**: 新設 `parseConfigModule`(94行)が narrowing で形状検証。`loadConfig.ts` の差分は +13/-4 に抑制(並行ブランチ競合の最小化)。
- **既知キーの型不正は throw**(`schema: 123` → 明確な message)。narrowing する以上、型不一致時の挙動決定が不可避で、黙殺より親切化の趣旨に合うと判断(過剰なら3テスト+チェック削除で戻せます)。
- **jiti の interop Proxy の罠を実測で発見・対処**: `export default null` は `.default` アクセスがモジュール自身を返すため、own-property descriptor 読みで真の default を取得。従来はゴミ素通り → 明確なエラーに。

## テスト(TDD: Red 9件実測 → Green)

+11件(構文/実行時2・export 形状5・warn 2・正常系非回帰2)。unit **596** / `test:types` 型エラー0 / `tsc --noEmit` clean / biome clean。

## マージ順の注意

**P1(#107)マージ後に rebase して追随予定**(loadConfig の戻り値形状が P1 で変わるため)。単独マージも可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja