### PR TITLE
feat: allow direct null on to-one relation keys in generated WhereUse

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaWhereUse.test.ts
@@ -34,8 +34,9 @@ describe("getOneGassmaWhereUse", () => {
     const result = getOneGassmaWhereUse(sheetContent, "", "User", relations);
 
     expect(result).toContain(
-      '"posts"?: { some?: GassmaPostWhereUse; every?: GassmaPostWhereUse; none?: GassmaPostWhereUse }',
+      '"posts"?: { some?: GassmaPostWhereUse; every?: GassmaPostWhereUse; none?: GassmaPostWhereUse };',
     );
+    expect(result).not.toContain("} | null");
   });
 
   it("should add manyToOne relation filter with is/isNot", () => {
@@ -53,7 +54,7 @@ describe("getOneGassmaWhereUse", () => {
     const result = getOneGassmaWhereUse(sheetContent, "", "Post", relations);
 
     expect(result).toContain(
-      '"author"?: { is?: GassmaUserWhereUse | null; isNot?: GassmaUserWhereUse | null }',
+      '"author"?: { is?: GassmaUserWhereUse | null; isNot?: GassmaUserWhereUse | null } | null;',
     );
   });
 
@@ -72,7 +73,7 @@ describe("getOneGassmaWhereUse", () => {
     const result = getOneGassmaWhereUse(sheetContent, "", "User", relations);
 
     expect(result).toContain(
-      '"profile"?: { is?: GassmaProfileWhereUse | null; isNot?: GassmaProfileWhereUse | null }',
+      '"profile"?: { is?: GassmaProfileWhereUse | null; isNot?: GassmaProfileWhereUse | null } | null;',
     );
   });
 
@@ -91,8 +92,9 @@ describe("getOneGassmaWhereUse", () => {
     const result = getOneGassmaWhereUse(sheetContent, "", "Post", relations);
 
     expect(result).toContain(
-      '"tags"?: { some?: GassmaTagWhereUse; every?: GassmaTagWhereUse; none?: GassmaTagWhereUse }',
+      '"tags"?: { some?: GassmaTagWhereUse; every?: GassmaTagWhereUse; none?: GassmaTagWhereUse };',
     );
+    expect(result).not.toContain("} | null");
   });
 
   it("should not add relation fields when no relations for model", () => {

--- a/src/__test__/generate/typeGenerate/strictSkip/whereFilterHaving.test.ts
+++ b/src/__test__/generate/typeGenerate/strictSkip/whereFilterHaving.test.ts
@@ -109,7 +109,7 @@ describe("strict WhereUse", () => {
       true,
     );
     expect(postResult).toContain(
-      '"author"?: { is?: GassmaUserWhereUse | null | Gassma.SkipValue; isNot?: GassmaUserWhereUse | null | Gassma.SkipValue } | Gassma.SkipValue;',
+      '"author"?: { is?: GassmaUserWhereUse | null | Gassma.SkipValue; isNot?: GassmaUserWhereUse | null | Gassma.SkipValue } | null | Gassma.SkipValue;',
     );
   });
 

--- a/src/__test__/types/query/where.test-d.ts
+++ b/src/__test__/types/query/where.test-d.ts
@@ -77,6 +77,24 @@ declare const client: GassmaClient;
   client.Post.findMany({ where: { author: { is: null } } });
 }
 
+// where: to-one relation に直接 null（is: null のショートハンド）
+{
+  client.User.findMany({ where: { profile: null } });
+  client.Post.findMany({ where: { author: null } });
+  client.Category.findMany({ where: { parent: null } });
+  // gassma に required 概念はないため FK 側 oneToOne も null 可（Prisma との差異）
+  client.Profile.findMany({ where: { user: null } });
+  client.User.findMany({ where: { posts: { some: { author: null } } } });
+}
+
+// where: list relation に直接 null は渡せない
+{
+  // @ts-expect-error posts は oneToMany なので null 不可
+  client.User.findMany({ where: { posts: null } });
+  // @ts-expect-error tags は manyToMany なので null 不可
+  client.Post.findMany({ where: { tags: null } });
+}
+
 // where: nullable フィールドの FilterConditions で null を使える
 {
   client.User.findMany({ where: { name: { equals: null } } });

--- a/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
+++ b/src/generate/typeGenerate/gassmaWhereUse/oneGassmaWhereUse.ts
@@ -23,7 +23,7 @@ const getRelationFields = (
     const targetWhere = `Gassma${schemaName}${rel.to}WhereUse`;
     const filterType = isListRelation(rel.type)
       ? `{ some?: ${targetWhere}${sk}; every?: ${targetWhere}${sk}; none?: ${targetWhere}${sk} }`
-      : `{ is?: ${targetWhere} | null${sk}; isNot?: ${targetWhere} | null${sk} }`;
+      : `{ is?: ${targetWhere} | null${sk}; isNot?: ${targetWhere} | null${sk} } | null`;
 
     return `${pre}  "${relationName}"?: ${filterType}${sk};\n`;
   }, "");


### PR DESCRIPTION
## 概要

本体 **akahoshi1421/gassma#145**(直値 `{ relation: null }` ショートハンド)の cli 型対応です。**#145 を先にマージしてください。**

## Prisma 型仕様の確認(生成 d.ts の実物・行番号レベル)

- optional to-one: `XOR<...RelationFilter, ...WhereInput> | null`(直値 null 許容)
- list リレーション: `ListRelationFilter` で **null なし**
- required to-one: null なし

## 変更(生成器は1行)

`oneGassmaWhereUse.ts`: to-one(oneToOne/manyToOne)の relation キー値 union に `| null` を追加。list(some/every/none)は付けない。

```diff
- "author"?: { is?: GassmaUserWhereUse | null; isNot?: GassmaUserWhereUse | null };
+ "author"?: { is?: GassmaUserWhereUse | null; isNot?: GassmaUserWhereUse | null } | null;
```

## Prisma との意図的差異(本体 PR にも明記)

Prisma は required to-one に null を許しませんが、gassma は**全 to-one に付与**します — 既存の `is?: ... | null` が全 to-one に付く型サーフェスと一貫し、シートには required 制約の実体が無く**空 FK セルの行は実在し得る**(不整合行の検索に有用)ため。

## テスト(TDD: Red → Green、空振りなし実証)

正例5件(非FK側 `User.profile` / `Post.author` / self-relation `Category.parent` / FK側 `Profile.user` / ネスト `posts.some.author: null`)+ list への null は `@ts-expect-error` 2件 + 生成側ユニットの厳密一致更新。

- unit **659** / `test:types` 型エラー0 / `tsc --noEmit` clean / biome clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja