### PR TITLE
feat: strictUndefinedChecks codegen (previewFeatures parse + Gassma.skip types + client.js flag)

### DIFF
--- a/scripts/genFixtureTypes.ts
+++ b/scripts/genFixtureTypes.ts
@@ -8,6 +8,7 @@ import { extractAutoincrement } from "../src/generate/read/extractAutoincrement"
 import { extractDefaults } from "../src/generate/read/extractDefaults";
 import { extractUpdatedAt } from "../src/generate/read/extractUpdatedAt";
 import { extractOptionalFields } from "../src/generate/read/extractOptionalFields";
+import { extractPreviewFeatures } from "../src/generate/read/extractPreviewFeatures";
 
 const fixturePath = path.join(
   __dirname,
@@ -15,30 +16,41 @@ const fixturePath = path.join(
 );
 const schemaText = fs.readFileSync(fixturePath, "utf-8");
 
-const parsed = prismaReader(schemaText);
-const relations = extractRelations(schemaText);
-const autoincrement = extractAutoincrement(schemaText);
-const defaults = extractDefaults(schemaText);
-const updatedAt = extractUpdatedAt(schemaText);
-const optionalFields = extractOptionalFields(schemaText);
-
-const generated = generater(
-  parsed,
-  relations,
-  "",
-  true,
-  defaults,
-  Object.keys(updatedAt),
-  Object.keys(autoincrement),
-  optionalFields,
-);
-const clientDts = generateClientDts("");
-
 const outDir = path.join(__dirname, "../src/__test__/types/__generated__");
 fs.mkdirSync(outDir, { recursive: true });
-fs.writeFileSync(
-  path.join(outDir, "client.d.ts"),
-  `${generated}\n${clientDts}`,
-);
 
-console.log(`generated fixture types -> ${path.join(outDir, "client.d.ts")}`);
+const generateFixture = (text: string, fileName: string) => {
+  const parsed = prismaReader(text);
+  const relations = extractRelations(text);
+  const autoincrement = extractAutoincrement(text);
+  const defaults = extractDefaults(text);
+  const updatedAt = extractUpdatedAt(text);
+  const optionalFields = extractOptionalFields(text);
+  const strict = extractPreviewFeatures(text).includes(
+    "strictUndefinedChecks",
+  );
+
+  const generated = generater(
+    parsed,
+    relations,
+    "",
+    true,
+    defaults,
+    Object.keys(updatedAt),
+    Object.keys(autoincrement),
+    optionalFields,
+    strict,
+  );
+  const clientDts = generateClientDts("");
+
+  fs.writeFileSync(path.join(outDir, fileName), `${generated}\n${clientDts}`);
+  console.log(`generated fixture types -> ${path.join(outDir, fileName)}`);
+};
+
+generateFixture(schemaText, "client.d.ts");
+
+const strictSchemaText = schemaText.replace(
+  'provider = "prisma-client-js"',
+  'provider        = "prisma-client-js"\n  previewFeatures = ["strictUndefinedChecks"]',
+);
+generateFixture(strictSchemaText, "clientStrict.d.ts");

--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -529,4 +529,31 @@ describe("generateClientJs", () => {
 
     expect(result).not.toContain("id:");
   });
+
+  it("should embed strictUndefinedChecks when enabled", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(result).toContain(
+      "Object.assign({}, options, { relations: testRelations, strictUndefinedChecks: true })",
+    );
+  });
+
+  it("should not embed strictUndefinedChecks by default", () => {
+    const result = generateClientJs({}, "Test");
+
+    expect(result).not.toContain("strictUndefinedChecks");
+  });
 });

--- a/src/__test__/generate/read/extractPreviewFeatures.test.ts
+++ b/src/__test__/generate/read/extractPreviewFeatures.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { extractPreviewFeatures } from "../../../generate/read/extractPreviewFeatures";
+
+describe("extractPreviewFeatures", () => {
+  it("should extract previewFeatures from generator block", () => {
+    const schema = `
+generator client {
+  provider        = "prisma-client-js"
+  output          = "./generated/gassma"
+  previewFeatures = ["strictUndefinedChecks"]
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+    expect(extractPreviewFeatures(schema)).toEqual(["strictUndefinedChecks"]);
+  });
+
+  it("should extract multiple preview features", () => {
+    const schema = `
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["strictUndefinedChecks", "someFutureFeature"]
+}
+
+model User {
+  id Int @id
+}
+`;
+    expect(extractPreviewFeatures(schema)).toEqual([
+      "strictUndefinedChecks",
+      "someFutureFeature",
+    ]);
+  });
+
+  it("should return empty array when previewFeatures is absent", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id Int @id
+}
+`;
+    expect(extractPreviewFeatures(schema)).toEqual([]);
+  });
+
+  it("should return empty array when no generator block exists", () => {
+    const schema = `
+model User {
+  id Int @id
+}
+`;
+    expect(extractPreviewFeatures(schema)).toEqual([]);
+  });
+
+  it("should return empty array for empty previewFeatures array", () => {
+    const schema = `
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = []
+}
+
+model User {
+  id Int @id
+}
+`;
+    expect(extractPreviewFeatures(schema)).toEqual([]);
+  });
+
+  it("should ignore non-string items", () => {
+    const schema = `
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["strictUndefinedChecks", 1]
+}
+
+model User {
+  id Int @id
+}
+`;
+    expect(extractPreviewFeatures(schema)).toEqual(["strictUndefinedChecks"]);
+  });
+});

