### PR TITLE
feat: drop cursor from generated GroupByData; accept orderBy arrays in relation options

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaFindSelect.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindSelect.test.ts
@@ -42,7 +42,9 @@ describe("getOneGassmaFindSelect", () => {
     expect(result).toContain("select?: GassmaTestPostFindSelect");
     expect(result).not.toContain("select?: GassmaTestPostSelect;");
     expect(result).toContain("where?: GassmaTestPostWhereUse");
-    expect(result).toContain("orderBy?: GassmaTestPostOrderBy");
+    expect(result).toContain(
+      "orderBy?: GassmaTestPostOrderBy | GassmaTestPostOrderBy[]",
+    );
     expect(result).toContain("include?: GassmaTestPostInclude");
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaGroupByData.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaGroupByData.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from "vitest";
 import { getOneGassmaGroupByData } from "../../../generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData";
 
 describe("getOneGassmaGroupByData", () => {
-  it("should extend AggregateData with by + having", () => {
+  it("should extend AggregateData without cursor, with by + having", () => {
     const result = getOneGassmaGroupByData(
       { id: [1], name: ["a"] },
       "",
       "User",
     );
     expect(result).toContain(
-      "export type GassmaUserGroupByData = GassmaUserAggregateData & {",
+      'export type GassmaUserGroupByData = Omit<GassmaUserAggregateData, "cursor"> & {',
     );
     expect(result).toContain("by:");
     expect(result).toContain("having?: GassmaUserHavingUse;");
@@ -34,7 +34,7 @@ describe("getOneGassmaGroupByData", () => {
   it("should prepend schemaName", () => {
     const result = getOneGassmaGroupByData({ id: [1] }, "Test", "User");
     expect(result).toContain("export type GassmaTestUserGroupByData");
-    expect(result).toContain("GassmaTestUserAggregateData");
+    expect(result).toContain('Omit<GassmaTestUserAggregateData, "cursor">');
     expect(result).toContain("GassmaTestUserHavingUse");
   });
 });

--- a/src/__test__/generate/typeGenerate/gassmaInclude.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaInclude.test.ts
@@ -43,7 +43,7 @@ describe("getOneGassmaInclude", () => {
     const result = getOneGassmaInclude("", "User", relations);
 
     expect(result).toContain(
-      '"posts"?: true | { select?: GassmaPostFindSelect; omit?: GassmaPostOmit; where?: GassmaPostWhereUse; orderBy?: GassmaPostOrderBy; take?: number; skip?: number; include?: GassmaPostInclude; _count?: GassmaPostCountValue };',
+      '"posts"?: true | { select?: GassmaPostFindSelect; omit?: GassmaPostOmit; where?: GassmaPostWhereUse; orderBy?: GassmaPostOrderBy | GassmaPostOrderBy[]; take?: number; skip?: number; include?: GassmaPostInclude; _count?: GassmaPostCountValue };',
     );
   });
 

--- a/src/__test__/generate/typeGenerate/strictSkip/selectOmitIncludeOrderBy.test.ts
+++ b/src/__test__/generate/typeGenerate/strictSkip/selectOmitIncludeOrderBy.test.ts
@@ -78,7 +78,7 @@ describe("strict FindSelect", () => {
 
   it("should add SkipValue to relation values and their options", () => {
     expect(result).toContain(
-      '"posts"?: true | { select?: GassmaPostFindSelect | Gassma.SkipValue; omit?: GassmaPostOmit | Gassma.SkipValue; where?: GassmaPostWhereUse | Gassma.SkipValue; orderBy?: GassmaPostOrderBy | Gassma.SkipValue; take?: number | Gassma.SkipValue; skip?: number | Gassma.SkipValue; include?: GassmaPostInclude | Gassma.SkipValue; _count?: GassmaPostCountValue | Gassma.SkipValue } | Gassma.SkipValue;',
+      '"posts"?: true | { select?: GassmaPostFindSelect | Gassma.SkipValue; omit?: GassmaPostOmit | Gassma.SkipValue; where?: GassmaPostWhereUse | Gassma.SkipValue; orderBy?: GassmaPostOrderBy | GassmaPostOrderBy[] | Gassma.SkipValue; take?: number | Gassma.SkipValue; skip?: number | Gassma.SkipValue; include?: GassmaPostInclude | Gassma.SkipValue; _count?: GassmaPostCountValue | Gassma.SkipValue } | Gassma.SkipValue;',
     );
   });
 
@@ -100,7 +100,7 @@ describe("strict Include", () => {
 
   it("should add SkipValue to relation values and their options", () => {
     expect(result).toContain(
-      '"posts"?: true | { select?: GassmaPostFindSelect | Gassma.SkipValue; omit?: GassmaPostOmit | Gassma.SkipValue; where?: GassmaPostWhereUse | Gassma.SkipValue; orderBy?: GassmaPostOrderBy | Gassma.SkipValue; take?: number | Gassma.SkipValue; skip?: number | Gassma.SkipValue; include?: GassmaPostInclude | Gassma.SkipValue; _count?: GassmaPostCountValue | Gassma.SkipValue } | Gassma.SkipValue;',
+      '"posts"?: true | { select?: GassmaPostFindSelect | Gassma.SkipValue; omit?: GassmaPostOmit | Gassma.SkipValue; where?: GassmaPostWhereUse | Gassma.SkipValue; orderBy?: GassmaPostOrderBy | GassmaPostOrderBy[] | Gassma.SkipValue; take?: number | Gassma.SkipValue; skip?: number | Gassma.SkipValue; include?: GassmaPostInclude | Gassma.SkipValue; _count?: GassmaPostCountValue | Gassma.SkipValue } | Gassma.SkipValue;',
     );
     expect(result).toContain(
       '"_count"?: GassmaUserCountValue | Gassma.SkipValue;',

--- a/src/__test__/types/aggregate/groupBy.test-d.ts
+++ b/src/__test__/types/aggregate/groupBy.test-d.ts
@@ -1,5 +1,9 @@
 import { expectTypeOf } from "vitest";
-import type { GassmaClient } from "../__generated__/client";
+import type {
+  GassmaClient,
+  GassmaUserAggregateData,
+  GassmaUserGroupByData,
+} from "../__generated__/client";
 
 declare const client: GassmaClient;
 
@@ -133,6 +137,24 @@ declare const client: GassmaClient;
     by: ["isActive"],
     orderBy: [{ isActive: "asc" }],
   });
+}
+
+// groupBy: cursor は存在しない（Prisma パリティ）
+{
+  const withCursor: GassmaUserGroupByData = {
+    by: ["isActive"],
+    // @ts-expect-error groupBy に cursor は指定できない
+    cursor: { id: 1 },
+  };
+  void withCursor;
+  expectTypeOf<GassmaUserGroupByData>().not.toHaveProperty("cursor");
+}
+
+// aggregate: cursor は引き続き使える（groupBy のみ除去）
+{
+  const aggregateData: GassmaUserAggregateData = { cursor: { id: 1 } };
+  void aggregateData;
+  client.User.aggregate({ cursor: { id: 1 }, _count: { id: true } });
 }
 
 // groupBy: _avg / _sum の数値フィールド限定が AggregateData から波及する

--- a/src/__test__/types/read/include.test-d.ts
+++ b/src/__test__/types/read/include.test-d.ts
@@ -132,3 +132,15 @@ declare const client: GassmaClient;
   type C = NonNullable<typeof c>;
   expectTypeOf<C["parent"]>().toBeNullable();
 }
+
+// include の relation オプション orderBy: 単一・配列の両方を受け付ける
+{
+  client.User.findFirst({
+    where: { id: 1 },
+    include: { posts: { orderBy: { title: "asc" } } },
+  });
+  client.User.findFirst({
+    where: { id: 1 },
+    include: { posts: { orderBy: [{ published: "desc" }, { title: "asc" }] } },
+  });
+}

--- a/src/__test__/types/read/select.test-d.ts
+++ b/src/__test__/types/read/select.test-d.ts
@@ -188,3 +188,21 @@ declare const client: GassmaClient;
   expectTypeOf<(typeof rs)[number]["posts"]>().toBeArray();
   expectTypeOf<(typeof rs)[number]>().not.toHaveProperty("email");
 }
+
+// select 内 relation の orderBy: 単一・配列の両方を受け付ける
+{
+  client.User.findFirstOrThrow({
+    where: {},
+    select: { posts: { orderBy: { title: "asc" }, select: { title: true } } },
+  });
+  const r = client.User.findFirstOrThrow({
+    where: {},
+    select: {
+      posts: {
+        orderBy: [{ published: "desc" }, { title: "asc" }],
+        select: { title: true },
+      },
+    },
+  });
+  expectTypeOf<(typeof r)["posts"][number]["title"]>().toEqualTypeOf<string>();
+}

--- a/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
+++ b/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
@@ -30,7 +30,7 @@ const getOneGassmaGroupByData = (
 
   const sk = skipUnion(strict);
 
-  return `\nexport type Gassma${schemaName}${sheetName}GroupByData = Gassma${schemaName}${sheetName}AggregateData & {
+  return `\nexport type Gassma${schemaName}${sheetName}GroupByData = Omit<Gassma${schemaName}${sheetName}AggregateData, "cursor"> & {
   by: ${byData}(${byArrayData})[];
   having?: Gassma${schemaName}${sheetName}HavingUse${sk};
 };

--- a/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
+++ b/src/generate/typeGenerate/gassmaInclude/oneGassmaInclude.ts
@@ -16,7 +16,7 @@ const getOneGassmaInclude = (
   const fields = Object.keys(modelRelations).reduce((pre, relationName) => {
     const targetModel = modelRelations[relationName].to;
     const target = `Gassma${schemaName}${targetModel}`;
-    const optionsType = `{ select?: ${target}FindSelect${sk}; omit?: ${target}Omit${sk}; where?: ${target}WhereUse${sk}; orderBy?: ${target}OrderBy${sk}; take?: number${sk}; skip?: number${sk}; include?: ${target}Include${sk}; _count?: ${target}CountValue${sk} }`;
+    const optionsType = `{ select?: ${target}FindSelect${sk}; omit?: ${target}Omit${sk}; where?: ${target}WhereUse${sk}; orderBy?: ${target}OrderBy | ${target}OrderBy[]${sk}; take?: number${sk}; skip?: number${sk}; include?: ${target}Include${sk}; _count?: ${target}CountValue${sk} }`;
     return `${pre}  "${relationName}"?: true | ${optionsType}${sk};\n`;
   }, "");
 

--- a/src/generate/typeGenerate/gassmaSelect/oneGassmaFindSelect.ts
+++ b/src/generate/typeGenerate/gassmaSelect/oneGassmaFindSelect.ts
@@ -27,7 +27,7 @@ const getOneGassmaFindSelect = (
     relationFields = Object.keys(modelRelations).reduce((pre, relationName) => {
       const targetModel = modelRelations[relationName].to;
       const target = `Gassma${schemaName}${targetModel}`;
-      const optionsType = `{ select?: ${target}FindSelect${sk}; omit?: ${target}Omit${sk}; where?: ${target}WhereUse${sk}; orderBy?: ${target}OrderBy${sk}; take?: number${sk}; skip?: number${sk}; include?: ${target}Include${sk}; _count?: ${target}CountValue${sk} }`;
+      const optionsType = `{ select?: ${target}FindSelect${sk}; omit?: ${target}Omit${sk}; where?: ${target}WhereUse${sk}; orderBy?: ${target}OrderBy | ${target}OrderBy[]${sk}; take?: number${sk}; skip?: number${sk}; include?: ${target}Include${sk}; _count?: ${target}CountValue${sk} }`;
       return `${pre}  "${relationName}"?: true | ${optionsType}${sk};\n`;
     }, "");
   }


### PR DESCRIPTION
## 概要

本体の型/実装乖離シリーズ(#146〜#149、マージ済み)の **cli 追随2点**です。

## 変更

1. **生成 GroupByData から cursor を除去**(本体 #148 対応): `Omit<AggregateData, "cursor"> & {...}` へ。groupBy に cursor は存在しない(Prisma 実測済み)。**AggregateData と FindFirstData の cursor は残存**(FindFirstData は本体実装が追いついたため)。
2. **Include / FindSelect の relation オプション `orderBy` に配列を許容**(本体 #149 対応): `OrderBy` → `OrderBy | OrderBy[]`。これが無いと生成 client から本体の新配列対応が使えなかった。strict(`SkipValue`)の配置は top-level Data 型の既存パターンと同一。

## テスト(TDD: 各サイクル Red→Green 実測)

- groupBy cursor 拒否 / `not.toHaveProperty("cursor")` / AggregateData 存続、include・select の relation orderBy 単一・配列正例、strict fixture 側も検証。
- **検証手法の注記**: TS 5.9 では generic 制約経由の call-site で excess property check が発火しないため、cursor 拒否は**型注釈への直接代入**方式でピン留め(旧生成器で fail・新生成器で pass の両方向を実測)。
- unit **758** / `test:types` 型エラー0(strict fixture 込み) / `tsc --noEmit` clean / biome clean。

これで型/実装乖離シリーズの cli 側は完了(件3 の changeSettings string 公開型は別判断のため未着手)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja