### PR TITLE
feat: generate $extends query types and runtime delegation

### DIFF
--- a/src/__test__/generate/generator.test.ts
+++ b/src/__test__/generate/generator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { generater } from "../../generate/generator";
 
 describe("generater", () => {
@@ -97,5 +97,14 @@ describe("generater", () => {
   it("should include GroupBy types", () => {
     expect(result).toContain("GassmaUserGroupByData");
     expect(result).toContain("GassmaUserGroupByResult");
+  });
+
+  it("should include Extension types", () => {
+    expect(result).toContain(
+      "export type GassmaExtension<O extends GassmaGlobalOmitConfig = {}> = {",
+    );
+    expect(result).toContain("export type GassmaUserQueryHooks");
+    expect(result).toContain("export type GassmaPostQueryHooks");
+    expect(result).toContain("export type GassmaAllModelsQueryHooks");
   });
 });

--- a/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { generateClientDts } from "../../../generate/jsGenerate/generateClientDts";
 
 describe("generateClientDts", () => {
@@ -31,9 +31,20 @@ describe("generateClientDts", () => {
     );
   });
 
+  it("should declare $extends on the client interface", () => {
+    const result = generateClientDts("Hoge");
+
+    expect(result).toContain(
+      "  $extends(extension: GassmaHogeExtension<O>): GassmaClient<O>;",
+    );
+  });
+
   it("should work with different schema names", () => {
     const result = generateClientDts("Fuga");
 
+    expect(result).toContain(
+      "  $extends(extension: GassmaFugaExtension<O>): GassmaClient<O>;",
+    );
     expect(result).toContain("export declare class GassmaClient");
     expect(result).toContain("options?: GassmaFugaClientOptions");
     expect(result).toContain(

--- a/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { generateClientJs } from "../../../generate/jsGenerate/generateClientJs";
+import type { AutoincrementConfig } from "../../../generate/read/extractAutoincrement";
 import type { DefaultsConfig } from "../../../generate/read/extractDefaults";
-import type { UpdatedAtConfig } from "../../../generate/read/extractUpdatedAt";
 import type { IgnoreConfig } from "../../../generate/read/extractIgnore";
 import type { MapConfig } from "../../../generate/read/extractMap";
-import type { AutoincrementConfig } from "../../../generate/read/extractAutoincrement";
+import type { UpdatedAtConfig } from "../../../generate/read/extractUpdatedAt";
 
 describe("generateClientJs", () => {
   it("should generate GassmaClient class with embedded relations", () => {
@@ -45,6 +45,46 @@ describe("generateClientJs", () => {
 
     expect(result).toContain("hogeRelations = {}");
     expect(result).toContain("class GassmaClient");
+  });
+
+  it("should delegate $extends to the core client instance", () => {
+    const result = generateClientJs({}, "Hoge");
+
+    expect(result).toContain(
+      "    this.$extends = (extension) => client.$extends(extension);",
+    );
+    expect(result.indexOf("Object.assign(this, client);")).toBeLessThan(
+      result.indexOf("this.$extends = (extension)"),
+    );
+  });
+
+  it("should expose a working $extends even though core defines it on the prototype", () => {
+    const code = generateClientJs({}, "Hoge");
+    const received: unknown[] = [];
+    class FakeCoreClient {
+      User = { findMany: () => [] };
+      $extends(extension: unknown) {
+        received.push(extension);
+        return { marker: "extended" };
+      }
+    }
+    const exportsObject: {
+      GassmaClient?: new (
+        options?: unknown,
+      ) => { $extends?: (extension: unknown) => unknown };
+    } = {};
+    const run = new Function("Gassma", "exports", code);
+    run({ GassmaClient: FakeCoreClient }, exportsObject);
+
+    const GeneratedClient = exportsObject.GassmaClient;
+    if (!GeneratedClient) throw new Error("GassmaClient not exported");
+    const instance = new GeneratedClient({});
+    expect(typeof instance.$extends).toBe("function");
+
+    const extension = { query: {} };
+    const extended = instance.$extends?.(extension);
+    expect(extended).toEqual({ marker: "extended" });
+    expect(received).toEqual([extension]);
   });
 
   it("should include onDelete and onUpdate when present", () => {

--- a/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { getGassmaExtension } from "../../../generate/typeGenerate/gassmaExtension";
+
+describe("getGassmaExtension", () => {
+  const result = getGassmaExtension(["User", "Post"], "Hoge");
+
+  it("should generate Extension type with optional query", () => {
+    expect(result).toContain(
+      "export type GassmaHogeExtension<O extends GassmaHogeGlobalOmitConfig = {}> = {",
+    );
+    expect(result).toContain("  query?: GassmaHogeQueryExtension<O>;");
+  });
+
+  it("should generate QueryExtension with per-model hooks and $allModels", () => {
+    expect(result).toContain(
+      "export type GassmaHogeQueryExtension<O extends GassmaHogeGlobalOmitConfig = {}> = {",
+    );
+    expect(result).toContain(
+      '  "User"?: GassmaHogeUserQueryHooks<O extends { "User": infer UO } ? UO extends GassmaHogeUserOmit ? UO : {} : {}, O>;',
+    );
+    expect(result).toContain(
+      '  "Post"?: GassmaHogePostQueryHooks<O extends { "Post": infer UO } ? UO extends GassmaHogePostOmit ? UO : {} : {}, O>;',
+    );
+    expect(result).toContain("  $allModels?: GassmaHogeAllModelsQueryHooks;");
+  });
+
+  it("should generate ModelName and OperationName unions", () => {
+    expect(result).toContain("export type GassmaHogeModelName =");
+    expect(result).toContain('  | "User"');
+    expect(result).toContain('  | "Post"');
+    expect(result).toContain("export type GassmaHogeOperationName =");
+    const operations = [
+      "findFirst",
+      "findFirstOrThrow",
+      "findMany",
+      "create",
+      "createMany",
+      "createManyAndReturn",
+      "update",
+      "updateMany",
+      "updateManyAndReturn",
+      "upsert",
+      "delete",
+      "deleteMany",
+      "count",
+      "aggregate",
+      "groupBy",
+    ];
+    operations.forEach((operation) => {
+      expect(result).toContain(`  | "${operation}"`);
+    });
+  });
+
+  it("should generate QueryHooks with generic hooks bound to model data types", () => {
+    expect(result).toContain(
+      "export type GassmaHogeUserQueryHooks<GO extends GassmaHogeUserOmit = {}, O = {}> = {",
+    );
+    expect(result).toContain(
+      "  findMany?: <T extends GassmaHogeUserFindManyData>(params: {",
+    );
+    expect(result).toContain(
+      '    query: (args: T) => GassmaHogeUserFindResult<T["select"], T["include"], T["omit"], GO, O>[];',
+    );
+    expect(result).toContain(
+      '  }) => GassmaHogeUserFindResult<T["select"], T["include"], T["omit"], GO, O>[];',
+    );
+    expect(result).toContain(
+      "  findFirst?: <T extends GassmaHogeUserFindFirstData>(params: {",
+    );
+    expect(result).toContain(
+      '  }) => GassmaHogeUserFindResult<T["select"], T["include"], T["omit"], GO, O> | null;',
+    );
+    expect(result).toContain(
+      "  findFirstOrThrow?: <T extends GassmaHogeUserFindFirstData>(params: {",
+    );
+    expect(result).toContain(
+      "  create?: <T extends GassmaHogeUserCreateData>(params: {",
+    );
+    expect(result).toContain(
+      "  createManyAndReturn?: <T extends GassmaHogeUserCreateManyAndReturnData>(params: {",
+    );
+    expect(result).toContain(
+      "  update?: <T extends GassmaHogeUserUpdateSingleData>(params: {",
+    );
+    expect(result).toContain(
+      "  upsert?: <T extends GassmaHogeUserUpsertSingleData>(params: {",
+    );
+    expect(result).toContain(
+      "  delete?: <T extends GassmaHogeUserDeleteSingleData>(params: {",
+    );
+    expect(result).toContain(
+      "  aggregate?: <T extends GassmaHogeUserAggregateData>(params: {",
+    );
+    expect(result).toContain("  }) => GassmaHogeUserAggregateResult<T>;");
+    expect(result).toContain(
+      "  groupBy?: <T extends GassmaHogeUserGroupByData>(params: {",
+    );
+    expect(result).toContain("  }) => GassmaHogeUserGroupByResult<T>[];");
+  });
+
+  it("should generate non-generic hooks with fixed args and results", () => {
+    expect(result).toContain("  createMany?: (params: {");
+    expect(result).toContain("    args: GassmaHogeUserCreateManyData;");
+    expect(result).toContain(
+      "    query: (args: GassmaHogeUserCreateManyData) => CreateManyReturn;",
+    );
+    expect(result).toContain("  }) => CreateManyReturn;");
+    expect(result).toContain("  updateMany?: (params: {");
+    expect(result).toContain(
+      "    query: (args: GassmaHogeUserUpdateData) => UpdateManyReturn;",
+    );
+    expect(result).toContain("  updateManyAndReturn?: (params: {");
+    expect(result).toContain(
+      "    query: (args: GassmaHogeUserUpdateData) => GassmaHogeUserFindResult<undefined, undefined, undefined, GO, O>[];",
+    );
+    expect(result).toContain("  deleteMany?: (params: {");
+    expect(result).toContain(
+      "    query: (args: GassmaHogeUserDeleteData) => DeleteManyReturn;",
+    );
+    expect(result).toContain("  count?: (params: {");
+    expect(result).toContain(
+      "    query: (args: GassmaHogeUserCountData) => number;",
+    );
+  });
+
+  it("should bind model and operation literals in hook params", () => {
+    expect(result).toContain('    model: "User";');
+    expect(result).toContain('    model: "Post";');
+    expect(result).toContain('    operation: "findMany";');
+    expect(result).toContain('    operation: "groupBy";');
+  });
+
+  it("should generate per-model QueryArgs union and model-level $allOperations", () => {
+    expect(result).toContain("export type GassmaHogeUserQueryArgs =");
+    expect(result).toContain("  | GassmaHogeUserFindFirstData");
+    expect(result).toContain("  | GassmaHogeUserFindManyData");
+    expect(result).toContain("  | GassmaHogeUserGroupByData;");
+    expect(result).toContain("  $allOperations?: (params: {");
+    expect(result).toContain("    operation: GassmaHogeOperationName;");
+    expect(result).toContain("    args: GassmaHogeUserQueryArgs;");
+    expect(result).toContain(
+      "    query: (args: GassmaHogeUserQueryArgs) => unknown;",
+    );
+  });
+
+  it("should generate $allModels hooks with model unions", () => {
+    expect(result).toContain("export type GassmaHogeAllModelsQueryHooks = {");
+    expect(result).toContain("    model: GassmaHogeModelName;");
+    expect(result).toContain(
+      "    args: GassmaHogeUserFindManyData | GassmaHogePostFindManyData;",
+    );
+    expect(result).toContain(
+      "    query: (args: GassmaHogeUserFindManyData | GassmaHogePostFindManyData) => unknown;",
+    );
+    expect(result).toContain("export type GassmaHogeQueryArgs =");
+    expect(result).toContain("  | GassmaHogeUserQueryArgs");
+    expect(result).toContain("  | GassmaHogePostQueryArgs;");
+    expect(result).toContain("    args: GassmaHogeQueryArgs;");
+  });
+
+  it("should remove invalid chars from type names but keep raw sheet keys", () => {
+    const spaced = getGassmaExtension(["My Sheet"], "");
+    expect(spaced).toContain(
+      '  "My Sheet"?: GassmaMySheetQueryHooks<O extends { "My Sheet": infer UO } ? UO extends GassmaMySheetOmit ? UO : {} : {}, O>;',
+    );
+    expect(spaced).toContain('    model: "My Sheet";');
+    expect(spaced).toContain("export type GassmaMySheetQueryArgs =");
+  });
+
+  it("should work with empty schema name", () => {
+    const plain = getGassmaExtension(["User"], "");
+    expect(plain).toContain(
+      "export type GassmaExtension<O extends GassmaGlobalOmitConfig = {}> = {",
+    );
+    expect(plain).toContain("  query?: GassmaQueryExtension<O>;");
+    expect(plain).toContain(
+      "export type GassmaUserQueryHooks<GO extends GassmaUserOmit = {}, O = {}> = {",
+    );
+  });
+});

--- a/src/__test__/types/extends/queryExtends.test-d.ts
+++ b/src/__test__/types/extends/queryExtends.test-d.ts
@@ -1,0 +1,213 @@
+import { expectTypeOf } from "vitest";
+import type {
+  CreateManyReturn,
+  GassmaClient,
+  GassmaModelName,
+  GassmaOperationName,
+  GassmaUserFindManyData,
+  GassmaUserQueryHooks,
+} from "../__generated__/client";
+
+declare const client: GassmaClient;
+declare function runQuery<A>(args: A): never;
+declare const userHooks: Required<GassmaUserQueryHooks>;
+declare const omitClient: GassmaClient<{ User: { email: true } }>;
+declare function acceptUserFindManyData(args: GassmaUserFindManyData): void;
+
+// 基本: モデル別フックが通り、model / operation / args が厳密に型づく
+{
+  const extended = client.$extends({
+    query: {
+      User: {
+        findMany({ model, operation, args, query }) {
+          expectTypeOf(model).toEqualTypeOf<"User">();
+          expectTypeOf(operation).toEqualTypeOf<"findMany">();
+          acceptUserFindManyData(args);
+          return query(args);
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({ where: { id: 1 } });
+  expectTypeOf(rows[0].id).toEqualTypeOf<number>();
+}
+
+// 全 15 操作 + $allOperations のフックを同時に書ける
+{
+  client.$extends({
+    query: {
+      User: {
+        findFirst: ({ args, query }) => query(args),
+        findFirstOrThrow: ({ args, query }) => query(args),
+        findMany: ({ args, query }) => query(args),
+        create: ({ args, query }) => query(args),
+        createMany: ({ args, query }) => query(args),
+        createManyAndReturn: ({ args, query }) => query(args),
+        update: ({ args, query }) => query(args),
+        updateMany: ({ args, query }) => query(args),
+        updateManyAndReturn: ({ args, query }) => query(args),
+        upsert: ({ args, query }) => query(args),
+        delete: ({ args, query }) => query(args),
+        deleteMany: ({ args, query }) => query(args),
+        count: ({ args, query }) => query(args),
+        aggregate: ({ args, query }) => query(args),
+        groupBy: ({ args, query }) => query(args),
+        $allOperations: ({ model, operation, args, query }) => {
+          expectTypeOf(model).toEqualTypeOf<"User">();
+          expectTypeOf(operation).toEqualTypeOf<GassmaOperationName>();
+          return query(args);
+        },
+      },
+    },
+  });
+}
+
+// query(args) の結果型は controller のメソッドと同じ型に相関する
+{
+  const viaController = client.User.findMany({ select: { id: true } });
+  const result = userHooks.findMany({
+    model: "User",
+    operation: "findMany",
+    args: { select: { id: true } },
+    query: runQuery,
+  });
+  expectTypeOf(result).toEqualTypeOf<typeof viaController>();
+}
+{
+  const viaController = client.User.aggregate({ _avg: { age: true } });
+  const result = userHooks.aggregate({
+    model: "User",
+    operation: "aggregate",
+    args: { _avg: { age: true } },
+    query: runQuery,
+  });
+  expectTypeOf(result).toEqualTypeOf<typeof viaController>();
+}
+{
+  const result = userHooks.count({
+    model: "User",
+    operation: "count",
+    args: { where: { isActive: true } },
+    query: runQuery,
+  });
+  expectTypeOf(result).toEqualTypeOf<number>();
+}
+{
+  const result = userHooks.createMany({
+    model: "User",
+    operation: "createMany",
+    args: { data: [{ email: "a@example.com", score: 1 }] },
+    query: runQuery,
+  });
+  expectTypeOf(result).toEqualTypeOf<CreateManyReturn>();
+}
+
+// args を加工して query に渡せる（スプレッド + 上書き）
+{
+  client.$extends({
+    query: {
+      User: {
+        findMany({ args, query }) {
+          return query({ ...args, take: 1 });
+        },
+      },
+    },
+  });
+}
+
+// $allModels: model はモデル名の union、operation は各操作リテラル
+{
+  const extended = client.$extends({
+    query: {
+      $allModels: {
+        findMany({ model, operation, args, query }) {
+          expectTypeOf(model).toEqualTypeOf<GassmaModelName>();
+          expectTypeOf(operation).toEqualTypeOf<"findMany">();
+          return query(args);
+        },
+        $allOperations({ model, operation, args, query }) {
+          expectTypeOf(model).toEqualTypeOf<GassmaModelName>();
+          expectTypeOf(operation).toEqualTypeOf<GassmaOperationName>();
+          return query(args);
+        },
+      },
+    },
+  });
+  const posts = extended.Post.findMany({ where: { published: true } });
+  expectTypeOf(posts[0].title).toEqualTypeOf<string>();
+}
+
+// $extends の戻り値でチェーンできる
+{
+  const extended = client
+    .$extends({
+      query: {
+        User: { findMany: ({ args, query }) => query(args) },
+      },
+    })
+    .$extends({
+      query: {
+        Post: { findFirst: ({ args, query }) => query(args) },
+      },
+    });
+  const post = extended.Post.findFirst({ where: { id: 1 } });
+  expectTypeOf(post).not.toEqualTypeOf<null>();
+}
+
+// globalOmit は $extends 後も維持される
+{
+  const extended = omitClient.$extends({});
+  const rows = extended.User.findMany({});
+  expectTypeOf(rows[0]).not.toHaveProperty("email");
+  expectTypeOf(rows[0]).toHaveProperty("id");
+}
+
+// 存在しない操作名は拒否される
+{
+  client.$extends({
+    query: {
+      User: {
+        // @ts-expect-error findAll という操作は存在しない
+        findAll: () => [],
+      },
+    },
+  });
+}
+
+// 存在しないモデル名は拒否される
+{
+  client.$extends({
+    query: {
+      // @ts-expect-error Nope というモデルは存在しない
+      Nope: {},
+    },
+  });
+}
+
+// 戻り値の型を変える加工は許可されない
+{
+  client.$extends({
+    query: {
+      User: {
+        // @ts-expect-error findMany フックは FindResult の配列以外を返せない
+        findMany() {
+          return "wrong";
+        },
+      },
+    },
+  });
+}
+
+// query には args と無関係な値を渡せない
+{
+  client.$extends({
+    query: {
+      User: {
+        findMany({ query }) {
+          // @ts-expect-error args 由来でないオブジェクトは query に渡せない
+          return query({ where: { unknownColumn: 1 } });
+        },
+      },
+    },
+  });
+}

--- a/src/generate/generator.ts
+++ b/src/generate/generator.ts
@@ -1,3 +1,5 @@
+import type { DefaultsConfig } from "./read/extractDefaults";
+import type { RelationsConfig } from "./read/extractRelations";
 import { getGassmaAggregateBaseReturn } from "./typeGenerate/gassmaAggregateBaseReturn";
 import { getGassmaAggregateData } from "./typeGenerate/gassmaAggregateData";
 import { getGassmaAggregateField } from "./typeGenerate/gassmaAggregateField";
@@ -6,6 +8,7 @@ import { getGassmaAnyUse } from "./typeGenerate/gassmaAnyUse";
 import { getGassmaByField } from "./typeGenerate/gassmaByField";
 import { getGassmaController } from "./typeGenerate/gassmaController";
 import { getGassmaCountData } from "./typeGenerate/gassmaCountData";
+import { getGassmaCountValue } from "./typeGenerate/gassmaCountValue";
 import { getGassmaCreate } from "./typeGenerate/gassmaCreate";
 import { getGassmaCreateMany } from "./typeGenerate/gassmaCreateMany";
 import { getGassmaCreateManyAndReturnData } from "./typeGenerate/gassmaCreateManyAndReturnData";
@@ -13,6 +16,7 @@ import { getGassmaCreateReturn } from "./typeGenerate/gassmaCreateReturn";
 import { getGassmaDefaultFindResult } from "./typeGenerate/gassmaDefaultFindResult";
 import { getGassmaDeleteData } from "./typeGenerate/gassmaDeleteData";
 import { getGassmaDeleteSingleData } from "./typeGenerate/gassmaDeleteSingleData";
+import { getGassmaExtension } from "./typeGenerate/gassmaExtension";
 import { getGassmaFilterCoditions } from "./typeGenerate/gassmaFilterConditions";
 import { getGassmaFindData } from "./typeGenerate/gassmaFindData";
 import { getGassmaFindFirstData } from "./typeGenerate/gassmaFindFirstData";
@@ -24,11 +28,10 @@ import { getGassmaGroupByKeyOfBaseReturn } from "./typeGenerate/gassmaGroupByKey
 import { getGassmaGroupByResult } from "./typeGenerate/gassmaGroupByResult";
 import { getGassmaHavingCore } from "./typeGenerate/gassmaHavingCore";
 import { getGassmaHavingUse } from "./typeGenerate/gassmaHavingUse";
+import { getGassmaInclude } from "./typeGenerate/gassmaInclude";
 import { getGassmaMain } from "./typeGenerate/gassmaMain";
 import { getGassmaManyCount } from "./typeGenerate/gassmaManyCount";
 import { getGassmaOmit } from "./typeGenerate/gassmaOmit";
-import { getGassmaInclude } from "./typeGenerate/gassmaInclude";
-import { getGassmaCountValue } from "./typeGenerate/gassmaCountValue";
 import { getGassmaOrderBy } from "./typeGenerate/gassmaOrderBy";
 import { getGassmaSelect } from "./typeGenerate/gassmaSelect";
 import { getGassmaSheet } from "./typeGenerate/gassmaSheet";
@@ -36,8 +39,6 @@ import { getGassmaUpdateData } from "./typeGenerate/gassmaUpdateData";
 import { getGassmaUpdateSingleData } from "./typeGenerate/gassmaUpdateSingleData";
 import { getGassmaUpsertSingleData } from "./typeGenerate/gassmaUpsertSingleData";
 import { getGassmaWhereUse } from "./typeGenerate/gassmaWhereUse";
-import type { DefaultsConfig } from "./read/extractDefaults";
-import type { RelationsConfig } from "./read/extractRelations";
 
 const generater = (
   dictYaml: Record<string, Record<string, unknown[]>>,
@@ -104,6 +105,7 @@ const generater = (
   result += getGassmaGroupByKeyOfBaseReturn(sheetNames, schema);
   result += getGassmaByField(sheetNames, schema);
   result += getGassmaGroupByResult(sheetNames, schema);
+  result += getGassmaExtension(sheetNames, schema);
 
   return result;
 };

--- a/src/generate/jsGenerate/generateClientDts.ts
+++ b/src/generate/jsGenerate/generateClientDts.ts
@@ -1,7 +1,9 @@
 import type { EnumsConfig } from "../read/extractEnums";
 
 const generateClientDts = (schemaName: string, enums?: EnumsConfig): string => {
-  let result = `export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> extends Gassma${schemaName}Sheet<O> {}
+  let result = `export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> extends Gassma${schemaName}Sheet<O> {
+  $extends(extension: Gassma${schemaName}Extension<O>): GassmaClient<O>;
+}
 export declare class GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> {
   constructor(options?: Gassma${schemaName}ClientOptions<O>);
 }

--- a/src/generate/jsGenerate/generateClientJs.ts
+++ b/src/generate/jsGenerate/generateClientJs.ts
@@ -1,11 +1,11 @@
-import type { RelationsConfig } from "../read/extractRelations";
+import type { AutoincrementConfig } from "../read/extractAutoincrement";
 import type { DefaultsConfig } from "../read/extractDefaults";
-import type { UpdatedAtConfig } from "../read/extractUpdatedAt";
+import type { EnumsConfig } from "../read/extractEnums";
 import type { IgnoreConfig } from "../read/extractIgnore";
 import type { MapConfig } from "../read/extractMap";
-import type { AutoincrementConfig } from "../read/extractAutoincrement";
 import type { MapSheetsConfig } from "../read/extractMapSheets";
-import type { EnumsConfig } from "../read/extractEnums";
+import type { RelationsConfig } from "../read/extractRelations";
+import type { UpdatedAtConfig } from "../read/extractUpdatedAt";
 
 const FUNCTION_MAP: Record<string, string> = {
   now: "() => new Date()",
@@ -172,6 +172,7 @@ ${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}${ignoreSheetsDecl}${mapSh
     const mergedOptions = ${mergeExpr};
     const client = new Gassma.GassmaClient(mergedOptions);
     Object.assign(this, client);
+    this.$extends = (extension) => client.$extends(extension);
   }
 }
 

--- a/src/generate/typeGenerate/gassmaExtension.ts
+++ b/src/generate/typeGenerate/gassmaExtension.ts
@@ -1,0 +1,56 @@
+import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getGassmaAllModelsQueryHooks } from "./gassmaExtension/allModelsQueryHooks";
+import {
+  EXTENSION_OPERATIONS,
+  toUnion,
+} from "./gassmaExtension/extensionOperations";
+import { getOneGassmaExtension } from "./gassmaExtension/oneGassmaExtension";
+
+const getGassmaExtension = (sheetNames: string[], schemaName: string) => {
+  const prefix = `Gassma${schemaName}`;
+
+  const modelNameUnion = toUnion(
+    sheetNames.map((sheetName) => `"${sheetName}"`),
+  );
+  const operationNameUnion = toUnion(
+    EXTENSION_OPERATIONS.map((operation) => `"${operation.name}"`),
+  );
+
+  const perSheet = sheetNames.reduce((pre, sheetName) => {
+    return (
+      pre +
+      getOneGassmaExtension(
+        schemaName,
+        sheetName,
+        getRemovedCantUseVarChar(sheetName),
+      )
+    );
+  }, "");
+
+  const queryExtensionEntries = sheetNames
+    .map((sheetName) => {
+      const self = `${prefix}${getRemovedCantUseVarChar(sheetName)}`;
+      const go = `O extends { "${sheetName}": infer UO } ? UO extends ${self}Omit ? UO : {} : {}`;
+      return `  "${sheetName}"?: ${self}QueryHooks<${go}, O>;`;
+    })
+    .join("\n");
+
+  return `
+export type ${prefix}ModelName =
+${modelNameUnion};
+
+export type ${prefix}OperationName =
+${operationNameUnion};
+${perSheet}${getGassmaAllModelsQueryHooks(sheetNames, schemaName)}
+export type ${prefix}QueryExtension<O extends ${prefix}GlobalOmitConfig = {}> = {
+${queryExtensionEntries}
+  $allModels?: ${prefix}AllModelsQueryHooks;
+};
+
+export type ${prefix}Extension<O extends ${prefix}GlobalOmitConfig = {}> = {
+  query?: ${prefix}QueryExtension<O>;
+};
+`;
+};
+
+export { getGassmaExtension };

--- a/src/generate/typeGenerate/gassmaExtension/allModelsQueryHooks.ts
+++ b/src/generate/typeGenerate/gassmaExtension/allModelsQueryHooks.ts
@@ -1,0 +1,44 @@
+import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+import { EXTENSION_OPERATIONS, toUnion } from "./extensionOperations";
+
+const getGassmaAllModelsQueryHooks = (
+  sheetNames: string[],
+  schemaName: string,
+) => {
+  const prefix = `Gassma${schemaName}`;
+  const selfOf = (sheetName: string) =>
+    `${prefix}${getRemovedCantUseVarChar(sheetName)}`;
+
+  const hooks = EXTENSION_OPERATIONS.map((operation) => {
+    const argsType = sheetNames
+      .map((sheetName) => `${selfOf(sheetName)}${operation.dataSuffix}`)
+      .join(" | ");
+    return `  ${operation.name}?: (params: {
+    model: ${prefix}ModelName;
+    operation: "${operation.name}";
+    args: ${argsType};
+    query: (args: ${argsType}) => unknown;
+  }) => unknown;`;
+  }).join("\n");
+
+  const queryArgsUnion = toUnion(
+    sheetNames.map((sheetName) => `${selfOf(sheetName)}QueryArgs`),
+  );
+
+  return `
+export type ${prefix}QueryArgs =
+${queryArgsUnion};
+
+export type ${prefix}AllModelsQueryHooks = {
+${hooks}
+  $allOperations?: (params: {
+    model: ${prefix}ModelName;
+    operation: ${prefix}OperationName;
+    args: ${prefix}QueryArgs;
+    query: (args: ${prefix}QueryArgs) => unknown;
+  }) => unknown;
+};
+`;
+};
+
+export { getGassmaAllModelsQueryHooks };

--- a/src/generate/typeGenerate/gassmaExtension/extensionOperations.ts
+++ b/src/generate/typeGenerate/gassmaExtension/extensionOperations.ts
@@ -1,0 +1,114 @@
+type ExtensionOperation = {
+  name: string;
+  dataSuffix: string;
+  generic: boolean;
+  result: (self: string) => string;
+};
+
+const genericFindResult = (self: string) =>
+  `${self}FindResult<T["select"], T["include"], T["omit"], GO, O>`;
+
+const EXTENSION_OPERATIONS: ExtensionOperation[] = [
+  {
+    name: "findFirst",
+    dataSuffix: "FindFirstData",
+    generic: true,
+    result: (self) => `${genericFindResult(self)} | null`,
+  },
+  {
+    name: "findFirstOrThrow",
+    dataSuffix: "FindFirstData",
+    generic: true,
+    result: (self) => genericFindResult(self),
+  },
+  {
+    name: "findMany",
+    dataSuffix: "FindManyData",
+    generic: true,
+    result: (self) => `${genericFindResult(self)}[]`,
+  },
+  {
+    name: "create",
+    dataSuffix: "CreateData",
+    generic: true,
+    result: (self) => genericFindResult(self),
+  },
+  {
+    name: "createMany",
+    dataSuffix: "CreateManyData",
+    generic: false,
+    result: () => "CreateManyReturn",
+  },
+  {
+    name: "createManyAndReturn",
+    dataSuffix: "CreateManyAndReturnData",
+    generic: true,
+    result: (self) => `${genericFindResult(self)}[]`,
+  },
+  {
+    name: "update",
+    dataSuffix: "UpdateSingleData",
+    generic: true,
+    result: (self) => `${genericFindResult(self)} | null`,
+  },
+  {
+    name: "updateMany",
+    dataSuffix: "UpdateData",
+    generic: false,
+    result: () => "UpdateManyReturn",
+  },
+  {
+    name: "updateManyAndReturn",
+    dataSuffix: "UpdateData",
+    generic: false,
+    result: (self) =>
+      `${self}FindResult<undefined, undefined, undefined, GO, O>[]`,
+  },
+  {
+    name: "upsert",
+    dataSuffix: "UpsertSingleData",
+    generic: true,
+    result: (self) => genericFindResult(self),
+  },
+  {
+    name: "delete",
+    dataSuffix: "DeleteSingleData",
+    generic: true,
+    result: (self) => `${genericFindResult(self)} | null`,
+  },
+  {
+    name: "deleteMany",
+    dataSuffix: "DeleteData",
+    generic: false,
+    result: () => "DeleteManyReturn",
+  },
+  {
+    name: "count",
+    dataSuffix: "CountData",
+    generic: false,
+    result: () => "number",
+  },
+  {
+    name: "aggregate",
+    dataSuffix: "AggregateData",
+    generic: true,
+    result: (self) => `${self}AggregateResult<T>`,
+  },
+  {
+    name: "groupBy",
+    dataSuffix: "GroupByData",
+    generic: true,
+    result: (self) => `${self}GroupByResult<T>[]`,
+  },
+];
+
+const toUnion = (members: string[]): string => {
+  const unique = members.filter(
+    (member, index) => members.indexOf(member) === index,
+  );
+  if (unique.length === 0) return "  | never";
+  return unique.map((member) => `  | ${member}`).join("\n");
+};
+
+export { EXTENSION_OPERATIONS, toUnion };
+export type { ExtensionOperation };

--- a/src/generate/typeGenerate/gassmaExtension/oneGassmaExtension.ts
+++ b/src/generate/typeGenerate/gassmaExtension/oneGassmaExtension.ts
@@ -1,0 +1,69 @@
+import {
+  EXTENSION_OPERATIONS,
+  type ExtensionOperation,
+  toUnion,
+} from "./extensionOperations";
+
+const getGenericHook = (
+  operation: ExtensionOperation,
+  self: string,
+  sheetName: string,
+) => {
+  const result = operation.result(self);
+  return `  ${operation.name}?: <T extends ${self}${operation.dataSuffix}>(params: {
+    model: "${sheetName}";
+    operation: "${operation.name}";
+    args: T;
+    query: (args: T) => ${result};
+  }) => ${result};`;
+};
+
+const getFixedHook = (
+  operation: ExtensionOperation,
+  self: string,
+  sheetName: string,
+) => {
+  const result = operation.result(self);
+  const data = `${self}${operation.dataSuffix}`;
+  return `  ${operation.name}?: (params: {
+    model: "${sheetName}";
+    operation: "${operation.name}";
+    args: ${data};
+    query: (args: ${data}) => ${result};
+  }) => ${result};`;
+};
+
+const getOneGassmaExtension = (
+  schemaName: string,
+  sheetName: string,
+  cleanSheetName: string,
+) => {
+  const self = `Gassma${schemaName}${cleanSheetName}`;
+
+  const argsUnion = toUnion(
+    EXTENSION_OPERATIONS.map((operation) => `${self}${operation.dataSuffix}`),
+  );
+
+  const hooks = EXTENSION_OPERATIONS.map((operation) =>
+    operation.generic
+      ? getGenericHook(operation, self, sheetName)
+      : getFixedHook(operation, self, sheetName),
+  ).join("\n");
+
+  return `
+export type ${self}QueryArgs =
+${argsUnion};
+
+export type ${self}QueryHooks<GO extends ${self}Omit = {}, O = {}> = {
+${hooks}
+  $allOperations?: (params: {
+    model: "${sheetName}";
+    operation: Gassma${schemaName}OperationName;
+    args: ${self}QueryArgs;
+    query: (args: ${self}QueryArgs) => unknown;
+  }) => unknown;
+};
+`;
+};
+
+export { getOneGassmaExtension };


### PR DESCRIPTION
## 概要

gassma 本体の `$extends({ query })`(gassma #152、マージ済み)に、cli の**型生成とランタイム生成**を追随させます。

## ⚠️ ランタイムのギャップも修正(型だけでは動かない)

生成される client.js は `Object.assign(this, client)` で **own プロパティ(controller群)のみ**コピーしており、core の `$extends` は**prototype メソッド**なのでコピーされていませんでした。つまり型を足すだけでは cli 生成クライアント(=主要な利用経路)のランタイムに `$extends` が存在しません。

→ 生成 client.js の constructor に `this.$extends = (extension) => client.$extends(extension);` を追加し、core クライアントへ委譲します。core の `$extends` は `Object.entries(this)` から controller を収集するため、core インスタンスに対して呼べば正しく動作しチェーンも成立します。

## 型生成

新規生成器 `getGassmaExtension` が per-model / per-operation の拡張型を出力:

- `Gassma{schema}Extension` / `QueryExtension<O>` / `{Model}QueryHooks<GO, O>` / `ModelName` / `OperationName` / `{Model}QueryArgs` / `AllModelsQueryHooks`
- **select/include を持つ10操作(findFirst/findFirstOrThrow/findMany/create/createManyAndReturn/update/upsert/delete/aggregate/groupBy)はジェネリック** `<T extends 〇〇Data>` で型づけし、`query(args)` が args から正しく絞られた結果型を返す(controller のメソッドシグネチャと完全一致)
- **globalOmit(GO/O)伝播も妥協なし**: `QueryExtension<O>` が `gassmaSheet` と同じ `infer UO` パターンで per-model GO を導出し、`$extends` 後もフック結果型・クライアント結果型の両方に globalOmit が効く
- `GassmaClient` interface に `$extends(extension): GassmaClient<O>` を追加(result 拡張は対象外なので戻り型は自クライアント型=チェーン可能)

## 妥協点

- `$allModels` / `$allOperations` は args をシート横断の union で提供しつつ**戻り値は `unknown`**(operation×args×result の相関型は Prisma 同様に見送り、誤検知ゼロを優先)

## テスト

- 型テスト `src/__test__/types/extends/queryExtends.test-d.ts`: 基本フック・model/operation リテラル・args 型・`query(args)` の controller 同型性(findMany select 相関 / aggregate / count / createMany)・全15操作+`$allOperations` 同時定義・args 加工・`$allModels`・チェーン・globalOmit 維持・`@ts-expect-error`(不正操作名/モデル名/戻り型/無関係 args)
- 生成文字列テスト: `getGassmaExtension` / `generateClientDts` / `generateClientJs`(生成 JS を評価して core への委譲・extension 受け渡しを確認する挙動テスト含む)

結果:
- `npm test`: **116 files / 789 tests 全 pass**(baseline 775 → +14)
- `npm run test:types`: **789 tests / Type Errors: no errors**
- `npx tsc --noEmit`: clean
- `npx biome check`: clean

## 後方互換

`$extends` 未使用時の生成物は既存とバイト一致(差分は interface への1メソッド追加 / ランタイム1行のみ)。既存の生成系テスト・スナップショットの変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)