--- a/src/__test__/generate/strictPreviewFeature.test.ts
+++ b/src/__test__/generate/strictPreviewFeature.test.ts
@@ -1,0 +1,85 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { generate } from "../../generate/generate";
+
+const schemaText = (
+  outDir: string,
+  previewFeatures?: string,
+) => `generator client {
+  provider = "prisma-client-js"
+  output   = "${outDir}"
+${previewFeatures ? `  previewFeatures = ${previewFeatures}\n` : ""}}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+
+describe("generate with previewFeatures strictUndefinedChecks", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let outDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(fs.mkdtempSync(path.join(os.tmpdir(), "gassma-gen-strict-")));
+    tmpDir = process.cwd();
+    outDir = path.join(tmpDir, "generated");
+    fs.mkdirSync(path.join(tmpDir, "schemas"), { recursive: true });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should inject strictUndefinedChecks into client.js and skip types into d.ts", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "schemas", "main.prisma"),
+      schemaText(outDir, '["strictUndefinedChecks"]'),
+    );
+
+    generate({ schema: "schemas/main.prisma" });
+
+    const js = fs.readFileSync(path.join(outDir, "mainClient.js"), "utf-8");
+    const dts = fs.readFileSync(path.join(outDir, "mainClient.d.ts"), "utf-8");
+
+    expect(js).toContain("strictUndefinedChecks: true");
+    expect(dts).toContain("const skip: unique symbol;");
+    expect(dts).toContain("Gassma.SkipValue");
+  });
+
+  it("should not change output without previewFeatures", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "schemas", "main.prisma"),
+      schemaText(outDir),
+    );
+
+    generate({ schema: "schemas/main.prisma" });
+
+    const js = fs.readFileSync(path.join(outDir, "mainClient.js"), "utf-8");
+    const dts = fs.readFileSync(path.join(outDir, "mainClient.d.ts"), "utf-8");
+
+    expect(js).not.toContain("strictUndefinedChecks");
+    expect(dts).not.toContain("SkipValue");
+    expect(dts).not.toContain("unique symbol");
+  });
+
+  it("should ignore unknown preview features", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "schemas", "main.prisma"),
+      schemaText(outDir, '["someFutureFeature"]'),
+    );
+
+    generate({ schema: "schemas/main.prisma" });
+
+    const js = fs.readFileSync(path.join(outDir, "mainClient.js"), "utf-8");
+
+    expect(js).not.toContain("strictUndefinedChecks");
+  });
+});

--- a/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -52,4 +52,52 @@ describe("getGassmaCommonTypes", () => {
     expect(result).not.toContain("type RelationListFilter");
     expect(result).not.toContain("type RelationSingleFilter");
   });
+
+  it("should not contain skip declarations by default", () => {
+    expect(result).not.toContain("skip");
+    expect(result).not.toContain("SkipValue");
+    expect(result).not.toContain("SkipOptional");
+  });
+
+  describe("strict mode", () => {
+    const strictResult = getGassmaCommonTypes(true);
+
+    it("should declare skip symbol and SkipValue", () => {
+      expect(strictResult).toContain("const skip: unique symbol;");
+      expect(strictResult).toContain("type SkipValue = typeof skip;");
+    });
+
+    it("should declare SkipOptional helper", () => {
+      expect(strictResult).toContain(
+        "type SkipOptional<T> = { [K in keyof T]: {} extends Pick<T, K> ? T[K] | SkipValue : T[K] };",
+      );
+    });
+
+    it("should add SkipValue to FilterConditions keys", () => {
+      expect(strictResult).toContain("equals?: T | FieldRef | SkipValue");
+      expect(strictResult).toContain("not?: T | SkipValue");
+      expect(strictResult).toContain("in?: T[] | SkipValue");
+      expect(strictResult).toContain("notIn?: T[] | SkipValue");
+      expect(strictResult).toContain("lt?: T | FieldRef | SkipValue");
+      expect(strictResult).toContain("lte?: T | FieldRef | SkipValue");
+      expect(strictResult).toContain("gt?: T | FieldRef | SkipValue");
+      expect(strictResult).toContain("gte?: T | FieldRef | SkipValue");
+      expect(strictResult).toContain(
+        "contains?: string | FieldRef | SkipValue",
+      );
+      expect(strictResult).toContain(
+        "startsWith?: string | FieldRef | SkipValue",
+      );
+      expect(strictResult).toContain(
+        "endsWith?: string | FieldRef | SkipValue",
+      );
+      expect(strictResult).toContain(
+        'mode?: "default" | "insensitive" | SkipValue',
+      );
+    });
+
+    it("should not add SkipValue to array element types", () => {
+      expect(strictResult).not.toContain("(T | SkipValue)[]");
+    });
+  });
 });

--- a/src/__test__/generate/typeGenerate/strictSkip/generatorStrict.test.ts
+++ b/src/__test__/generate/typeGenerate/strictSkip/generatorStrict.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { generater } from "../../../../generate/generator";
+import type { RelationsConfig } from "../../../../generate/read/extractRelations";
+
+const dictYaml: Record<string, Record<string, unknown[]>> = {
+  User: {
+    "id?": ["number"],
+    name: ["string"],
+  },
+  Post: {
+    "id?": ["number"],
+    title: ["string"],
+    authorId: ["number"],
+  },
+};
+
+const relations: RelationsConfig = {
+  User: {
+    posts: {
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+  Post: {
+    author: {
+      type: "manyToOne",
+      to: "User",
+      field: "authorId",
+      reference: "id",
+    },
+  },
+};
+
+describe("generater strict mode", () => {
+  const result = generater(
+    dictYaml,
+    relations,
+    "",
+    true,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    true,
+  );
+
+  it("should declare skip in the Gassma namespace", () => {
+    expect(result).toContain("const skip: unique symbol;");
+    expect(result).toContain("type SkipValue = typeof skip;");
+    expect(result).toContain("type SkipOptional<T> =");
+  });
+
+  it("should add SkipValue across generated input types", () => {
+    expect(result).toContain(
+      '"id"?: number | null | GassmaUseridFilterConditions | Gassma.SkipValue;',
+    );
+    expect(result).toContain("where?: GassmaUserWhereUse | Gassma.SkipValue;");
+    expect(result).toContain("data: Gassma.SkipOptional<");
+  });
+
+  it("should not touch output types", () => {
+    expect(result).toContain("export type GassmaUserUse = {");
+  });
+});
+
+describe("generater non-strict regression", () => {
+  const result = generater(dictYaml, relations, "", true);
+
+  it("should not contain any skip-related declarations", () => {
+    expect(result).not.toContain("SkipValue");
+    expect(result).not.toContain("SkipOptional");
+    expect(result).not.toContain("unique symbol");
+  });
+});

--- a/src/__test__/generate/typeGenerate/strictSkip/selectOmitIncludeOrderBy.test.ts
+++ b/src/__test__/generate/typeGenerate/strictSkip/selectOmitIncludeOrderBy.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaSelect } from "../../../../generate/typeGenerate/gassmaSelect/oneGassmaSelect";
+import { getOneGassmaFindSelect } from "../../../../generate/typeGenerate/gassmaSelect/oneGassmaFindSelect";
+import { getOneGassmaNumberSelect } from "../../../../generate/typeGenerate/gassmaSelect/oneGassmaNumberSelect";
+import { getOneGassmaOmit } from "../../../../generate/typeGenerate/gassmaOmit/oneGassmaOmit";
+import { getOneGassmaInclude } from "../../../../generate/typeGenerate/gassmaInclude/oneGassmaInclude";
+import { getOneGassmaOrderBy } from "../../../../generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy";
+import { getOneGassmaCountValue } from "../../../../generate/typeGenerate/gassmaCountValue/oneGassmaCountValue";
+import type { RelationsConfig } from "../../../../generate/read/extractRelations";
+
+const relations: RelationsConfig = {
+  User: {
+    posts: {
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+};
+
+describe("strict Select", () => {
+  it("should add SkipValue to select values", () => {
+    const result = getOneGassmaSelect({ id: ["number"] }, "", "User", true);
+    expect(result).toContain('"id"?: true | Gassma.SkipValue;');
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaSelect({ id: ["number"] }, "", "User")).not.toContain(
+      "Skip",
+    );
+  });
+});
+
+describe("strict NumberSelect", () => {
+  it("should add SkipValue to select values", () => {
+    const result = getOneGassmaNumberSelect(
+      { id: ["number"] },
+      "",
+      "User",
+      true,
+    );
+    expect(result).toContain('"id"?: true | Gassma.SkipValue;');
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(
+      getOneGassmaNumberSelect({ id: ["number"] }, "", "User"),
+    ).not.toContain("Skip");
+  });
+});
+
+describe("strict Omit", () => {
+  it("should add SkipValue to omit values", () => {
+    const result = getOneGassmaOmit({ id: ["number"] }, "", "User", true);
+    expect(result).toContain('"id"?: true | false | Gassma.SkipValue;');
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaOmit({ id: ["number"] }, "", "User")).not.toContain(
+      "Skip",
+    );
+  });
+});
+
+describe("strict FindSelect", () => {
+  const result = getOneGassmaFindSelect(
+    { id: ["number"] },
+    "",
+    "User",
+    relations,
+    true,
+  );
+
+  it("should add SkipValue to scalar values", () => {
+    expect(result).toContain('"id"?: true | Gassma.SkipValue;');
+  });
+
+  it("should add SkipValue to relation values and their options", () => {
+    expect(result).toContain(
+      '"posts"?: true | { select?: GassmaPostFindSelect | Gassma.SkipValue; omit?: GassmaPostOmit | Gassma.SkipValue; where?: GassmaPostWhereUse | Gassma.SkipValue; orderBy?: GassmaPostOrderBy | Gassma.SkipValue; take?: number | Gassma.SkipValue; skip?: number | Gassma.SkipValue; include?: GassmaPostInclude | Gassma.SkipValue; _count?: GassmaPostCountValue | Gassma.SkipValue } | Gassma.SkipValue;',
+    );
+  });
+
+  it("should add SkipValue to _count", () => {
+    expect(result).toContain(
+      '"_count"?: GassmaUserCountValue | Gassma.SkipValue;',
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(
+      getOneGassmaFindSelect({ id: ["number"] }, "", "User", relations),
+    ).not.toContain("Skip");
+  });
+});
+
+describe("strict Include", () => {
+  const result = getOneGassmaInclude("", "User", relations, true);
+
+  it("should add SkipValue to relation values and their options", () => {
+    expect(result).toContain(
+      '"posts"?: true | { select?: GassmaPostFindSelect | Gassma.SkipValue; omit?: GassmaPostOmit | Gassma.SkipValue; where?: GassmaPostWhereUse | Gassma.SkipValue; orderBy?: GassmaPostOrderBy | Gassma.SkipValue; take?: number | Gassma.SkipValue; skip?: number | Gassma.SkipValue; include?: GassmaPostInclude | Gassma.SkipValue; _count?: GassmaPostCountValue | Gassma.SkipValue } | Gassma.SkipValue;',
+    );
+    expect(result).toContain(
+      '"_count"?: GassmaUserCountValue | Gassma.SkipValue;',
+    );
+  });
+
+  it("should keep empty include unchanged", () => {
+    expect(getOneGassmaInclude("", "Post", {}, true)).toContain(
+      "export type GassmaPostInclude = {};",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaInclude("", "User", relations)).not.toContain("Skip");
+  });
+});
+
+describe("strict OrderBy", () => {
+  const result = getOneGassmaOrderBy(
+    { id: ["number"] },
+    "",
+    "User",
+    relations,
+    true,
+  );
+
+  it("should add SkipValue to scalar values", () => {
+    expect(result).toContain(
+      '"id"?: "asc" | "desc" | Gassma.SortOrderInput | Gassma.SkipValue;',
+    );
+  });
+
+  it("should add SkipValue to relation values", () => {
+    expect(result).toContain(
+      '"posts"?: GassmaPostOrderBy | { _count: "asc" | "desc" } | Gassma.SkipValue;',
+    );
+  });
+
+  it("should add SkipValue to _count values", () => {
+    expect(result).toContain(
+      '"_count"?: { "posts"?: "asc" | "desc" | Gassma.SkipValue } | Gassma.SkipValue;',
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(
+      getOneGassmaOrderBy({ id: ["number"] }, "", "User", relations),
+    ).not.toContain("Skip");
+  });
+});
+
+describe("strict CountValue", () => {
+  it("should add SkipValue to relation count values", () => {
+    const result = getOneGassmaCountValue("", "User", relations, true);
+    expect(result).toContain(
+      '"posts"?: true | { where?: GassmaPostWhereUse | Gassma.SkipValue } | Gassma.SkipValue;',
+    );
+  });
+
+  it("should keep no-relation CountValue unchanged", () => {
+    expect(getOneGassmaCountValue("", "Post", {}, true)).toContain(
+      "export type GassmaPostCountValue = true;",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaCountValue("", "User", relations)).not.toContain("Skip");
+  });
+});

--- a/src/__test__/generate/typeGenerate/strictSkip/topLevelData.test.ts
+++ b/src/__test__/generate/typeGenerate/strictSkip/topLevelData.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaFindData } from "../../../../generate/typeGenerate/gassmaFindData/oneGassmaFindData";
+import { getOneGassmaFindFirstData } from "../../../../generate/typeGenerate/gassmaFindData/oneGassmaFindFirstData";
+import { getOneGassmaAggregateData } from "../../../../generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData";
+import { getOneGassmaCountData } from "../../../../generate/typeGenerate/gassmaCountData/oneGassmaCountData";
+import { getOneGassmaGroupByData } from "../../../../generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData";
+import { getOneGassmaDeleteData } from "../../../../generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData";
+import { getOneGassmaDeleteSingleData } from "../../../../generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData";
+
+describe("strict FindData", () => {
+  const result = getOneGassmaFindData({ id: ["number"] }, "", "User", true);
+
+  it("should add SkipValue to optional top-level arguments", () => {
+    expect(result).toContain("where?: GassmaUserWhereUse | Gassma.SkipValue;");
+    expect(result).toContain(
+      "orderBy?: GassmaUserOrderBy | GassmaUserOrderBy[] | Gassma.SkipValue;",
+    );
+    expect(result).toContain("take?: number | Gassma.SkipValue;");
+    expect(result).toContain("skip?: number | Gassma.SkipValue;");
+    expect(result).toContain('distinct?: "id" | ("id")[] | Gassma.SkipValue;');
+    expect(result).toContain("include?: GassmaUserInclude | Gassma.SkipValue;");
+    expect(result).toContain(
+      "cursor?: Gassma.SkipOptional<Partial<GassmaUserUse>> | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "_count?: GassmaUserCountValue | Gassma.SkipValue;",
+    );
+  });
+
+  it("should add SkipValue to select / omit branches", () => {
+    expect(result).toContain(
+      "({ select?: GassmaUserFindSelect | Gassma.SkipValue; omit?: never } | { select?: never; omit?: GassmaUserOmit | Gassma.SkipValue })",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    const plain = getOneGassmaFindData({ id: ["number"] }, "", "User");
+    expect(plain).not.toContain("Skip");
+  });
+});
+
+describe("strict FindFirstData", () => {
+  const result = getOneGassmaFindFirstData("", "User", true);
+
+  it("should add SkipValue to optional top-level arguments", () => {
+    expect(result).toContain("where?: GassmaUserWhereUse | Gassma.SkipValue;");
+    expect(result).toContain(
+      "orderBy?: GassmaUserOrderBy | GassmaUserOrderBy[] | Gassma.SkipValue;",
+    );
+    expect(result).toContain("include?: GassmaUserInclude | Gassma.SkipValue;");
+    expect(result).toContain(
+      "cursor?: Gassma.SkipOptional<Partial<GassmaUserUse>> | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "_count?: GassmaUserCountValue | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "({ select?: GassmaUserFindSelect | Gassma.SkipValue; omit?: never } | { select?: never; omit?: GassmaUserOmit | Gassma.SkipValue })",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaFindFirstData("", "User")).not.toContain("Skip");
+  });
+});
+
+describe("strict AggregateData", () => {
+  const result = getOneGassmaAggregateData("", "User", true);
+
+  it("should add SkipValue to optional top-level arguments", () => {
+    expect(result).toContain("where?: GassmaUserWhereUse | Gassma.SkipValue;");
+    expect(result).toContain(
+      "orderBy?: GassmaUserOrderBy | GassmaUserOrderBy[] | Gassma.SkipValue;",
+    );
+    expect(result).toContain("take?: number | Gassma.SkipValue;");
+    expect(result).toContain("skip?: number | Gassma.SkipValue;");
+    expect(result).toContain(
+      "cursor?: Gassma.SkipOptional<Partial<GassmaUserUse>> | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "_avg?: GassmaUserNumberSelect | Gassma.SkipValue;",
+    );
+    expect(result).toContain("_count?: GassmaUserSelect | Gassma.SkipValue;");
+    expect(result).toContain("_max?: GassmaUserSelect | Gassma.SkipValue;");
+    expect(result).toContain("_min?: GassmaUserSelect | Gassma.SkipValue;");
+    expect(result).toContain(
+      "_sum?: GassmaUserNumberSelect | Gassma.SkipValue;",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaAggregateData("", "User")).not.toContain("Skip");
+  });
+});
+
+describe("strict CountData", () => {
+  const result = getOneGassmaCountData("", "User", true);
+
+  it("should add SkipValue to optional top-level arguments", () => {
+    expect(result).toContain("where?: GassmaUserWhereUse | Gassma.SkipValue;");
+    expect(result).toContain(
+      "orderBy?: GassmaUserOrderBy | GassmaUserOrderBy[] | Gassma.SkipValue;",
+    );
+    expect(result).toContain("take?: number | Gassma.SkipValue;");
+    expect(result).toContain("skip?: number | Gassma.SkipValue;");
+    expect(result).toContain(
+      "cursor?: Gassma.SkipOptional<Partial<GassmaUserUse>> | Gassma.SkipValue;",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaCountData("", "User")).not.toContain("Skip");
+  });
+});
+
+describe("strict GroupByData", () => {
+  const result = getOneGassmaGroupByData({ id: ["number"] }, "", "User", true);
+
+  it("should add SkipValue to having but not to by", () => {
+    expect(result).toContain(
+      "having?: GassmaUserHavingUse | Gassma.SkipValue;",
+    );
+    expect(result).toContain('by: "id" | ("id")[];');
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(
+      getOneGassmaGroupByData({ id: ["number"] }, "", "User"),
+    ).not.toContain("Skip");
+  });
+});
+
+describe("strict DeleteData", () => {
+  const result = getOneGassmaDeleteData("", "User", true);
+
+  it("should add SkipValue to where and limit", () => {
+    expect(result).toContain("where?: GassmaUserWhereUse | Gassma.SkipValue;");
+    expect(result).toContain("limit?: number | Gassma.SkipValue;");
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaDeleteData("", "User")).not.toContain("Skip");
+  });
+});
+
+describe("strict DeleteSingleData", () => {
+  const result = getOneGassmaDeleteSingleData("", "User", true);
+
+  it("should not add SkipValue to required where", () => {
+    expect(result).toContain("where: GassmaUserWhereUse;");
+  });
+
+  it("should add SkipValue to include / select / omit", () => {
+    expect(result).toContain("include?: GassmaUserInclude | Gassma.SkipValue;");
+    expect(result).toContain(
+      "({ select?: GassmaUserSelect | Gassma.SkipValue; omit?: never } | { select?: never; omit?: GassmaUserOmit | Gassma.SkipValue })",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaDeleteSingleData("", "User")).not.toContain("Skip");
+  });
+});

--- a/src/__test__/generate/typeGenerate/strictSkip/whereFilterHaving.test.ts
+++ b/src/__test__/generate/typeGenerate/strictSkip/whereFilterHaving.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import { getOneSheetGassmaFilterConditions } from "../../../../generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions";
+import { getOneGassmaWhereUse } from "../../../../generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse";
+import { getOneGassmaHavingCore } from "../../../../generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore";
+import { getOneGassmaHavingUse } from "../../../../generate/typeGenerate/gassmaHavingUse/oneGassmaHavingUse";
+import type { RelationsConfig } from "../../../../generate/read/extractRelations";
+
+const relations: RelationsConfig = {
+  User: {
+    posts: {
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+  Post: {
+    author: {
+      type: "manyToOne",
+      to: "User",
+      field: "authorId",
+      reference: "id",
+    },
+  },
+};
+
+describe("strict FilterConditions", () => {
+  const result = getOneSheetGassmaFilterConditions(
+    { id: ["number"] },
+    "",
+    "User",
+    true,
+  );
+
+  it("should add SkipValue to every key", () => {
+    expect(result).toContain(
+      "equals?: number | Gassma.FieldRef | Gassma.SkipValue;",
+    );
+    expect(result).toContain("not?: number | Gassma.SkipValue;");
+    expect(result).toContain("in?: number[] | Gassma.SkipValue;");
+    expect(result).toContain("notIn?: number[] | Gassma.SkipValue;");
+    expect(result).toContain(
+      "lt?: number | Gassma.FieldRef | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "lte?: number | Gassma.FieldRef | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "gt?: number | Gassma.FieldRef | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "gte?: number | Gassma.FieldRef | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "contains?: string | Gassma.FieldRef | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "startsWith?: string | Gassma.FieldRef | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "endsWith?: string | Gassma.FieldRef | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      'mode?: "default" | "insensitive" | Gassma.SkipValue;',
+    );
+  });
+
+  it("should not add SkipValue to array elements", () => {
+    expect(result).not.toContain("(number | Gassma.SkipValue)[]");
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    const plain = getOneSheetGassmaFilterConditions(
+      { id: ["number"] },
+      "",
+      "User",
+    );
+    expect(plain).not.toContain("SkipValue");
+  });
+});
+
+describe("strict WhereUse", () => {
+  const result = getOneGassmaWhereUse(
+    { id: ["number"] },
+    "",
+    "User",
+    relations,
+    true,
+  );
+
+  it("should add SkipValue to column values", () => {
+    expect(result).toContain(
+      '"id"?: number | GassmaUseridFilterConditions | Gassma.SkipValue;',
+    );
+  });
+
+  it("should add SkipValue to list relation filters", () => {
+    expect(result).toContain(
+      '"posts"?: { some?: GassmaPostWhereUse | Gassma.SkipValue; every?: GassmaPostWhereUse | Gassma.SkipValue; none?: GassmaPostWhereUse | Gassma.SkipValue } | Gassma.SkipValue;',
+    );
+  });
+
+  it("should add SkipValue to single relation filters", () => {
+    const postResult = getOneGassmaWhereUse(
+      { authorId: ["number"] },
+      "",
+      "Post",
+      relations,
+      true,
+    );
+    expect(postResult).toContain(
+      '"author"?: { is?: GassmaUserWhereUse | null | Gassma.SkipValue; isNot?: GassmaUserWhereUse | null | Gassma.SkipValue } | Gassma.SkipValue;',
+    );
+  });
+
+  it("should add SkipValue to AND / OR / NOT", () => {
+    expect(result).toContain(
+      "AND?: GassmaUserWhereUse[] | GassmaUserWhereUse | Gassma.SkipValue;",
+    );
+    expect(result).toContain("OR?: GassmaUserWhereUse[] | Gassma.SkipValue;");
+    expect(result).toContain(
+      "NOT?: GassmaUserWhereUse[] | GassmaUserWhereUse | Gassma.SkipValue;",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    const plain = getOneGassmaWhereUse(
+      { id: ["number"] },
+      "",
+      "User",
+      relations,
+    );
+    expect(plain).not.toContain("SkipValue");
+  });
+});
+
+describe("strict HavingCore", () => {
+  const result = getOneGassmaHavingCore(
+    { score: ["number"] },
+    "",
+    "User",
+    true,
+  );
+
+  it("should add SkipValue to aggregate keys", () => {
+    expect(result).toContain(
+      "_avg?: Gassma.FilterConditions<number> | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "_count?: Gassma.FilterConditions<number> | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "_max?: GassmaUserscoreFilterConditions | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "_min?: GassmaUserscoreFilterConditions | Gassma.SkipValue;",
+    );
+    expect(result).toContain(
+      "_sum?: Gassma.FilterConditions<number> | Gassma.SkipValue;",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    const plain = getOneGassmaHavingCore({ score: ["number"] }, "", "User");
+    expect(plain).not.toContain("SkipValue");
+  });
+});
+
+describe("strict HavingUse", () => {
+  const result = getOneGassmaHavingUse({ score: ["number"] }, "", "User", true);
+
+  it("should add SkipValue to column values", () => {
+    expect(result).toContain(
+      '"score"?: number | GassmaUserscoreHavingCore | Gassma.SkipValue;',
+    );
+  });
+
+  it("should add SkipValue to AND / OR / NOT", () => {
+    expect(result).toContain(
+      "AND?: GassmaUserHavingUse[] | GassmaUserHavingUse | Gassma.SkipValue;",
+    );
+    expect(result).toContain("OR?: GassmaUserHavingUse[] | Gassma.SkipValue;");
+    expect(result).toContain(
+      "NOT?: GassmaUserHavingUse[] | GassmaUserHavingUse | Gassma.SkipValue;",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    const plain = getOneGassmaHavingUse({ score: ["number"] }, "", "User");
+    expect(plain).not.toContain("SkipValue");
+  });
+});

--- a/src/__test__/generate/typeGenerate/strictSkip/writeData.test.ts
+++ b/src/__test__/generate/typeGenerate/strictSkip/writeData.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from "vitest";
+import { buildCreateDataType } from "../../../../generate/typeGenerate/util/buildCreateDataType";
+import { getNestedWriteFields } from "../../../../generate/typeGenerate/util/getNestedWriteFields";
+import { getOneGassmaCreate } from "../../../../generate/typeGenerate/gassmaCreate/oneGassmaCreate";
+import { getOneGassmaCreateMany } from "../../../../generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany";
+import { getOneGassmaCreateManyAndReturnData } from "../../../../generate/typeGenerate/gassmaCreateMany/oneGassmaCreateManyAndReturnData";
+import { getOneGassmaUpdateData } from "../../../../generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData";
+import { getOneGassmaUpdateSingleData } from "../../../../generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData";
+import { getOneGassmaUpsertSingleData } from "../../../../generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData";
+import type { RelationsConfig } from "../../../../generate/read/extractRelations";
+
+const relations: RelationsConfig = {
+  User: {
+    posts: {
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+  Post: {
+    author: {
+      type: "manyToOne",
+      to: "User",
+      field: "authorId",
+      reference: "id",
+    },
+  },
+};
+
+describe("strict buildCreateDataType", () => {
+  it("should wrap base type with SkipOptional", () => {
+    const result = buildCreateDataType("", "User", relations, true);
+    expect(result).toContain("Gassma.SkipOptional<GassmaUserUse>");
+  });
+
+  it("should wrap FK-omitted base type with SkipOptional", () => {
+    const result = buildCreateDataType("", "Post", relations, true);
+    expect(result).toContain(
+      'Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">>',
+    );
+  });
+
+  it("should keep FK Pick branch without SkipValue", () => {
+    const result = buildCreateDataType("", "Post", relations, true);
+    expect(result).toContain('Pick<GassmaPostUse, "authorId">');
+    expect(result).not.toContain(
+      'Pick<GassmaPostUse, "authorId"> | Gassma.SkipValue',
+    );
+  });
+
+  it("should add SkipValue to FK relation operations", () => {
+    const result = buildCreateDataType("", "Post", relations, true);
+    expect(result).toContain(
+      '"author": { create?: Gassma.SkipOptional<GassmaUserUse> | Gassma.SkipValue; connect?: GassmaUserWhereUse | Gassma.SkipValue; connectOrCreate?: { where: GassmaUserWhereUse; create: Gassma.SkipOptional<GassmaUserUse> } | Gassma.SkipValue }',
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(buildCreateDataType("", "Post", relations)).not.toContain("Skip");
+  });
+});
+
+describe("strict getNestedWriteFields", () => {
+  const createFields = getNestedWriteFields(
+    "",
+    "User",
+    relations,
+    "create",
+    true,
+  );
+  const updateFields = getNestedWriteFields(
+    "",
+    "User",
+    relations,
+    "update",
+    true,
+  );
+
+  it("should add SkipValue to the relation key", () => {
+    expect(createFields).toContain("} | Gassma.SkipValue;\n");
+  });
+
+  it("should add SkipValue to create context operations", () => {
+    expect(createFields).toContain(
+      'create?: Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">> | Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">>[] | Gassma.SkipValue',
+    );
+    expect(createFields).toContain(
+      'createMany?: { data: Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">>[] } | Gassma.SkipValue',
+    );
+    expect(createFields).toContain(
+      "connect?: GassmaPostWhereUse | GassmaPostWhereUse[] | Gassma.SkipValue",
+    );
+    expect(createFields).toContain(
+      'connectOrCreate?: { where: GassmaPostWhereUse; create: Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">> } | { where: GassmaPostWhereUse; create: Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">> }[] | Gassma.SkipValue',
+    );
+  });
+
+  it("should add SkipValue to update-only operations for list relations", () => {
+    expect(updateFields).toContain(
+      "update?: { where: GassmaPostWhereUse; data: Gassma.SkipOptional<Partial<GassmaPostUse>> } | { where: GassmaPostWhereUse; data: Gassma.SkipOptional<Partial<GassmaPostUse>> }[] | Gassma.SkipValue",
+    );
+    expect(updateFields).toContain(
+      "delete?: GassmaPostWhereUse | GassmaPostWhereUse[] | Gassma.SkipValue",
+    );
+    expect(updateFields).toContain(
+      "deleteMany?: GassmaPostWhereUse | GassmaPostWhereUse[] | Gassma.SkipValue",
+    );
+    expect(updateFields).toContain(
+      "disconnect?: GassmaPostWhereUse | GassmaPostWhereUse[] | Gassma.SkipValue",
+    );
+    expect(updateFields).toContain(
+      "set?: GassmaPostWhereUse[] | Gassma.SkipValue",
+    );
+  });
+
+  it("should add SkipValue to update-only operations for single relations", () => {
+    const postUpdate = getNestedWriteFields(
+      "",
+      "Post",
+      relations,
+      "update",
+      true,
+    );
+    expect(postUpdate).toContain(
+      "update?: Gassma.SkipOptional<Partial<GassmaUserUse>> | Gassma.SkipValue",
+    );
+    expect(postUpdate).toContain("delete?: true | Gassma.SkipValue");
+    expect(postUpdate).toContain("disconnect?: true | Gassma.SkipValue");
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getNestedWriteFields("", "User", relations, "update")).not.toContain(
+      "Skip",
+    );
+  });
+});
+
+describe("strict CreateData", () => {
+  const result = getOneGassmaCreate("", "User", relations, true);
+
+  it("should not add SkipValue to data itself", () => {
+    expect(result).toContain("data: Gassma.SkipOptional<GassmaUserUse>");
+  });
+
+  it("should add SkipValue to include / select / omit", () => {
+    expect(result).toContain("include?: GassmaUserInclude | Gassma.SkipValue;");
+    expect(result).toContain(
+      "({ select?: GassmaUserSelect | Gassma.SkipValue; omit?: never } | { select?: never; omit?: GassmaUserOmit | Gassma.SkipValue })",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaCreate("", "User", relations)).not.toContain("Skip");
+  });
+});
+
+describe("strict CreateManyData", () => {
+  it("should wrap data elements with SkipOptional", () => {
+    const result = getOneGassmaCreateMany("", "User", true);
+    expect(result).toContain("data: Gassma.SkipOptional<GassmaUserUse>[];");
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaCreateMany("", "User")).not.toContain("Skip");
+  });
+});
+
+describe("strict CreateManyAndReturnData", () => {
+  const result = getOneGassmaCreateManyAndReturnData("", "User", true);
+
+  it("should wrap data elements and add SkipValue to options", () => {
+    expect(result).toContain("data: Gassma.SkipOptional<GassmaUserUse>[];");
+    expect(result).toContain("include?: GassmaUserInclude | Gassma.SkipValue;");
+    expect(result).toContain(
+      "({ select?: GassmaUserSelect | Gassma.SkipValue; omit?: never } | { select?: never; omit?: GassmaUserOmit | Gassma.SkipValue })",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaCreateManyAndReturnData("", "User")).not.toContain(
+      "Skip",
+    );
+  });
+});
+
+describe("strict UpdateData", () => {
+  const result = getOneGassmaUpdateData("", "User", true);
+
+  it("should add SkipValue to data values and optional arguments", () => {
+    expect(result).toContain(
+      "data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation | Gassma.SkipValue }>;",
+    );
+    expect(result).toContain("where?: GassmaUserWhereUse | Gassma.SkipValue;");
+    expect(result).toContain("limit?: number | Gassma.SkipValue;");
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaUpdateData("", "User")).not.toContain("Skip");
+  });
+});
+
+describe("strict UpdateSingleData", () => {
+  const result = getOneGassmaUpdateSingleData("", "User", relations, true);
+
+  it("should not add SkipValue to required where", () => {
+    expect(result).toContain("where: GassmaUserWhereUse;");
+  });
+
+  it("should add SkipValue to data values", () => {
+    expect(result).toContain(
+      "Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation | Gassma.SkipValue }>",
+    );
+  });
+
+  it("should add SkipValue to include / select / omit", () => {
+    expect(result).toContain("include?: GassmaUserInclude | Gassma.SkipValue;");
+    expect(result).toContain(
+      "({ select?: GassmaUserSelect | Gassma.SkipValue; omit?: never } | { select?: never; omit?: GassmaUserOmit | Gassma.SkipValue })",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaUpdateSingleData("", "User", relations)).not.toContain(
+      "Skip",
+    );
+  });
+});
+
+describe("strict UpsertSingleData", () => {
+  const result = getOneGassmaUpsertSingleData("", "User", relations, true);
+
+  it("should not add SkipValue to required where / create / update themselves", () => {
+    expect(result).toContain("where: GassmaUserWhereUse;");
+    expect(result).toContain("create: Gassma.SkipOptional<GassmaUserUse>");
+    expect(result).toContain(
+      "update: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.NumberOperation | Gassma.SkipValue }>",
+    );
+  });
+
+  it("should add SkipValue to include / select / omit", () => {
+    expect(result).toContain("include?: GassmaUserInclude | Gassma.SkipValue;");
+    expect(result).toContain(
+      "({ select?: GassmaUserSelect | Gassma.SkipValue; omit?: never } | { select?: never; omit?: GassmaUserOmit | Gassma.SkipValue })",
+    );
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaUpsertSingleData("", "User", relations)).not.toContain(
+      "Skip",
+    );
+  });
+});

--- a/src/__test__/generate/typeGenerate/util/skipUnion.test.ts
+++ b/src/__test__/generate/typeGenerate/util/skipUnion.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import {
+  skipUnion,
+  skipOptionalWrap,
+} from "../../../../generate/typeGenerate/util/skipUnion";
+
+describe("skipUnion", () => {
+  it("should return SkipValue union suffix when strict", () => {
+    expect(skipUnion(true)).toBe(" | Gassma.SkipValue");
+  });
+
+  it("should return empty string when not strict", () => {
+    expect(skipUnion(false)).toBe("");
+    expect(skipUnion(undefined)).toBe("");
+  });
+});
+
+describe("skipOptionalWrap", () => {
+  it("should wrap type expression with SkipOptional when strict", () => {
+    expect(skipOptionalWrap("GassmaUserUse", true)).toBe(
+      "Gassma.SkipOptional<GassmaUserUse>",
+    );
+  });
+
+  it("should return type expression as-is when not strict", () => {
+    expect(skipOptionalWrap("GassmaUserUse", false)).toBe("GassmaUserUse");
+    expect(skipOptionalWrap("GassmaUserUse", undefined)).toBe("GassmaUserUse");
+  });
+});

--- a/src/__test__/types/strict/skip.test-d.ts
+++ b/src/__test__/types/strict/skip.test-d.ts
@@ -1,0 +1,165 @@
+import { Gassma, GassmaClient } from "../__generated__/clientStrict";
+import { Gassma as PlainGassma } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// Gassma.skip の型が SkipValue になる
+{
+  const value: Gassma.SkipValue = Gassma.skip;
+  void value;
+}
+
+// 非 strict の生成物には skip が存在しない
+{
+  // @ts-expect-error 非 strict では skip は生成されない
+  PlainGassma.skip;
+}
+
+// where: フィールド値・where 自体に skip を渡せる
+{
+  client.User.findMany({ where: { id: Gassma.skip } });
+  client.User.findMany({ where: Gassma.skip });
+  client.User.findMany({ where: { AND: Gassma.skip, OR: Gassma.skip } });
+}
+
+// where: FilterConditions の各キーに skip を渡せる
+{
+  client.User.findMany({
+    where: { id: { equals: Gassma.skip, in: Gassma.skip, mode: Gassma.skip } },
+  });
+}
+
+// where: 配列要素には skip を渡せない
+{
+  // @ts-expect-error in の配列要素に skip は不可
+  client.User.findMany({ where: { id: { in: [Gassma.skip] } } });
+}
+
+// where: relation filter に skip を渡せる
+{
+  client.User.findMany({ where: { posts: Gassma.skip } });
+  client.User.findMany({ where: { posts: { some: Gassma.skip } } });
+}
+
+// トップレベルのオプショナル引数に skip を渡せる
+{
+  client.User.findMany({
+    orderBy: Gassma.skip,
+    take: Gassma.skip,
+    skip: Gassma.skip,
+    cursor: Gassma.skip,
+    distinct: Gassma.skip,
+    include: Gassma.skip,
+  });
+  client.User.findMany({ select: Gassma.skip });
+  client.User.findMany({ omit: Gassma.skip });
+}
+
+// orderBy / select / omit / include の値に skip を渡せる
+{
+  client.User.findMany({ orderBy: { id: Gassma.skip } });
+  client.User.findMany({ select: { id: Gassma.skip } });
+  client.User.findMany({ omit: { id: Gassma.skip } });
+  client.User.findMany({ include: { posts: Gassma.skip } });
+}
+
+// create: オプショナルなフィールド値に skip を渡せる
+{
+  client.User.create({
+    data: {
+      email: "a@example.com",
+      score: 1,
+      id: Gassma.skip,
+      name: Gassma.skip,
+      isActive: Gassma.skip,
+    },
+  });
+}
+
+// create: 必須フィールドに skip は不可
+{
+  // @ts-expect-error email は必須なので skip 不可
+  client.User.create({ data: { email: Gassma.skip, score: 1 } });
+}
+
+// create: data 自体に skip は不可
+{
+  // @ts-expect-error data は必須引数なので skip 不可
+  client.User.create({ data: Gassma.skip });
+}
+
+// create: 必須 FK に skip は不可
+{
+  client.Post.create({
+    // @ts-expect-error authorId は必須 FK なので skip 不可
+    data: { title: "t", authorId: Gassma.skip },
+  });
+}
+
+// nested write: 各操作値に skip を渡せる
+{
+  client.User.create({
+    data: { email: "a@example.com", score: 1, posts: Gassma.skip },
+  });
+  client.User.create({
+    data: {
+      email: "a@example.com",
+      score: 1,
+      posts: { create: Gassma.skip, connect: Gassma.skip },
+    },
+  });
+}
+
+// nested write: create 配列の要素に skip は不可
+{
+  client.User.create({
+    data: {
+      email: "a@example.com",
+      score: 1,
+      // @ts-expect-error 配列要素に skip は不可
+      posts: { create: [Gassma.skip] },
+    },
+  });
+}
+
+// update: data の値に skip を渡せるが where 自体には不可
+{
+  client.User.update({ where: { id: 1 }, data: { name: Gassma.skip } });
+  // @ts-expect-error update の where は必須引数なので skip 不可
+  client.User.update({ where: Gassma.skip, data: {} });
+}
+
+// updateMany: where / limit / data 値に skip を渡せる
+{
+  client.User.updateMany({
+    where: Gassma.skip,
+    data: { name: Gassma.skip },
+    limit: Gassma.skip,
+  });
+}
+
+// upsert: create / update の値に skip を渡せる
+{
+  client.User.upsert({
+    where: { id: 1 },
+    create: { email: "a@example.com", score: 1, name: Gassma.skip },
+    update: { name: Gassma.skip },
+  });
+}
+
+// delete / deleteMany
+{
+  client.User.deleteMany({ where: Gassma.skip, limit: Gassma.skip });
+  // @ts-expect-error delete の where は必須引数なので skip 不可
+  client.User.delete({ where: Gassma.skip });
+}
+
+// aggregate / count / groupBy
+{
+  client.User.aggregate({ where: Gassma.skip, _avg: Gassma.skip });
+  client.User.count({ where: Gassma.skip, take: Gassma.skip });
+  client.User.groupBy({ by: "id", having: Gassma.skip });
+  client.User.groupBy({ by: "id", having: { score: Gassma.skip } });
+  // @ts-expect-error by は必須引数なので skip 不可
+  client.User.groupBy({ by: Gassma.skip });
+}

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -3,6 +3,7 @@ import { generater } from "./generator";
 import { generateClientDts } from "./jsGenerate/generateClientDts";
 import { generateClientJs } from "./jsGenerate/generateClientJs";
 import { extractOutputPath } from "./read/extractOutputPath";
+import { extractPreviewFeatures } from "./read/extractPreviewFeatures";
 import { extractAutoincrement } from "./read/extractAutoincrement";
 import { extractDefaults } from "./read/extractDefaults";
 import { extractRelations } from "./read/extractRelations";
@@ -105,6 +106,9 @@ function generateFromSchema(
   const map = extractMap(schemaText);
   const mapSheets = extractMapSheets(schemaText);
   const enums = extractEnums(schemaText);
+  const strict = extractPreviewFeatures(schemaText).includes(
+    "strictUndefinedChecks",
+  );
 
   const resultString = generater(
     parsed,
@@ -115,6 +119,7 @@ function generateFromSchema(
     Object.keys(updatedAt),
     Object.keys(autoincrement),
     optionalFields,
+    strict,
   );
   const clientDts = generateClientDts(schemaName, enums);
   const mergedDts = resultString + "\n" + clientDts;
@@ -132,6 +137,7 @@ function generateFromSchema(
     autoincrement,
     enums,
     datasourceUrl,
+    strict,
   );
   jsWriter(clientJs, `${baseName}Client`, outputPath);
 

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -48,15 +48,22 @@ const generater = (
   updatedAtModels?: string[],
   autoincrementModels?: string[],
   optionalFields?: Record<string, string[]>,
+  strict?: boolean,
 ) => {
   const schema = schemaName ?? "";
   const sheetNames = Object.keys(dictYaml);
-  let result = getGassmaMain(sheetNames, schema, includeCommon, {
-    dictYaml,
-    defaults: defaults ?? {},
-    updatedAtModels: updatedAtModels ?? [],
-    autoincrementModels: autoincrementModels ?? [],
-  });
+  let result = getGassmaMain(
+    sheetNames,
+    schema,
+    includeCommon,
+    {
+      dictYaml,
+      defaults: defaults ?? {},
+      updatedAtModels: updatedAtModels ?? [],
+      autoincrementModels: autoincrementModels ?? [],
+    },
+    strict,
+  );
 
   result += getGassmaSheet(sheetNames, schema);
   result += getGassmaController(sheetNames, schema);
@@ -64,29 +71,29 @@ const generater = (
     result += getGassmaManyCount();
   }
   result += getGassmaAnyUse(dictYaml, schema, optionalFields ?? {});
-  result += getGassmaCreate(sheetNames, schema, relations);
-  result += getGassmaCreateMany(sheetNames, schema);
-  result += getGassmaCreateManyAndReturnData(sheetNames, schema);
-  result += getGassmaFilterCoditions(dictYaml, schema);
-  result += getGassmaWhereUse(dictYaml, schema, relations);
-  result += getGassmaHavingCore(dictYaml, schema);
-  result += getGassmaHavingUse(dictYaml, schema);
-  result += getGassmaFindData(dictYaml, schema);
-  result += getGassmaFindFirstData(sheetNames, schema);
+  result += getGassmaCreate(sheetNames, schema, relations, strict);
+  result += getGassmaCreateMany(sheetNames, schema, strict);
+  result += getGassmaCreateManyAndReturnData(sheetNames, schema, strict);
+  result += getGassmaFilterCoditions(dictYaml, schema, strict);
+  result += getGassmaWhereUse(dictYaml, schema, relations, strict);
+  result += getGassmaHavingCore(dictYaml, schema, strict);
+  result += getGassmaHavingUse(dictYaml, schema, strict);
+  result += getGassmaFindData(dictYaml, schema, strict);
+  result += getGassmaFindFirstData(sheetNames, schema, strict);
   result += getGassmaFindManyData(sheetNames, schema);
-  result += getGassmaUpdateData(sheetNames, schema);
-  result += getGassmaUpdateSingleData(sheetNames, schema, relations);
-  result += getGassmaUpsertSingleData(sheetNames, schema, relations);
-  result += getGassmaDeleteData(sheetNames, schema);
-  result += getGassmaDeleteSingleData(sheetNames, schema);
-  result += getGassmaAggregateData(sheetNames, schema);
-  result += getGassmaGroupByData(dictYaml, schema);
-  result += getGassmaInclude(sheetNames, schema, relations);
-  result += getGassmaCountValue(sheetNames, schema, relations);
-  result += getGassmaOrderBy(dictYaml, schema, relations);
-  result += getGassmaSelect(dictYaml, schema, relations);
-  result += getGassmaOmit(dictYaml, schema);
-  result += getGassmaCountData(sheetNames, schema);
+  result += getGassmaUpdateData(sheetNames, schema, strict);
+  result += getGassmaUpdateSingleData(sheetNames, schema, relations, strict);
+  result += getGassmaUpsertSingleData(sheetNames, schema, relations, strict);
+  result += getGassmaDeleteData(sheetNames, schema, strict);
+  result += getGassmaDeleteSingleData(sheetNames, schema, strict);
+  result += getGassmaAggregateData(sheetNames, schema, strict);
+  result += getGassmaGroupByData(dictYaml, schema, strict);
+  result += getGassmaInclude(sheetNames, schema, relations, strict);
+  result += getGassmaCountValue(sheetNames, schema, relations, strict);
+  result += getGassmaOrderBy(dictYaml, schema, relations, strict);
+  result += getGassmaSelect(dictYaml, schema, relations, strict);
+  result += getGassmaOmit(dictYaml, schema, strict);
+  result += getGassmaCountData(sheetNames, schema, strict);
   result += getGassmaCreateReturn(dictYaml, schema);
   result += getGassmaDefaultFindResult(sheetNames, schema);
   result += getGassmaFindResult(sheetNames, schema, relations);

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -93,6 +93,7 @@ const generateClientJs = (
   autoincrement?: AutoincrementConfig,
   enums?: EnumsConfig,
   datasourceUrl?: string,
+  strictUndefinedChecks?: boolean,
 ): string => {
   const lowerName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
   const relationsJson =
@@ -161,6 +162,7 @@ const generateClientJs = (
   if (hasMapSheets) mergeProps.push(`mapSheets: ${lowerName}MapSheets`);
   if (hasAutoincrement)
     mergeProps.push(`autoincrement: ${lowerName}Autoincrement`);
+  if (strictUndefinedChecks) mergeProps.push("strictUndefinedChecks: true");
   const mergeExpr = `Object.assign({}, options, { ${mergeProps.join(", ")} })`;
 
   return `const ${lowerName}Relations = ${relationsJson};

--- a/src/generate/read/extractPreviewFeatures.ts
+++ b/src/generate/read/extractPreviewFeatures.ts
@@ -1,0 +1,26 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+
+const extractPreviewFeatures = (schemaText: string): string[] => {
+  const ast = parsePrismaSchema(schemaText);
+
+  return ast.declarations.reduce<string[]>((pre, decl) => {
+    if (decl.kind !== "generator") return pre;
+
+    const config = decl.members.find(
+      (m) => m.kind === "config" && m.name.value === "previewFeatures",
+    );
+    if (!config || config.kind !== "config") return pre;
+    if (config.value.kind !== "array") return pre;
+
+    const features = config.value.items.reduce<string[]>((names, item) => {
+      if (item.kind === "literal" && typeof item.value === "string") {
+        return [...names, item.value];
+      }
+      return names;
+    }, []);
+
+    return [...pre, ...features];
+  }, []);
+};
+
+export { extractPreviewFeatures };

--- a/src/generate/typeGenerate/gassmaAggregateData.ts
+++ b/src/generate/typeGenerate/gassmaAggregateData.ts
@@ -1,13 +1,22 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaAggregateData } from "./gassmaAggregateData/oneGassmaAggregateData";
 
-const getGassmaAggregateData = (sheetNames: string[], schemaName: string) => {
+const getGassmaAggregateData = (
+  sheetNames: string[],
+  schemaName: string,
+  strict?: boolean,
+) => {
   const aggregateDstaDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaAggregateData(schemaName, removedSpaceCurrentSheetName)
+      pre +
+      getOneGassmaAggregateData(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        strict,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
+++ b/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
@@ -1,16 +1,28 @@
-const getOneGassmaAggregateData = (schemaName: string, sheetName: string) => {
+import { skipOptionalWrap, skipUnion } from "../util/skipUnion";
+
+const getOneGassmaAggregateData = (
+  schemaName: string,
+  sheetName: string,
+  strict?: boolean,
+) => {
+  const sk = skipUnion(strict);
+  const cursorType = skipOptionalWrap(
+    `Partial<Gassma${schemaName}${sheetName}Use>`,
+    strict,
+  );
+
   return `
 export type Gassma${schemaName}${sheetName}AggregateData = {
-  where?: Gassma${schemaName}${sheetName}WhereUse;
-  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[];
-  take?: number;
-  skip?: number;
-  cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
-  _avg?: Gassma${schemaName}${sheetName}NumberSelect;
-  _count?: Gassma${schemaName}${sheetName}Select;
-  _max?: Gassma${schemaName}${sheetName}Select;
-  _min?: Gassma${schemaName}${sheetName}Select;
-  _sum?: Gassma${schemaName}${sheetName}NumberSelect;
+  where?: Gassma${schemaName}${sheetName}WhereUse${sk};
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[]${sk};
+  take?: number${sk};
+  skip?: number${sk};
+  cursor?: ${cursorType}${sk};
+  _avg?: Gassma${schemaName}${sheetName}NumberSelect${sk};
+  _count?: Gassma${schemaName}${sheetName}Select${sk};
+  _max?: Gassma${schemaName}${sheetName}Select${sk};
+  _min?: Gassma${schemaName}${sheetName}Select${sk};
+  _sum?: Gassma${schemaName}${sheetName}NumberSelect${sk};
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -1,5 +1,16 @@
-const getGassmaCommonTypes = () => {
-  return `  type RelationsConfig = Record<string, Record<string, unknown>>;
+const getSkipDeclarations = () => {
+  return `  const skip: unique symbol;
+  type SkipValue = typeof skip;
+  type SkipOptional<T> = { [K in keyof T]: {} extends Pick<T, K> ? T[K] | SkipValue : T[K] };
+
+`;
+};
+
+const getGassmaCommonTypes = (strict?: boolean) => {
+  const skipDecls = strict ? getSkipDeclarations() : "";
+  const sk = strict ? " | SkipValue" : "";
+
+  return `${skipDecls}  type RelationsConfig = Record<string, Record<string, unknown>>;
 
   type NumberOperation = {
     increment?: number;
@@ -14,18 +25,18 @@ const getGassmaCommonTypes = () => {
   };
 
   type FilterConditions<T> = {
-    equals?: T | FieldRef;
-    not?: T;
-    in?: T[];
-    notIn?: T[];
-    lt?: T | FieldRef;
-    lte?: T | FieldRef;
-    gt?: T | FieldRef;
-    gte?: T | FieldRef;
-    contains?: string | FieldRef;
-    startsWith?: string | FieldRef;
-    endsWith?: string | FieldRef;
-    mode?: "default" | "insensitive";
+    equals?: T | FieldRef${sk};
+    not?: T${sk};
+    in?: T[]${sk};
+    notIn?: T[]${sk};
+    lt?: T | FieldRef${sk};
+    lte?: T | FieldRef${sk};
+    gt?: T | FieldRef${sk};
+    gte?: T | FieldRef${sk};
+    contains?: string | FieldRef${sk};
+    startsWith?: string | FieldRef${sk};
+    endsWith?: string | FieldRef${sk};
+    mode?: "default" | "insensitive"${sk};
   };
 
   type TrueKeys<T> = { [K in keyof T]: T[K] extends true ? K : never }[keyof T];

--- a/src/generate/typeGenerate/gassmaCountData.ts
+++ b/src/generate/typeGenerate/gassmaCountData.ts
@@ -1,13 +1,18 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaCountData } from "./gassmaCountData/oneGassmaCountData";
 
-const getGassmaCountData = (sheetNames: string[], schemaName: string) => {
+const getGassmaCountData = (
+  sheetNames: string[],
+  schemaName: string,
+  strict?: boolean,
+) => {
   const countDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaCountData(schemaName, removedSpaceCurrentSheetName)
+      pre +
+      getOneGassmaCountData(schemaName, removedSpaceCurrentSheetName, strict)
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
+++ b/src/generate/typeGenerate/gassmaCountData/oneGassmaCountData.ts
@@ -1,11 +1,23 @@
-const getOneGassmaCountData = (schemaName: string, sheetName: string) => {
+import { skipOptionalWrap, skipUnion } from "../util/skipUnion";
+
+const getOneGassmaCountData = (
+  schemaName: string,
+  sheetName: string,
+  strict?: boolean,
+) => {
+  const sk = skipUnion(strict);
+  const cursorType = skipOptionalWrap(
+    `Partial<Gassma${schemaName}${sheetName}Use>`,
+    strict,
+  );
+
   return `
 export type Gassma${schemaName}${sheetName}CountData = {
-  where?: Gassma${schemaName}${sheetName}WhereUse;
-  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[];
-  take?: number;
-  skip?: number;
-  cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
+  where?: Gassma${schemaName}${sheetName}WhereUse${sk};
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[]${sk};
+  take?: number${sk};
+  skip?: number${sk};
+  cursor?: ${cursorType}${sk};
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaCountValue.ts
+++ b/src/generate/typeGenerate/gassmaCountValue.ts
@@ -6,6 +6,7 @@ const getGassmaCountValue = (
   sheetNames: string[],
   schemaName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
   return sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
@@ -17,6 +18,7 @@ const getGassmaCountValue = (
         schemaName,
         removedSpaceCurrentSheetName,
         relations,
+        strict,
       )
     );
   }, "");

--- a/src/generate/typeGenerate/gassmaCountValue/oneGassmaCountValue.ts
+++ b/src/generate/typeGenerate/gassmaCountValue/oneGassmaCountValue.ts
@@ -1,18 +1,21 @@
 import type { RelationsConfig } from "../../read/extractRelations";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaCountValue = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ): string => {
   const modelRelations = relations?.[sheetName];
   if (!modelRelations || Object.keys(modelRelations).length === 0) {
     return `\nexport type Gassma${schemaName}${sheetName}CountValue = true;\n`;
   }
 
+  const sk = skipUnion(strict);
   const fields = Object.keys(modelRelations).reduce((pre, relationName) => {
     const targetModel = modelRelations[relationName].to;
-    return `${pre}    "${relationName}"?: true | { where?: Gassma${schemaName}${targetModel}WhereUse };\n`;
+    return `${pre}    "${relationName}"?: true | { where?: Gassma${schemaName}${targetModel}WhereUse${sk} }${sk};\n`;
   }, "");
 
   return `\nexport type Gassma${schemaName}${sheetName}CountValue = true | { select: {\n${fields}  } };\n`;

--- a/src/generate/typeGenerate/gassmaCreate.ts
+++ b/src/generate/typeGenerate/gassmaCreate.ts
@@ -6,6 +6,7 @@ const getGassmaCreate = (
   sheetNames: string[],
   schemaName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
   const createTypeDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
@@ -13,7 +14,12 @@ const getGassmaCreate = (
 
     return (
       pre +
-      getOneGassmaCreate(schemaName, removedSpaceCurrentSheetName, relations)
+      getOneGassmaCreate(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        relations,
+        strict,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
+++ b/src/generate/typeGenerate/gassmaCreate/oneGassmaCreate.ts
@@ -1,12 +1,20 @@
 import type { RelationsConfig } from "../../read/extractRelations";
 import { buildCreateDataType } from "../util/buildCreateDataType";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaCreate = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
-  const dataType = buildCreateDataType(schemaName, sheetName, relations);
+  const sk = skipUnion(strict);
+  const dataType = buildCreateDataType(
+    schemaName,
+    sheetName,
+    relations,
+    strict,
+  );
 
   const selectType = `Gassma${schemaName}${sheetName}Select`;
   const omitType = `Gassma${schemaName}${sheetName}Omit`;
@@ -14,8 +22,8 @@ const getOneGassmaCreate = (
   return `
 export type Gassma${schemaName}${sheetName}CreateData = {
   data: ${dataType};
-  include?: Gassma${schemaName}${sheetName}Include;
-} & ({ select?: ${selectType}; omit?: never } | { select?: never; omit?: ${omitType} });
+  include?: Gassma${schemaName}${sheetName}Include${sk};
+} & ({ select?: ${selectType}${sk}; omit?: never } | { select?: never; omit?: ${omitType}${sk} });
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaCreateMany.ts
+++ b/src/generate/typeGenerate/gassmaCreateMany.ts
@@ -1,13 +1,18 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaCreateMany } from "./gassmaCreateMany/oneGassmaCreateMany";
 
-const getGassmaCreateMany = (sheetNames: string[], schemaName: string) => {
+const getGassmaCreateMany = (
+  sheetNames: string[],
+  schemaName: string,
+  strict?: boolean,
+) => {
   const createManyTypeDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaCreateMany(schemaName, removedSpaceCurrentSheetName)
+      pre +
+      getOneGassmaCreateMany(schemaName, removedSpaceCurrentSheetName, strict)
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany.ts
+++ b/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany.ts
@@ -1,7 +1,18 @@
-const getOneGassmaCreateMany = (schemaName: string, sheetName: string) => {
+import { skipOptionalWrap } from "../util/skipUnion";
+
+const getOneGassmaCreateMany = (
+  schemaName: string,
+  sheetName: string,
+  strict?: boolean,
+) => {
+  const elementType = skipOptionalWrap(
+    `Gassma${schemaName}${sheetName}Use`,
+    strict,
+  );
+
   return `
 export type Gassma${schemaName}${sheetName}CreateManyData = {
-  data: Gassma${schemaName}${sheetName}Use[];
+  data: ${elementType}[];
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateManyAndReturnData.ts
+++ b/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateManyAndReturnData.ts
@@ -1,15 +1,23 @@
+import { skipOptionalWrap, skipUnion } from "../util/skipUnion";
+
 const getOneGassmaCreateManyAndReturnData = (
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
+  const elementType = skipOptionalWrap(
+    `Gassma${schemaName}${sheetName}Use`,
+    strict,
+  );
   const selectType = `Gassma${schemaName}${sheetName}Select`;
   const omitType = `Gassma${schemaName}${sheetName}Omit`;
 
   return `
 export type Gassma${schemaName}${sheetName}CreateManyAndReturnData = {
-  data: Gassma${schemaName}${sheetName}Use[];
-  include?: Gassma${schemaName}${sheetName}Include;
-} & ({ select?: ${selectType}; omit?: never } | { select?: never; omit?: ${omitType} });
+  data: ${elementType}[];
+  include?: Gassma${schemaName}${sheetName}Include${sk};
+} & ({ select?: ${selectType}${sk}; omit?: never } | { select?: never; omit?: ${omitType}${sk} });
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaCreateManyAndReturnData.ts
+++ b/src/generate/typeGenerate/gassmaCreateManyAndReturnData.ts
@@ -4,6 +4,7 @@ import { getOneGassmaCreateManyAndReturnData } from "./gassmaCreateMany/oneGassm
 const getGassmaCreateManyAndReturnData = (
   sheetNames: string[],
   schemaName: string,
+  strict?: boolean,
 ) => {
   const createManyAndReturnDeclare = sheetNames.reduce(
     (pre, currentSheetName) => {
@@ -15,6 +16,7 @@ const getGassmaCreateManyAndReturnData = (
         getOneGassmaCreateManyAndReturnData(
           schemaName,
           removedSpaceCurrentSheetName,
+          strict,
         )
       );
     },

--- a/src/generate/typeGenerate/gassmaDeleteData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteData.ts
@@ -1,13 +1,18 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaDeleteData } from "./gassmaDeleteManyData/oneGassmaDeleteManyData";
 
-const getGassmaDeleteData = (sheetNames: string[], schemaName: string) => {
+const getGassmaDeleteData = (
+  sheetNames: string[],
+  schemaName: string,
+  strict?: boolean,
+) => {
   const deleteManyData = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaDeleteData(schemaName, removedSpaceCurrentSheetName)
+      pre +
+      getOneGassmaDeleteData(schemaName, removedSpaceCurrentSheetName, strict)
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteManyData.ts
@@ -1,8 +1,16 @@
-const getOneGassmaDeleteData = (schemaName: string, sheetName: string) => {
+import { skipUnion } from "../util/skipUnion";
+
+const getOneGassmaDeleteData = (
+  schemaName: string,
+  sheetName: string,
+  strict?: boolean,
+) => {
+  const sk = skipUnion(strict);
+
   return `
 export type Gassma${schemaName}${sheetName}DeleteData = {
-  where?: Gassma${schemaName}${sheetName}WhereUse;
-  limit?: number;
+  where?: Gassma${schemaName}${sheetName}WhereUse${sk};
+  limit?: number${sk};
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteManyData/oneGassmaDeleteSingleData.ts
@@ -1,15 +1,19 @@
+import { skipUnion } from "../util/skipUnion";
+
 const getOneGassmaDeleteSingleData = (
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const selectType = `Gassma${schemaName}${sheetName}Select`;
   const omitType = `Gassma${schemaName}${sheetName}Omit`;
 
   return `
 export type Gassma${schemaName}${sheetName}DeleteSingleData = {
   where: Gassma${schemaName}${sheetName}WhereUse;
-  include?: Gassma${schemaName}${sheetName}Include;
-} & ({ select?: ${selectType}; omit?: never } | { select?: never; omit?: ${omitType} });
+  include?: Gassma${schemaName}${sheetName}Include${sk};
+} & ({ select?: ${selectType}${sk}; omit?: never } | { select?: never; omit?: ${omitType}${sk} });
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaDeleteSingleData.ts
+++ b/src/generate/typeGenerate/gassmaDeleteSingleData.ts
@@ -4,6 +4,7 @@ import { getOneGassmaDeleteSingleData } from "./gassmaDeleteManyData/oneGassmaDe
 const getGassmaDeleteSingleData = (
   sheetNames: string[],
   schemaName: string,
+  strict?: boolean,
 ) => {
   const deleteSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
@@ -11,7 +12,11 @@ const getGassmaDeleteSingleData = (
 
     return (
       pre +
-      getOneGassmaDeleteSingleData(schemaName, removedSpaceCurrentSheetName)
+      getOneGassmaDeleteSingleData(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        strict,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaFilterConditions.ts
+++ b/src/generate/typeGenerate/gassmaFilterConditions.ts
@@ -4,6 +4,7 @@ import { getOneSheetGassmaFilterConditions } from "./gassmaFilterConditions/oneS
 const getGassmaFilterCoditions = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
+  strict?: boolean,
 ) => {
   const filterConditionsDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -17,6 +18,7 @@ const getGassmaFilterCoditions = (
           sheetContent,
           schemaName,
           removedSpaceCurrentSheetName,
+          strict,
         )
       );
     },

--- a/src/generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions.ts
+++ b/src/generate/typeGenerate/gassmaFilterConditions/oneSheetGassmaFilterConditions.ts
@@ -1,11 +1,14 @@
 import { getColumnType } from "../../util/getColumnType";
 import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneSheetGassmaFilterConditions = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const oneFilterConditions = Object.keys(sheetContent).reduce(
     (pre, columnName) => {
       const columnTypes = sheetContent[columnName];
@@ -19,18 +22,18 @@ const getOneSheetGassmaFilterConditions = (
 
       const oneFilterConditionsType = `
 export type Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions = {
-  equals?: ${now}${isQuestionMark ? " | null" : ""} | Gassma.FieldRef;
-  not?: ${now}${isQuestionMark ? " | null" : ""};
-  in?: ${isOneType ? `${now}[]` : `(${now})[]`};
-  notIn?: ${isOneType ? `${now}[]` : `(${now})[]`};
-  lt?: ${now} | Gassma.FieldRef;
-  lte?: ${now} | Gassma.FieldRef;
-  gt?: ${now} | Gassma.FieldRef;
-  gte?: ${now} | Gassma.FieldRef;
-  contains?: string | Gassma.FieldRef;
-  startsWith?: string | Gassma.FieldRef;
-  endsWith?: string | Gassma.FieldRef;
-  mode?: "default" | "insensitive";
+  equals?: ${now}${isQuestionMark ? " | null" : ""} | Gassma.FieldRef${sk};
+  not?: ${now}${isQuestionMark ? " | null" : ""}${sk};
+  in?: ${isOneType ? `${now}[]` : `(${now})[]`}${sk};
+  notIn?: ${isOneType ? `${now}[]` : `(${now})[]`}${sk};
+  lt?: ${now} | Gassma.FieldRef${sk};
+  lte?: ${now} | Gassma.FieldRef${sk};
+  gt?: ${now} | Gassma.FieldRef${sk};
+  gte?: ${now} | Gassma.FieldRef${sk};
+  contains?: string | Gassma.FieldRef${sk};
+  startsWith?: string | Gassma.FieldRef${sk};
+  endsWith?: string | Gassma.FieldRef${sk};
+  mode?: "default" | "insensitive"${sk};
 };
 `;
 

--- a/src/generate/typeGenerate/gassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData.ts
@@ -4,6 +4,7 @@ import { getOneGassmaFindData } from "./gassmaFindData/oneGassmaFindData";
 const getGassmaFindData = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
+  strict?: boolean,
 ) => {
   const findDeclare = Object.keys(dictYaml).reduce((pre, currentSheetName) => {
     const sheetContent = dictYaml[currentSheetName];
@@ -16,6 +17,7 @@ const getGassmaFindData = (
         sheetContent,
         schemaName,
         removedSpaceCurrentSheetName,
+        strict,
       )
     );
   }, "");

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindData.ts
@@ -1,7 +1,10 @@
+import { skipOptionalWrap, skipUnion } from "../util/skipUnion";
+
 const getOneGassmaFindData = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
   const distinctArrayData = Object.keys(sheetContent).reduce(
     (pre, columnName, index) => {
@@ -25,19 +28,24 @@ const getOneGassmaFindData = (
     return `${pre}"${removedQuestionMark}" | `;
   }, "");
 
+  const sk = skipUnion(strict);
+  const cursorType = skipOptionalWrap(
+    `Partial<Gassma${schemaName}${sheetName}Use>`,
+    strict,
+  );
   const selectType = `Gassma${schemaName}${sheetName}FindSelect`;
   const omitType = `Gassma${schemaName}${sheetName}Omit`;
 
   return `\nexport type Gassma${schemaName}${sheetName}FindData = {
-  where?: Gassma${schemaName}${sheetName}WhereUse;
-  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[];
-  take?: number;
-  skip?: number;
-  distinct?: ${distinctData}(${distinctArrayData})[];
-  include?: Gassma${schemaName}${sheetName}Include;
-  cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
-  _count?: Gassma${schemaName}${sheetName}CountValue;
-} & ({ select?: ${selectType}; omit?: never } | { select?: never; omit?: ${omitType} });\n`;
+  where?: Gassma${schemaName}${sheetName}WhereUse${sk};
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[]${sk};
+  take?: number${sk};
+  skip?: number${sk};
+  distinct?: ${distinctData}(${distinctArrayData})[]${sk};
+  include?: Gassma${schemaName}${sheetName}Include${sk};
+  cursor?: ${cursorType}${sk};
+  _count?: Gassma${schemaName}${sheetName}CountValue${sk};
+} & ({ select?: ${selectType}${sk}; omit?: never } | { select?: never; omit?: ${omitType}${sk} });\n`;
 };
 
 export { getOneGassmaFindData };

--- a/src/generate/typeGenerate/gassmaFindData/oneGassmaFindFirstData.ts
+++ b/src/generate/typeGenerate/gassmaFindData/oneGassmaFindFirstData.ts
@@ -1,14 +1,25 @@
-const getOneGassmaFindFirstData = (schemaName: string, sheetName: string) => {
+import { skipOptionalWrap, skipUnion } from "../util/skipUnion";
+
+const getOneGassmaFindFirstData = (
+  schemaName: string,
+  sheetName: string,
+  strict?: boolean,
+) => {
+  const sk = skipUnion(strict);
+  const cursorType = skipOptionalWrap(
+    `Partial<Gassma${schemaName}${sheetName}Use>`,
+    strict,
+  );
   const selectType = `Gassma${schemaName}${sheetName}FindSelect`;
   const omitType = `Gassma${schemaName}${sheetName}Omit`;
 
   return `\nexport type Gassma${schemaName}${sheetName}FindFirstData = {
-  where?: Gassma${schemaName}${sheetName}WhereUse;
-  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[];
-  include?: Gassma${schemaName}${sheetName}Include;
-  cursor?: Partial<Gassma${schemaName}${sheetName}Use>;
-  _count?: Gassma${schemaName}${sheetName}CountValue;
-} & ({ select?: ${selectType}; omit?: never } | { select?: never; omit?: ${omitType} });\n`;
+  where?: Gassma${schemaName}${sheetName}WhereUse${sk};
+  orderBy?: Gassma${schemaName}${sheetName}OrderBy | Gassma${schemaName}${sheetName}OrderBy[]${sk};
+  include?: Gassma${schemaName}${sheetName}Include${sk};
+  cursor?: ${cursorType}${sk};
+  _count?: Gassma${schemaName}${sheetName}CountValue${sk};
+} & ({ select?: ${selectType}${sk}; omit?: never } | { select?: never; omit?: ${omitType}${sk} });\n`;
 };
 
 export { getOneGassmaFindFirstData };

--- a/src/generate/typeGenerate/gassmaFindFirstData.ts
+++ b/src/generate/typeGenerate/gassmaFindFirstData.ts
@@ -1,13 +1,22 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaFindFirstData } from "./gassmaFindData/oneGassmaFindFirstData";
 
-const getGassmaFindFirstData = (sheetNames: string[], schemaName: string) => {
+const getGassmaFindFirstData = (
+  sheetNames: string[],
+  schemaName: string,
+  strict?: boolean,
+) => {
   const findFirstDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaFindFirstData(schemaName, removedSpaceCurrentSheetName)
+      pre +
+      getOneGassmaFindFirstData(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        strict,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaGroupByData.ts
+++ b/src/generate/typeGenerate/gassmaGroupByData.ts
@@ -4,6 +4,7 @@ import { getOneGassmaGroupByData } from "./gassmaGroupByData/oneGassmaGroupByDat
 const getGassmaGroupByData = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
+  strict?: boolean,
 ) => {
   const groupByDataDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -17,6 +18,7 @@ const getGassmaGroupByData = (
           sheetContent,
           schemaName,
           removedSpaceCurrentSheetName,
+          strict,
         )
       );
     },

--- a/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
+++ b/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
@@ -1,7 +1,10 @@
+import { skipUnion } from "../util/skipUnion";
+
 const getOneGassmaGroupByData = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
   const byArrayData = Object.keys(sheetContent).reduce(
     (pre, columnName, index) => {
@@ -25,9 +28,11 @@ const getOneGassmaGroupByData = (
     return `${pre}"${removedQuestionMark}" | `;
   }, "");
 
+  const sk = skipUnion(strict);
+
   return `\nexport type Gassma${schemaName}${sheetName}GroupByData = Gassma${schemaName}${sheetName}AggregateData & {
   by: ${byData}(${byArrayData})[];
-  having?: Gassma${schemaName}${sheetName}HavingUse;
+  having?: Gassma${schemaName}${sheetName}HavingUse${sk};
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaHavingCore.ts
+++ b/src/generate/typeGenerate/gassmaHavingCore.ts
@@ -4,6 +4,7 @@ import { getOneGassmaHavingCore } from "./gassmaHavingCore/oneGassmaHavingCore";
 const getGassmaHavingCore = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
+  strict?: boolean,
 ) => {
   const havingCoreDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -17,6 +18,7 @@ const getGassmaHavingCore = (
           sheetContent,
           schemaName,
           removedSpaceCurrentSheetName,
+          strict,
         )
       );
     },

--- a/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
+++ b/src/generate/typeGenerate/gassmaHavingCore/oneGassmaHavingCore.ts
@@ -1,26 +1,29 @@
 import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
 import { isNumberColumn } from "../../util/isNumberColumn";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaHavingCore = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const oneHavingCore = Object.keys(sheetContent).reduce((pre, columnName) => {
     const removedSpaceCurrentColumnName = getRemovedCantUseVarChar(columnName);
     const isNumber = isNumberColumn(sheetContent[columnName]);
     const avgLine = isNumber
-      ? "  _avg?: Gassma.FilterConditions<number>;\n"
+      ? `  _avg?: Gassma.FilterConditions<number>${sk};\n`
       : "";
     const sumLine = isNumber
-      ? "  _sum?: Gassma.FilterConditions<number>;\n"
+      ? `  _sum?: Gassma.FilterConditions<number>${sk};\n`
       : "";
 
     const oneHavingCoreType = `
 export type Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}HavingCore = {
-${avgLine}  _count?: Gassma.FilterConditions<number>;
-  _max?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
-  _min?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
+${avgLine}  _count?: Gassma.FilterConditions<number>${sk};
+  _max?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions${sk};
+  _min?: Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions${sk};
 ${sumLine}} & Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;
 `;
 

--- a/src/generate/typeGenerate/gassmaHavingUse.ts
+++ b/src/generate/typeGenerate/gassmaHavingUse.ts
@@ -4,6 +4,7 @@ import { getOneGassmaHavingUse } from "./gassmaHavingUse/oneGassmaHavingUse";
 const getGassmaHavingUse = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
+  strict?: boolean,
 ) => {
   const havingUseDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -17,6 +18,7 @@ const getGassmaHavingUse = (
           sheetContent,
           schemaName,
           removedSpaceCurrentSheetName,
+          strict,
         )
       );
     },

--- a/src/generate/typeGenerate/gassmaHavingUse/oneGassmaHavingUse.ts
+++ b/src/generate/typeGenerate/gassmaHavingUse/oneGassmaHavingUse.ts
@@ -1,11 +1,14 @@
 import { getColumnType } from "../../util/getColumnType";
 import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaHavingUse = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const oneHavingUse = Object.keys(sheetContent).reduce((pre, columnName) => {
     const columnTypes = sheetContent[columnName];
     const now = getColumnType(columnTypes);
@@ -16,13 +19,13 @@ const getOneGassmaHavingUse = (
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}HavingCore;\n`;
+    return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}HavingCore${sk};\n`;
   }, `\nexport type Gassma${schemaName}${sheetName}HavingUse = {\n`);
 
   return `${oneHavingUse}
-  AND?: Gassma${schemaName}${sheetName}HavingUse[] | Gassma${schemaName}${sheetName}HavingUse;
-  OR?: Gassma${schemaName}${sheetName}HavingUse[];
-  NOT?: Gassma${schemaName}${sheetName}HavingUse[] | Gassma${schemaName}${sheetName}HavingUse;
+  AND?: Gassma${schemaName}${sheetName}HavingUse[] | Gassma${schemaName}${sheetName}HavingUse${sk};
+  OR?: Gassma${schemaName}${sheetName}HavingUse[]${sk};
+  NOT?: Gassma${schemaName}${sheetName}HavingUse[] | Gassma${schemaName}${sheetName}HavingUse${sk};
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaInclude.ts
+++ b/src/generate/typeGenerate/gassmaInclude.ts
@@ -6,6 +6,7 @@ const getGassmaInclude = (
   sheetNames: string[],
   schemaName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
   return sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
@@ -13,7 +14,12 @@ const getGassmaInclude = (
 
     return (
       pre +
-      getOneGassmaInclude(schemaName, removedSpaceCurrentSheetName, relations)
+      getOneGassmaInclude(
+        schemaName,
+        removedSpaceCurrentSheetName,
+        relations,
+        strict,
+      )
     );
   }, "");
 };

--- a/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
+++ b/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
@@ -1,23 +1,26 @@
 import type { RelationsConfig } from "../../read/extractRelations";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaInclude = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ): string => {
   const modelRelations = relations?.[sheetName];
   if (!modelRelations || Object.keys(modelRelations).length === 0) {
     return `\nexport type Gassma${schemaName}${sheetName}Include = {};\n`;
   }
 
+  const sk = skipUnion(strict);
   const fields = Object.keys(modelRelations).reduce((pre, relationName) => {
     const targetModel = modelRelations[relationName].to;
     const target = `Gassma${schemaName}${targetModel}`;
-    const optionsType = `{ select?: ${target}FindSelect; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; include?: ${target}Include; _count?: ${target}CountValue }`;
-    return `${pre}  "${relationName}"?: true | ${optionsType};\n`;
+    const optionsType = `{ select?: ${target}FindSelect${sk}; omit?: ${target}Omit${sk}; where?: ${target}WhereUse${sk}; orderBy?: ${target}OrderBy${sk}; take?: number${sk}; skip?: number${sk}; include?: ${target}Include${sk}; _count?: ${target}CountValue${sk} }`;
+    return `${pre}  "${relationName}"?: true | ${optionsType}${sk};\n`;
   }, "");
 
-  const countField = `  "_count"?: Gassma${schemaName}${sheetName}CountValue;\n`;
+  const countField = `  "_count"?: Gassma${schemaName}${sheetName}CountValue${sk};\n`;
 
   return `\nexport type Gassma${schemaName}${sheetName}Include = {\n${fields}${countField}};\n`;
 };

--- a/src/generate/typeGenerate/gassmaMain.ts
+++ b/src/generate/typeGenerate/gassmaMain.ts
@@ -37,8 +37,8 @@ const getGassmaClientOptions = (schemaName: string) => {
 };\n\n`;
 };
 
-const getGassmaCommonNamespace = () => {
-  const commonTypes = getGassmaCommonTypes();
+const getGassmaCommonNamespace = (strict?: boolean) => {
+  const commonTypes = getGassmaCommonTypes(strict);
   const errorClasses = getGassmaErrorClasses();
 
   return `export namespace Gassma {
@@ -118,8 +118,10 @@ const getGassmaMain = (
   schemaName: string,
   includeCommon?: boolean,
   options?: GassmaMainOptions,
+  strict?: boolean,
 ) => {
-  const common = includeCommon !== false ? getGassmaCommonNamespace() : "";
+  const common =
+    includeCommon !== false ? getGassmaCommonNamespace(strict) : "";
   const mainOptions = options ?? {
     dictYaml: {},
     defaults: {},

--- a/src/generate/typeGenerate/gassmaOmit.ts
+++ b/src/generate/typeGenerate/gassmaOmit.ts
@@ -4,6 +4,7 @@ import { getOneGassmaOmit } from "./gassmaOmit/oneGassmaOmit";
 const getGassmaOmit = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
+  strict?: boolean,
 ) => {
   const omitDeclare = Object.keys(dictYaml).reduce((pre, currentSheetName) => {
     const sheetContent = dictYaml[currentSheetName];
@@ -12,7 +13,12 @@ const getGassmaOmit = (
 
     return (
       pre +
-      getOneGassmaOmit(sheetContent, schemaName, removedSpaceCurrentSheetName)
+      getOneGassmaOmit(
+        sheetContent,
+        schemaName,
+        removedSpaceCurrentSheetName,
+        strict,
+      )
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaOmit/oneGassmaOmit.ts
+++ b/src/generate/typeGenerate/gassmaOmit/oneGassmaOmit.ts
@@ -1,15 +1,19 @@
+import { skipUnion } from "../util/skipUnion";
+
 const getOneGassmaOmit = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const oneOmit = Object.keys(sheetContent).reduce((pre, columnName) => {
     const isQuestionMark = columnName.at(-1) === "?";
     const removedQuestionMark = isQuestionMark
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: true | false;\n`;
+    return `${pre}  "${removedQuestionMark}"?: true | false${sk};\n`;
   }, `\nexport type Gassma${schemaName}${sheetName}Omit = {\n`);
 
   return `${oneOmit}};\n`;

--- a/src/generate/typeGenerate/gassmaOrderBy.ts
+++ b/src/generate/typeGenerate/gassmaOrderBy.ts
@@ -6,6 +6,7 @@ const getGassmaOrderBy = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
   const orderByDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -20,6 +21,7 @@ const getGassmaOrderBy = (
           schemaName,
           removedSpaceCurrentSheetName,
           relations,
+          strict,
         )
       );
     },

--- a/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
+++ b/src/generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy.ts
@@ -1,33 +1,36 @@
 import type { RelationsConfig } from "../../read/extractRelations";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaOrderBy = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const scalarFields = Object.keys(sheetContent).reduce((pre, columnName) => {
     const isQuestionMark = columnName.at(-1) === "?";
     const removedQuestionMark = isQuestionMark
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: "asc" | "desc" | Gassma.SortOrderInput;\n`;
+    return `${pre}  "${removedQuestionMark}"?: "asc" | "desc" | Gassma.SortOrderInput${sk};\n`;
   }, `\nexport type Gassma${schemaName}${sheetName}OrderBy = {\n`);
 
   const modelRelations = relations?.[sheetName];
   const relationFields = modelRelations
     ? Object.keys(modelRelations).reduce((pre, relationName) => {
         const targetModel = modelRelations[relationName].to;
-        return `${pre}  "${relationName}"?: Gassma${schemaName}${targetModel}OrderBy | { _count: "asc" | "desc" };\n`;
+        return `${pre}  "${relationName}"?: Gassma${schemaName}${targetModel}OrderBy | { _count: "asc" | "desc" }${sk};\n`;
       }, "")
     : "";
 
   const countField =
     modelRelations && Object.keys(modelRelations).length > 0
       ? `  "_count"?: { ${Object.keys(modelRelations)
-          .map((name) => `"${name}"?: "asc" | "desc"`)
-          .join("; ")} };\n`
+          .map((name) => `"${name}"?: "asc" | "desc"${sk}`)
+          .join("; ")} }${sk};\n`
       : "";
 
   return `${scalarFields}${relationFields}${countField}};\n`;

--- a/src/generate/typeGenerate/gassmaSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect.ts
@@ -8,6 +8,7 @@ const getGassmaSelect = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
   const selectDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -21,17 +22,20 @@ const getGassmaSelect = (
           sheetContent,
           schemaName,
           removedSpaceCurrentSheetName,
+          strict,
         ) +
         getOneGassmaNumberSelect(
           sheetContent,
           schemaName,
           removedSpaceCurrentSheetName,
+          strict,
         ) +
         getOneGassmaFindSelect(
           sheetContent,
           schemaName,
           removedSpaceCurrentSheetName,
           relations,
+          strict,
         )
       );
     },

--- a/src/generate/typeGenerate/gassmaSelect/oneGassmaFindSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect/oneGassmaFindSelect.ts
@@ -1,18 +1,21 @@
 import type { RelationsConfig } from "../../read/extractRelations";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaFindSelect = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const scalarFields = Object.keys(sheetContent).reduce((pre, columnName) => {
     const isQuestionMark = columnName.at(-1) === "?";
     const removedQuestionMark = isQuestionMark
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: true;\n`;
+    return `${pre}  "${removedQuestionMark}"?: true${sk};\n`;
   }, "");
 
   const modelRelations = relations?.[sheetName];
@@ -24,13 +27,13 @@ const getOneGassmaFindSelect = (
     relationFields = Object.keys(modelRelations).reduce((pre, relationName) => {
       const targetModel = modelRelations[relationName].to;
       const target = `Gassma${schemaName}${targetModel}`;
-      const optionsType = `{ select?: ${target}FindSelect; omit?: ${target}Omit; where?: ${target}WhereUse; orderBy?: ${target}OrderBy; take?: number; skip?: number; include?: ${target}Include; _count?: ${target}CountValue }`;
-      return `${pre}  "${relationName}"?: true | ${optionsType};\n`;
+      const optionsType = `{ select?: ${target}FindSelect${sk}; omit?: ${target}Omit${sk}; where?: ${target}WhereUse${sk}; orderBy?: ${target}OrderBy${sk}; take?: number${sk}; skip?: number${sk}; include?: ${target}Include${sk}; _count?: ${target}CountValue${sk} }`;
+      return `${pre}  "${relationName}"?: true | ${optionsType}${sk};\n`;
     }, "");
   }
 
   const countField = hasRelations
-    ? `  "_count"?: Gassma${schemaName}${sheetName}CountValue;\n`
+    ? `  "_count"?: Gassma${schemaName}${sheetName}CountValue${sk};\n`
     : "";
 
   return `\nexport type Gassma${schemaName}${sheetName}FindSelect = {\n${scalarFields}${relationFields}${countField}};\n`;

--- a/src/generate/typeGenerate/gassmaSelect/oneGassmaNumberSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect/oneGassmaNumberSelect.ts
@@ -1,9 +1,11 @@
 import { isNumberColumn } from "../../util/isNumberColumn";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaNumberSelect = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
   const numberColumnNames = Object.keys(sheetContent).filter((columnName) =>
     isNumberColumn(sheetContent[columnName]),
@@ -15,13 +17,14 @@ const getOneGassmaNumberSelect = (
     return `\nexport type ${typeName} = Record<string, never>;\n`;
   }
 
+  const sk = skipUnion(strict);
   const oneSelect = numberColumnNames.reduce((pre, columnName) => {
     const isQuestionMark = columnName.at(-1) === "?";
     const removedQuestionMark = isQuestionMark
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: true;\n`;
+    return `${pre}  "${removedQuestionMark}"?: true${sk};\n`;
   }, `\nexport type ${typeName} = {\n`);
 
   return `${oneSelect}};\n`;

--- a/src/generate/typeGenerate/gassmaSelect/oneGassmaSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect/oneGassmaSelect.ts
@@ -1,15 +1,19 @@
+import { skipUnion } from "../util/skipUnion";
+
 const getOneGassmaSelect = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const oneSelct = Object.keys(sheetContent).reduce((pre, columnName) => {
     const isQuestionMark = columnName.at(-1) === "?";
     const removedQuestionMark = isQuestionMark
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: true;\n`;
+    return `${pre}  "${removedQuestionMark}"?: true${sk};\n`;
   }, `\nexport type Gassma${schemaName}${sheetName}Select = {\n`);
 
   return `${oneSelct}};\n`;

--- a/src/generate/typeGenerate/gassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData.ts
@@ -1,13 +1,18 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaUpdateData } from "./gassmaUpdateData/oneGassmaUpdateData";
 
-const getGassmaUpdateData = (sheetNames: string[], schemaName: string) => {
+const getGassmaUpdateData = (
+  sheetNames: string[],
+  schemaName: string,
+  strict?: boolean,
+) => {
   const updateDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
       getRemovedCantUseVarChar(currentSheetName);
 
     return (
-      pre + getOneGassmaUpdateData(schemaName, removedSpaceCurrentSheetName)
+      pre +
+      getOneGassmaUpdateData(schemaName, removedSpaceCurrentSheetName, strict)
     );
   }, "");
 

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateData.ts
@@ -1,11 +1,18 @@
-const getOneGassmaUpdateData = (schemaName: string, sheetName: string) => {
-  const dataType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>`;
+import { skipUnion } from "../util/skipUnion";
+
+const getOneGassmaUpdateData = (
+  schemaName: string,
+  sheetName: string,
+  strict?: boolean,
+) => {
+  const sk = skipUnion(strict);
+  const dataType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation${sk} }>`;
 
   return `
 export type Gassma${schemaName}${sheetName}UpdateData = {
-  where?: Gassma${schemaName}${sheetName}WhereUse;
+  where?: Gassma${schemaName}${sheetName}WhereUse${sk};
   data: ${dataType};
-  limit?: number;
+  limit?: number${sk};
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateData/oneGassmaUpdateSingleData.ts
@@ -1,18 +1,22 @@
 import type { RelationsConfig } from "../../read/extractRelations";
 import { getNestedWriteFields } from "../util/getNestedWriteFields";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaUpdateSingleData = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const nestedFields = getNestedWriteFields(
     schemaName,
     sheetName,
     relations,
     "update",
+    strict,
   );
-  const baseDataType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>`;
+  const baseDataType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation${sk} }>`;
   const dataType = nestedFields
     ? `${baseDataType} & {\n${nestedFields}  }`
     : baseDataType;
@@ -24,8 +28,8 @@ const getOneGassmaUpdateSingleData = (
 export type Gassma${schemaName}${sheetName}UpdateSingleData = {
   where: Gassma${schemaName}${sheetName}WhereUse;
   data: ${dataType};
-  include?: Gassma${schemaName}${sheetName}Include;
-} & ({ select?: ${selectType}; omit?: never } | { select?: never; omit?: ${omitType} });
+  include?: Gassma${schemaName}${sheetName}Include${sk};
+} & ({ select?: ${selectType}${sk}; omit?: never } | { select?: never; omit?: ${omitType}${sk} });
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaUpdateSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpdateSingleData.ts
@@ -6,6 +6,7 @@ const getGassmaUpdateSingleData = (
   sheetNames: string[],
   schemaName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
   const updateSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
@@ -17,6 +18,7 @@ const getGassmaUpdateSingleData = (
         schemaName,
         removedSpaceCurrentSheetName,
         relations,
+        strict,
       )
     );
   }, "");

--- a/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertData/oneGassmaUpsertSingleData.ts
@@ -1,21 +1,30 @@
 import type { RelationsConfig } from "../../read/extractRelations";
 import { buildCreateDataType } from "../util/buildCreateDataType";
 import { getNestedWriteFields } from "../util/getNestedWriteFields";
+import { skipUnion } from "../util/skipUnion";
 
 const getOneGassmaUpsertSingleData = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
-  const createType = buildCreateDataType(schemaName, sheetName, relations);
+  const sk = skipUnion(strict);
+  const createType = buildCreateDataType(
+    schemaName,
+    sheetName,
+    relations,
+    strict,
+  );
 
   const nestedFields = getNestedWriteFields(
     schemaName,
     sheetName,
     relations,
     "update",
+    strict,
   );
-  const baseUpdateType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation }>`;
+  const baseUpdateType = `Partial<{ [K in keyof Gassma${schemaName}${sheetName}Use]: Gassma${schemaName}${sheetName}Use[K] | Gassma.NumberOperation${sk} }>`;
   const updateType = nestedFields
     ? `${baseUpdateType} & {\n${nestedFields}  }`
     : baseUpdateType;
@@ -28,8 +37,8 @@ export type Gassma${schemaName}${sheetName}UpsertSingleData = {
   where: Gassma${schemaName}${sheetName}WhereUse;
   create: ${createType};
   update: ${updateType};
-  include?: Gassma${schemaName}${sheetName}Include;
-} & ({ select?: ${selectType}; omit?: never } | { select?: never; omit?: ${omitType} });
+  include?: Gassma${schemaName}${sheetName}Include${sk};
+} & ({ select?: ${selectType}${sk}; omit?: never } | { select?: never; omit?: ${omitType}${sk} });
 `;
 };
 

--- a/src/generate/typeGenerate/gassmaUpsertSingleData.ts
+++ b/src/generate/typeGenerate/gassmaUpsertSingleData.ts
@@ -6,6 +6,7 @@ const getGassmaUpsertSingleData = (
   sheetNames: string[],
   schemaName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
   const upsertSingleDataDeclare = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
@@ -17,6 +18,7 @@ const getGassmaUpsertSingleData = (
         schemaName,
         removedSpaceCurrentSheetName,
         relations,
+        strict,
       )
     );
   }, "");

--- a/src/generate/typeGenerate/gassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse.ts
@@ -6,6 +6,7 @@ const getGassmaWhereUse = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
   const whereUseDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) => {
@@ -20,6 +21,7 @@ const getGassmaWhereUse = (
           schemaName,
           removedSpaceCurrentSheetName,
           relations,
+          strict,
         )
       );
     },

--- a/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
@@ -1,6 +1,7 @@
 import { getColumnType } from "../../util/getColumnType";
 import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
 import type { RelationsConfig } from "../../read/extractRelations";
+import { skipUnion } from "../util/skipUnion";
 
 const isListRelation = (type: string): boolean =>
   type === "oneToMany" || type === "manyToMany";
@@ -9,19 +10,22 @@ const getRelationFields = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ): string => {
   if (!relations) return "";
   const modelRelations = relations[sheetName];
   if (!modelRelations) return "";
 
+  const sk = skipUnion(strict);
+
   return Object.keys(modelRelations).reduce((pre, relationName) => {
     const rel = modelRelations[relationName];
     const targetWhere = `Gassma${schemaName}${rel.to}WhereUse`;
     const filterType = isListRelation(rel.type)
-      ? `{ some?: ${targetWhere}; every?: ${targetWhere}; none?: ${targetWhere} }`
-      : `{ is?: ${targetWhere} | null; isNot?: ${targetWhere} | null }`;
+      ? `{ some?: ${targetWhere}${sk}; every?: ${targetWhere}${sk}; none?: ${targetWhere}${sk} }`
+      : `{ is?: ${targetWhere} | null${sk}; isNot?: ${targetWhere} | null${sk} }`;
 
-    return `${pre}  "${relationName}"?: ${filterType};\n`;
+    return `${pre}  "${relationName}"?: ${filterType}${sk};\n`;
   }, "");
 };
 
@@ -30,7 +34,9 @@ const getOneGassmaWhereUse = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ) => {
+  const sk = skipUnion(strict);
   const oneWhereUse = Object.keys(sheetContent).reduce((pre, columnName) => {
     const columnTypes = sheetContent[columnName];
     const now = getColumnType(columnTypes);
@@ -41,15 +47,20 @@ const getOneGassmaWhereUse = (
       ? columnName.substring(0, columnName.length - 1)
       : columnName;
 
-    return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions;\n`;
+    return `${pre}  "${removedQuestionMark}"?: ${now}${isQuestionMark ? " | null" : ""} | Gassma${schemaName}${sheetName}${removedSpaceCurrentColumnName}FilterConditions${sk};\n`;
   }, `\nexport type Gassma${schemaName}${sheetName}WhereUse = {\n`);
 
-  const relationFields = getRelationFields(schemaName, sheetName, relations);
+  const relationFields = getRelationFields(
+    schemaName,
+    sheetName,
+    relations,
+    strict,
+  );
 
   return `${oneWhereUse}${relationFields}
-  AND?: Gassma${schemaName}${sheetName}WhereUse[] | Gassma${schemaName}${sheetName}WhereUse;
-  OR?: Gassma${schemaName}${sheetName}WhereUse[];
-  NOT?: Gassma${schemaName}${sheetName}WhereUse[] | Gassma${schemaName}${sheetName}WhereUse;
+  AND?: Gassma${schemaName}${sheetName}WhereUse[] | Gassma${schemaName}${sheetName}WhereUse${sk};
+  OR?: Gassma${schemaName}${sheetName}WhereUse[]${sk};
+  NOT?: Gassma${schemaName}${sheetName}WhereUse[] | Gassma${schemaName}${sheetName}WhereUse${sk};
 };
 `;
 };

--- a/src/generate/typeGenerate/util/buildCreateDataType.ts
+++ b/src/generate/typeGenerate/util/buildCreateDataType.ts
@@ -3,15 +3,19 @@ import type {
   RelationsConfig,
 } from "../../read/extractRelations";
 import { getNestedWriteFields } from "./getNestedWriteFields";
+import { skipOptionalWrap, skipUnion } from "./skipUnion";
 
 const buildFkXorPart = (
   schemaName: string,
   use: string,
   relationName: string,
   rel: RelationDefinition,
+  strict?: boolean,
 ): string => {
+  const sk = skipUnion(strict);
   const target = `Gassma${schemaName}${rel.to}`;
-  const ops = `create?: ${target}Use; connect?: ${target}WhereUse; connectOrCreate?: { where: ${target}WhereUse; create: ${target}Use }`;
+  const targetCreate = skipOptionalWrap(`${target}Use`, strict);
+  const ops = `create?: ${targetCreate}${sk}; connect?: ${target}WhereUse${sk}; connectOrCreate?: { where: ${target}WhereUse; create: ${targetCreate} }${sk}`;
 
   return `(Pick<${use}, "${rel.field}"> | { "${relationName}": { ${ops} } })`;
 };
@@ -20,6 +24,7 @@ const buildCreateDataType = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  strict?: boolean,
 ): string => {
   const use = `Gassma${schemaName}${sheetName}Use`;
   const modelRelations = relations?.[sheetName] ?? {};
@@ -31,15 +36,18 @@ const buildCreateDataType = (
     sheetName,
     relations,
     "create",
+    strict,
   );
 
   const fkFieldsUnion = fkRelationNames
     .map((name) => `"${modelRelations[name].field}"`)
     .join(" | ");
   const baseType =
-    fkRelationNames.length > 0 ? `Omit<${use}, ${fkFieldsUnion}>` : use;
+    fkRelationNames.length > 0
+      ? skipOptionalWrap(`Omit<${use}, ${fkFieldsUnion}>`, strict)
+      : skipOptionalWrap(use, strict);
   const xorParts = fkRelationNames.map((name) =>
-    buildFkXorPart(schemaName, use, name, modelRelations[name]),
+    buildFkXorPart(schemaName, use, name, modelRelations[name], strict),
   );
   const nestedParts = nestedFields ? [`{\n${nestedFields}  }`] : [];
 

--- a/src/generate/typeGenerate/util/getNestedWriteFields.ts
+++ b/src/generate/typeGenerate/util/getNestedWriteFields.ts
@@ -2,6 +2,7 @@ import type {
   RelationDefinition,
   RelationsConfig,
 } from "../../read/extractRelations";
+import { skipOptionalWrap, skipUnion } from "./skipUnion";
 
 type NestedWriteContext = "create" | "update";
 
@@ -18,11 +19,13 @@ const isListRelation = (type: string): boolean =>
 const buildBaseOpTypes = (
   rel: RelationDefinition,
   target: string,
+  strict?: boolean,
 ): BaseOpTypes => {
-  const childCreate =
+  const rawChildCreate =
     rel.type === "oneToMany" || rel.type === "oneToOne"
       ? `Omit<${target}Use, "${rel.reference}">`
       : `${target}Use`;
+  const childCreate = skipOptionalWrap(rawChildCreate, strict);
   const isList = isListRelation(rel.type);
   const createType = isList ? `${childCreate} | ${childCreate}[]` : childCreate;
   const connectType = isList
@@ -39,53 +42,59 @@ const buildBaseOpTypes = (
 const buildCreateContextOps = (
   rel: RelationDefinition,
   target: string,
+  strict?: boolean,
 ): string[] => {
-  const base = buildBaseOpTypes(rel, target);
+  const sk = skipUnion(strict);
+  const base = buildBaseOpTypes(rel, target, strict);
   const createManyOps =
     rel.type === "oneToMany"
-      ? [`createMany?: { data: ${base.childCreate}[] }`]
+      ? [`createMany?: { data: ${base.childCreate}[] }${sk}`]
       : [];
 
   return [
-    `create?: ${base.createType}`,
+    `create?: ${base.createType}${sk}`,
     ...createManyOps,
-    `connect?: ${base.connectType}`,
-    `connectOrCreate?: ${base.connectOrCreateType}`,
+    `connect?: ${base.connectType}${sk}`,
+    `connectOrCreate?: ${base.connectOrCreateType}${sk}`,
   ];
 };
 
 const buildUpdateOnlyOps = (
   rel: RelationDefinition,
   target: string,
+  strict?: boolean,
 ): string[] => {
+  const sk = skipUnion(strict);
+  const partialUpdate = skipOptionalWrap(`Partial<${target}Use>`, strict);
   if (rel.type === "oneToMany") {
     return [
-      `update?: { where: ${target}WhereUse; data: Partial<${target}Use> } | { where: ${target}WhereUse; data: Partial<${target}Use> }[]`,
-      `delete?: ${target}WhereUse | ${target}WhereUse[]`,
-      `deleteMany?: ${target}WhereUse | ${target}WhereUse[]`,
-      `disconnect?: ${target}WhereUse | ${target}WhereUse[]`,
-      `set?: ${target}WhereUse[]`,
+      `update?: { where: ${target}WhereUse; data: ${partialUpdate} } | { where: ${target}WhereUse; data: ${partialUpdate} }[]${sk}`,
+      `delete?: ${target}WhereUse | ${target}WhereUse[]${sk}`,
+      `deleteMany?: ${target}WhereUse | ${target}WhereUse[]${sk}`,
+      `disconnect?: ${target}WhereUse | ${target}WhereUse[]${sk}`,
+      `set?: ${target}WhereUse[]${sk}`,
     ];
   }
   if (rel.type === "oneToOne" || rel.type === "manyToOne") {
     return [
-      `update?: Partial<${target}Use>`,
-      "delete?: true",
-      "disconnect?: true",
+      `update?: ${partialUpdate}${sk}`,
+      `delete?: true${sk}`,
+      `disconnect?: true${sk}`,
     ];
   }
   return [
-    `disconnect?: ${target}WhereUse | ${target}WhereUse[]`,
-    `set?: ${target}WhereUse[]`,
+    `disconnect?: ${target}WhereUse | ${target}WhereUse[]${sk}`,
+    `set?: ${target}WhereUse[]${sk}`,
   ];
 };
 
 const buildUpdateContextOps = (
   rel: RelationDefinition,
   target: string,
+  strict?: boolean,
 ): string[] => [
-  ...buildCreateContextOps(rel, target),
-  ...buildUpdateOnlyOps(rel, target),
+  ...buildCreateContextOps(rel, target, strict),
+  ...buildUpdateOnlyOps(rel, target, strict),
 ];
 
 const getNestedWriteFields = (
@@ -93,11 +102,13 @@ const getNestedWriteFields = (
   sheetName: string,
   relations: RelationsConfig | undefined,
   context: NestedWriteContext,
+  strict?: boolean,
 ): string => {
   if (!relations) return "";
   const modelRelations = relations[sheetName];
   if (!modelRelations) return "";
 
+  const sk = skipUnion(strict);
   const relationNames = Object.keys(modelRelations).filter(
     (name) => context === "update" || modelRelations[name].type !== "manyToOne",
   );
@@ -107,10 +118,10 @@ const getNestedWriteFields = (
     const target = `Gassma${schemaName}${rel.to}`;
     const ops =
       context === "create"
-        ? buildCreateContextOps(rel, target)
-        : buildUpdateContextOps(rel, target);
+        ? buildCreateContextOps(rel, target, strict)
+        : buildUpdateContextOps(rel, target, strict);
 
-    return `${pre}    "${relationName}"?: { ${ops.join("; ")} };\n`;
+    return `${pre}    "${relationName}"?: { ${ops.join("; ")} }${sk};\n`;
   }, "");
 };
 

--- a/src/generate/typeGenerate/util/skipUnion.ts
+++ b/src/generate/typeGenerate/util/skipUnion.ts
@@ -1,0 +1,7 @@
+const skipUnion = (strict?: boolean): string =>
+  strict ? " | Gassma.SkipValue" : "";
+
+const skipOptionalWrap = (typeExpr: string, strict?: boolean): string =>
+  strict ? `Gassma.SkipOptional<${typeExpr}>` : typeExpr;
+
+export { skipUnion, skipOptionalWrap };


### PR DESCRIPTION
## 概要

本体（gassma #143、マージ済み）の `Gassma.skip` / `strictUndefinedChecks`（opt-in）に **cli 側で追随**しました。有効化の入口は Prisma と同じく **generator ブロックの `previewFeatures = ["strictUndefinedChecks"]`**。

## 実装（3点）

1. **`extractPreviewFeatures`（新規）**: generator ブロックの `previewFeatures` 配列をパース（extractOutputPath と同じパーサ）。未知の preview 名・空配列・generator なしでも壊れない。
2. **client.js 注入**: 有効時のみ生成 client.js の `GassmaClient` オプションに `strictUndefinedChecks: true` を追加（relations/defaults/omit と同位置）。
3. **生成型分岐（有効時のみ）**: 入力値型に `| Gassma.SkipValue` を付与。対象 = where 値 / FilterConditions 各キー / data・create・update 値 / nested write の各操作値 / select・omit・include / orderBy / トップレベルの**オプショナル**引数。**配列要素・必須引数には付けない**（本体が throw する箇所）。生成 d.ts の `Gassma` namespace に `skip` / `SkipValue` / `SkipOptional<T>` ヘルパーを出力。

## 設計

有効/無効は**生成時に確定**するので、型パラメータ分岐（`GassmaClient<Strict>`）ではなく **Prisma と同じ生成文字列の出し分け**。共通ヘルパー `skipUnion` / `SkipOptional<T>`（オプショナルキーのみに SkipValue を足す homomorphic mapped type、eOPT 環境でも壊れない）で全生成関数にスレッディング。**全対象を実装**（設計案止まりなし）。

## 検証

- **無効時（デフォルト）は生成物がバイト単位で従来と一致**（origin/main の素の生成器と BYTE_IDENTICAL 実証）。後方互換。
- `npm run test:types`: **137 ファイル 758 テスト + Type Errors なし**、tsc clean、build 成功、biome clean。
- 型テスト `types/strict/skip.test-d.ts`: skip 受容 / 配列要素拒否 / 必須引数拒否 / 非 strict では namespace に skip 不在（`@ts-expect-error` 込み）。
- **bin 実挙動**（私も独立確認）: previewFeatures **あり** → client.js に `strictUndefinedChecks: true`・d.ts に SkipValue（113件）、**なし** → 両方 0 件・merge 行も従来通り。

## 妥協点・未対応

- **undefined の型レベル完全拒否は利用側 tsconfig `exactOptionalPropertyTypes` が前提**（Prisma と同じ制約）。cli リポジトリ自体への eOPT 導入は既存 src が多数エラーになるため見送り。型テストは「skip を渡せる/渡せない」に限定。
- generate 時の eOPT 推奨 console 出力は**仕様追加になるため未実装**（1行で足せる状態、要否は別途判断）。
- `GassmaClientOptions` 型に `strictUndefinedChecks?: boolean` は追加せず（有効化入口は previewFeatures のみ、注入は codegen が行う。非 strict 時の型を変えない制約とも整合）。

## reference（別途・変更なし）

`previewFeatures` の書き方・`Gassma.skip` の使い方・`exactOptionalPropertyTypes` 推奨の追記が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMKrXnx9WMRGvtxhWGtWcx