### PR TITLE
feat: generate $extends result types (computed fields)

### DIFF
--- a/src/__test__/generate/generator.test.ts
+++ b/src/__test__/generate/generator.test.ts
@@ -107,4 +107,13 @@ describe("generater", () => {
     expect(result).toContain("export type GassmaPostQueryHooks");
     expect(result).toContain("export type GassmaAllModelsQueryHooks");
   });
+
+  it("should include result extension types", () => {
+    expect(result).toContain("export type GassmaResultScalars<M> =");
+    expect(result).toContain("export type GassmaResultExtension<R_> = {");
+    expect(result).toContain("export type GassmaComputedMap<CMap, R> = {");
+    expect(result).toContain("export type GassmaExtendsFn<O extends");
+    expect(result).toContain("export type GassmaExtendedClient<O extends");
+    expect(result).toContain("  result?: GassmaResultConfig;");
+  });
 });

--- a/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -31,20 +31,16 @@ describe("generateClientDts", () => {
     );
   });
 
-  it("should declare $extends on the client interface", () => {
+  it("should declare generic $extends on the client interface", () => {
     const result = generateClientDts("Hoge");
 
-    expect(result).toContain(
-      "  $extends(extension: GassmaHogeExtension<O>): GassmaClient<O>;",
-    );
+    expect(result).toContain("  $extends: GassmaHogeExtendsFn<O, {}>;");
   });
 
   it("should work with different schema names", () => {
     const result = generateClientDts("Fuga");
 
-    expect(result).toContain(
-      "  $extends(extension: GassmaFugaExtension<O>): GassmaClient<O>;",
-    );
+    expect(result).toContain("  $extends: GassmaFugaExtendsFn<O, {}>;");
     expect(result).toContain("export declare class GassmaClient");
     expect(result).toContain("options?: GassmaFugaClientOptions");
     expect(result).toContain(

--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaController/oneGassmaController";
 
 describe("getOneGassmaController", () => {
   const result = getOneGassmaController("", "User");
+  const res = `Gassma.WithComputed<GassmaUserFindResult<Gassma.StripComputed<T["select"], C>, T["include"], T["omit"], GO, O>, C, T["select"], T["omit"]>`;
 
-  it("should generate controller class declaration with GO and full omit config O", () => {
+  it("should generate controller class declaration with GO, O and computed map C", () => {
     expect(result).toContain(
-      "export declare class GassmaUserController<GO extends GassmaUserOmit = {}, O = {}>",
+      "export declare class GassmaUserController<GO extends GassmaUserOmit = {}, O = {}, C = {}>",
     );
   });
 
@@ -20,9 +21,15 @@ describe("getOneGassmaController", () => {
 
   it("should include CRUD methods", () => {
     expect(result).toContain("createMany(");
-    expect(result).toContain("create<T extends GassmaUserCreateData>");
-    expect(result).toContain("findFirst<T extends GassmaUserFindFirstData>");
-    expect(result).toContain("findMany<T extends GassmaUserFindManyData>");
+    expect(result).toContain(
+      "create<T extends GassmaUserCreateData & Gassma.ComputedArgs<C>>",
+    );
+    expect(result).toContain(
+      "findFirst<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<C>>",
+    );
+    expect(result).toContain(
+      "findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<C>>",
+    );
     expect(result).toContain("updateMany(");
     expect(result).not.toContain("upsertMany(");
     expect(result).toContain("deleteMany(");
@@ -36,47 +43,62 @@ describe("getOneGassmaController", () => {
 
   it("should have generic delete method with model-specific type", () => {
     expect(result).toContain(
-      'delete<T extends GassmaUserDeleteSingleData>(deleteData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O> | null',
+      `delete<T extends GassmaUserDeleteSingleData & Gassma.ComputedArgs<C>>(deleteData: T): ${res} | null`,
     );
   });
 
   it("should have generic upsert method with model-specific type", () => {
     expect(result).toContain(
-      'upsert<T extends GassmaUserUpsertSingleData>(upsertData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O>',
+      `upsert<T extends GassmaUserUpsertSingleData & Gassma.ComputedArgs<C>>(upsertData: T): ${res}`,
     );
   });
 
   it("should include createManyAndReturn method with generic type", () => {
     expect(result).toContain(
-      "createManyAndReturn<T extends GassmaUserCreateManyAndReturnData>",
+      `createManyAndReturn<T extends GassmaUserCreateManyAndReturnData & Gassma.ComputedArgs<C>>(createdData: T): ${res}[]`,
     );
   });
 
-  it("should include updateManyAndReturn method with globalOmit applied", () => {
+  it("should include updateManyAndReturn method with globalOmit and computed applied", () => {
     expect(result).toContain(
-      "updateManyAndReturn(updateData: GassmaUserUpdateData): GassmaUserFindResult<undefined, undefined, undefined, GO, O>[]",
+      "updateManyAndReturn(updateData: GassmaUserUpdateData): Gassma.WithComputed<GassmaUserFindResult<undefined, undefined, undefined, GO, O>, C, undefined, undefined>[]",
     );
   });
 
   it("should use FindFirstData for findFirst", () => {
-    expect(result).toContain("findFirst<T extends GassmaUserFindFirstData>");
+    expect(result).toContain(
+      `findFirst<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<C>>(findData: T): ${res} | null`,
+    );
   });
 
   it("should use FindFirstData for findFirstOrThrow", () => {
     expect(result).toContain(
-      "findFirstOrThrow<T extends GassmaUserFindFirstData>",
+      `findFirstOrThrow<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<C>>(findData: T): ${res}`,
     );
   });
 
   it("should have generic create method with FindResult return", () => {
     expect(result).toContain(
-      'create<T extends GassmaUserCreateData>(createdData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O>',
+      `create<T extends GassmaUserCreateData & Gassma.ComputedArgs<C>>(createdData: T): ${res}`,
     );
   });
 
   it("should have generic update method with model-specific type", () => {
     expect(result).toContain(
-      'update<T extends GassmaUserUpdateSingleData>(updateData: T): GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O> | null',
+      `update<T extends GassmaUserUpdateSingleData & Gassma.ComputedArgs<C>>(updateData: T): ${res} | null`,
+    );
+  });
+
+  it("should not wrap aggregate-family returns with computed fields", () => {
+    expect(result).toContain(
+      "aggregate<T extends GassmaUserAggregateData>(aggregateData: T): GassmaUserAggregateResult<T>",
+    );
+    expect(result).toContain("count(coutData: GassmaUserCountData): number");
+    expect(result).toContain(
+      "groupBy<T extends GassmaUserGroupByData>(groupByData: T): GassmaUserGroupByResult<T>[]",
+    );
+    expect(result).toContain(
+      "createMany(createdData: GassmaUserCreateManyData): CreateManyReturn",
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
@@ -4,11 +4,75 @@ import { getGassmaExtension } from "../../../generate/typeGenerate/gassmaExtensi
 describe("getGassmaExtension", () => {
   const result = getGassmaExtension(["User", "Post"], "Hoge");
 
-  it("should generate Extension type with optional query", () => {
+  it("should generate Extension type with optional query and result", () => {
     expect(result).toContain(
       "export type GassmaHogeExtension<O extends GassmaHogeGlobalOmitConfig = {}> = {",
     );
     expect(result).toContain("  query?: GassmaHogeQueryExtension<O>;");
+    expect(result).toContain("  result?: GassmaHogeResultConfig;");
+  });
+
+  it("should generate ResultScalars conditional lookup per model", () => {
+    expect(result).toContain("export type GassmaHogeResultScalars<M> =");
+    expect(result).toContain(
+      '  M extends "User" ? GassmaHogeUserDefaultFindResult :',
+    );
+    expect(result).toContain(
+      '  M extends "Post" ? GassmaHogePostDefaultFindResult :',
+    );
+    expect(result).toContain("  { [field: string]: unknown };");
+  });
+
+  it("should generate ResultShape and needs-correlated ResultExtension", () => {
+    expect(result).toContain("export type GassmaHogeResultShape = {");
+    expect(result).toContain(
+      '  [M in GassmaHogeModelName | "$allModels"]?: unknown;',
+    );
+    expect(result).toContain("export type GassmaHogeResultExtension<R_> = {");
+    expect(result).toContain(
+      "    [F in keyof R_[M]]?: Gassma.ResultField<GassmaHogeResultScalars<M>, R_[M][F]>;",
+    );
+  });
+
+  it("should generate loose ResultConfig for annotations", () => {
+    expect(result).toContain("export type GassmaHogeResultConfig = {");
+    expect(result).toContain('  [M in GassmaHogeModelName | "$allModels"]?: {');
+    expect(result).toContain("      needs?: { [key: string]: boolean };");
+    expect(result).toContain("      compute: (record: any) => unknown;");
+  });
+
+  it("should generate ComputedMap merging per model", () => {
+    expect(result).toContain("export type GassmaHogeComputedMap<CMap, R> = {");
+    expect(result).toContain(
+      '  "User": Gassma.MergeShape<Gassma.At<CMap, "User">, Gassma.ComputedOf<R, "User">>;',
+    );
+    expect(result).toContain(
+      '  "Post": Gassma.MergeShape<Gassma.At<CMap, "Post">, Gassma.ComputedOf<R, "Post">>;',
+    );
+  });
+
+  it("should generate generic ExtendsFn capturing result literal", () => {
+    expect(result).toContain(
+      "export type GassmaHogeExtendsFn<O extends GassmaHogeGlobalOmitConfig, CMap> = <R_ extends GassmaHogeResultShape = {}, R extends GassmaHogeResultConfig = {}>(extension: {",
+    );
+    expect(result).toContain("  query?: GassmaHogeQueryExtension<O>;");
+    expect(result).toContain("  result?: GassmaHogeResultExtension<R_> & R;");
+    expect(result).toContain(
+      "}) => GassmaHogeExtendedClient<O, GassmaHogeComputedMap<CMap, R>>;",
+    );
+  });
+
+  it("should generate ExtendedClient with computed controllers and chainable $extends", () => {
+    expect(result).toContain(
+      "export type GassmaHogeExtendedClient<O extends GassmaHogeGlobalOmitConfig = {}, CMap = {}> = {",
+    );
+    expect(result).toContain(
+      '  "User": GassmaHogeUserController<O extends { "User": infer UO } ? UO extends GassmaHogeUserOmit ? UO : {} : {}, O, Gassma.At<CMap, "User">>;',
+    );
+    expect(result).toContain(
+      '  "Post": GassmaHogePostController<O extends { "Post": infer UO } ? UO extends GassmaHogePostOmit ? UO : {} : {}, O, Gassma.At<CMap, "Post">>;',
+    );
+    expect(result).toContain("  $extends: GassmaHogeExtendsFn<O, CMap>;");
   });
 
   it("should generate QueryExtension with per-model hooks and $allModels", () => {
@@ -165,6 +229,12 @@ describe("getGassmaExtension", () => {
     );
     expect(spaced).toContain('    model: "My Sheet";');
     expect(spaced).toContain("export type GassmaMySheetQueryArgs =");
+    expect(spaced).toContain(
+      '  M extends "My Sheet" ? GassmaMySheetDefaultFindResult :',
+    );
+    expect(spaced).toContain(
+      '  "My Sheet": GassmaMySheetController<O extends { "My Sheet": infer UO } ? UO extends GassmaMySheetOmit ? UO : {} : {}, O, Gassma.At<CMap, "My Sheet">>;',
+    );
   });
 
   it("should work with empty schema name", () => {

--- a/src/__test__/types/extends/resultExtends.test-d.ts
+++ b/src/__test__/types/extends/resultExtends.test-d.ts
@@ -1,0 +1,342 @@
+import { expectTypeOf } from "vitest";
+import { GassmaClient } from "../__generated__/client";
+
+const client = new GassmaClient();
+const omitClient = new GassmaClient({ omit: { User: { email: true } } });
+
+// 基本: 算出フィールドがトップレベル結果に付き、既存フィールドも残る
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({});
+  expectTypeOf(rows[0].fullName).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].id).toEqualTypeOf<number>();
+  expectTypeOf(rows[0].email).toEqualTypeOf<string>();
+}
+
+// compute 引数は needs で宣言したフィールドだけを持つ
+{
+  client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true, age: true },
+          compute: (user) => {
+            expectTypeOf(user.email).toEqualTypeOf<string>();
+            expectTypeOf(user.age).toEqualTypeOf<number | null>();
+            // @ts-expect-error needs に無い name は参照できない
+            return user.name;
+          },
+        },
+      },
+    },
+  });
+}
+
+// needs にスカラー以外のキーは書けない
+{
+  client.$extends({
+    result: {
+      User: {
+        bad: {
+          // @ts-expect-error nope というスカラーは存在しない
+          needs: { nope: true },
+          compute: () => 1,
+        },
+      },
+    },
+  });
+}
+
+// 存在しないモデル名は拒否される
+{
+  client.$extends({
+    result: {
+      // @ts-expect-error Nope というモデルは存在しない
+      Nope: {
+        x: { compute: () => 1 },
+      },
+    },
+  });
+}
+
+// $allModels は全モデルの結果に付く
+{
+  const extended = client.$extends({
+    result: {
+      $allModels: {
+        tag: { compute: () => "t" },
+      },
+    },
+  });
+  expectTypeOf(extended.User.findMany({})[0].tag).toEqualTypeOf<string>();
+  expectTypeOf(extended.Post.findMany({})[0].tag).toEqualTypeOf<string>();
+}
+
+// 同名はモデル固有が $allModels に勝つ
+{
+  const extended = client.$extends({
+    result: {
+      $allModels: {
+        tag: { compute: () => "t" },
+      },
+      User: {
+        tag: { compute: () => 123 },
+      },
+    },
+  });
+  expectTypeOf(extended.User.findMany({})[0].tag).toEqualTypeOf<number>();
+  expectTypeOf(extended.Post.findMany({})[0].tag).toEqualTypeOf<string>();
+}
+
+// select: 選択した算出フィールドだけが結果に出る
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  const withSel = extended.User.findMany({
+    select: { id: true, fullName: true },
+  });
+  expectTypeOf(withSel[0].fullName).toEqualTypeOf<string>();
+  expectTypeOf(withSel[0].id).toEqualTypeOf<number>();
+  expectTypeOf(withSel[0]).not.toHaveProperty("email");
+
+  const noSel = extended.User.findMany({ select: { id: true } });
+  expectTypeOf(noSel[0]).not.toHaveProperty("fullName");
+
+  const onlyComputed = extended.User.findMany({ select: { fullName: true } });
+  expectTypeOf(onlyComputed[0].fullName).toEqualTypeOf<string>();
+  expectTypeOf(onlyComputed[0]).not.toHaveProperty("id");
+}
+
+// omit: 算出フィールドも needs 対象の実カラムも除去できる
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  const dropComputed = extended.User.findMany({ omit: { fullName: true } });
+  expectTypeOf(dropComputed[0]).not.toHaveProperty("fullName");
+  expectTypeOf(dropComputed[0].id).toEqualTypeOf<number>();
+
+  const dropNeeded = extended.User.findMany({ omit: { email: true } });
+  expectTypeOf(dropNeeded[0].fullName).toEqualTypeOf<string>();
+  expectTypeOf(dropNeeded[0]).not.toHaveProperty("email");
+}
+
+// 既存フィールドの上書き（select 経由でも算出型が勝つ）
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        name: {
+          needs: { id: true },
+          compute: (user) => user.id,
+        },
+      },
+    },
+  });
+  expectTypeOf(extended.User.findMany({})[0].name).toEqualTypeOf<number>();
+  const selected = extended.User.findMany({
+    select: { name: true, email: true },
+  });
+  expectTypeOf(selected[0].name).toEqualTypeOf<number>();
+  expectTypeOf(selected[0].email).toEqualTypeOf<string>();
+}
+
+// レコードを返す全操作に算出フィールドが付く
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  expectTypeOf(
+    extended.User.create({ data: { email: "a@example.com", score: 1 } })
+      .fullName,
+  ).toEqualTypeOf<string>();
+  expectTypeOf(
+    extended.User.findFirstOrThrow({ where: { id: 1 } }).fullName,
+  ).toEqualTypeOf<string>();
+  const found = extended.User.findFirst({ where: { id: 1 } });
+  if (found) expectTypeOf(found.fullName).toEqualTypeOf<string>();
+  const updated = extended.User.update({
+    where: { id: 1 },
+    data: { name: "a" },
+  });
+  if (updated) expectTypeOf(updated.fullName).toEqualTypeOf<string>();
+  expectTypeOf(
+    extended.User.upsert({
+      where: { id: 1 },
+      update: {},
+      create: { email: "a@example.com", score: 1 },
+    }).fullName,
+  ).toEqualTypeOf<string>();
+  const deleted = extended.User.delete({ where: { id: 1 } });
+  if (deleted) expectTypeOf(deleted.fullName).toEqualTypeOf<string>();
+  expectTypeOf(
+    extended.User.createManyAndReturn({
+      data: [{ email: "a@example.com", score: 1 }],
+    })[0].fullName,
+  ).toEqualTypeOf<string>();
+  expectTypeOf(
+    extended.User.updateManyAndReturn({ data: { name: "a" } })[0].fullName,
+  ).toEqualTypeOf<string>();
+}
+
+// レコードを返さない操作は非対象のまま
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  expectTypeOf(extended.User.count({})).toEqualTypeOf<number>();
+  expectTypeOf(
+    extended.User.createMany({ data: [{ email: "a@example.com", score: 1 }] })
+      .count,
+  ).toEqualTypeOf<number>();
+  expectTypeOf(
+    extended.User.updateMany({ data: { name: "a" } }).count,
+  ).toEqualTypeOf<number>();
+  expectTypeOf(extended.User.deleteMany({}).count).toEqualTypeOf<number>();
+}
+
+// 算出フィールドはネストしたリレーション結果には出ない（Tier1）
+{
+  const extended = client.$extends({
+    result: {
+      $allModels: {
+        tag: { compute: () => "t" },
+      },
+    },
+  });
+  const rows = extended.User.findMany({ include: { posts: true } });
+  expectTypeOf(rows[0].tag).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0]).not.toHaveProperty("tag");
+  expectTypeOf(rows[0].posts[0].title).toEqualTypeOf<string>();
+}
+
+// query と result を同一 extension で併用できる
+{
+  const extended = client.$extends({
+    query: {
+      User: {
+        findMany: ({ args, query }) => query(args),
+      },
+    },
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  expectTypeOf(extended.User.findMany({})[0].fullName).toEqualTypeOf<string>();
+}
+
+// チェーン: 算出フィールドが累積し、同名は後勝ち
+{
+  const extended = client
+    .$extends({
+      result: {
+        User: {
+          fullName: {
+            needs: { email: true },
+            compute: (user) => `x${user.email}`,
+          },
+        },
+      },
+    })
+    .$extends({
+      result: {
+        Post: {
+          headline: {
+            needs: { title: true },
+            compute: (post) => `# ${post.title}`,
+          },
+        },
+      },
+    });
+  expectTypeOf(extended.User.findMany({})[0].fullName).toEqualTypeOf<string>();
+  expectTypeOf(extended.Post.findMany({})[0].headline).toEqualTypeOf<string>();
+
+  const overridden = client
+    .$extends({ result: { User: { tag: { compute: () => "s" } } } })
+    .$extends({ result: { User: { tag: { compute: () => 2 } } } });
+  expectTypeOf(overridden.User.findMany({})[0].tag).toEqualTypeOf<number>();
+}
+
+// globalOmit は result 拡張後も維持される
+{
+  const extended = omitClient.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({});
+  expectTypeOf(rows[0].fullName).toEqualTypeOf<string>();
+  expectTypeOf(rows[0]).not.toHaveProperty("email");
+  expectTypeOf(rows[0].id).toEqualTypeOf<number>();
+}
+
+// 拡張なしクライアントは従来どおり
+{
+  const rows = client.User.findMany({ where: { id: 1 } });
+  expectTypeOf(rows[0].id).toEqualTypeOf<number>();
+  expectTypeOf(rows[0]).not.toHaveProperty("fullName");
+  // @ts-expect-error 素のクライアントの select に算出フィールドは書けない
+  client.User.findMany({ select: { fullName: true } });
+}
+
+// query-only 拡張と空拡張は従来型のまま
+{
+  const queryOnly = client.$extends({
+    query: {
+      User: { findMany: ({ args, query }) => query(args) },
+    },
+  });
+  expectTypeOf(queryOnly.User.findMany({})[0].id).toEqualTypeOf<number>();
+  expectTypeOf(queryOnly.User.findMany({})[0]).not.toHaveProperty("fullName");
+
+  const empty = client.$extends({});
+  expectTypeOf(empty.User.findMany({})[0].id).toEqualTypeOf<number>();
+}

--- a/src/generate/jsGenerate/generateClientDts.ts
+++ b/src/generate/jsGenerate/generateClientDts.ts
@@ -2,7 +2,7 @@ import type { EnumsConfig } from "../read/extractEnums";
 
 const generateClientDts = (schemaName: string, enums?: EnumsConfig): string => {
   let result = `export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> extends Gassma${schemaName}Sheet<O> {
-  $extends(extension: Gassma${schemaName}Extension<O>): GassmaClient<O>;
+  $extends: Gassma${schemaName}ExtendsFn<O, {}>;
 }
 export declare class GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> {
   constructor(options?: Gassma${schemaName}ClientOptions<O>);

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -43,6 +43,33 @@ const getGassmaCommonTypes = (strict?: boolean) => {
   type FalseKeys<T> = { [K in keyof T]: T[K] extends false ? K : never }[keyof T];
   type ResolveOmitKeys<GO, QO> = Exclude<TrueKeys<GO>, FalseKeys<QO>> | TrueKeys<QO>;
 
+  type At<X, K> = K extends keyof X ? X[K] : {};
+  type MergeShape<A, B> = Omit<A, keyof B> & B;
+  type ComputedReturns<Fields> = {
+    [F in keyof Fields]: Fields[F] extends { compute: (...args: never[]) => infer V } ? V : never;
+  };
+  type ComputedOf<R, M> = MergeShape<ComputedReturns<At<R, "$allModels">>, ComputedReturns<At<R, M>>>;
+  type ResultField<Scalars, S> = {
+    needs?: { [K in keyof S]: K extends keyof Scalars ? S[K] : never } & { [K in keyof Scalars]?: boolean };
+    compute(record: { [K in keyof S as S[K] extends true ? K & keyof Scalars : never]: Scalars[K & keyof Scalars] }): unknown;
+  };
+  type ComputedArgs<C> = [keyof C] extends [never] ? {} : {
+    select?: { [K in keyof C]?: true };
+    omit?: { [K in keyof C]?: true | false };
+  };
+  type SelectedComputed<C, S> = {
+    [K in keyof C as K extends keyof S ? (S[K] extends true ? K : never) : never]: C[K];
+  };
+  type ActiveComputed<C, QO> = { [K in keyof C as K extends TrueKeys<QO> ? never : K]: C[K] };
+  type StripComputed<S, C> = [keyof C] extends [never]
+    ? S
+    : S extends object ? { [K in Exclude<keyof S, keyof C>]: S[K] } : S;
+  type WithComputed<Base, C, S, QO> = [keyof C] extends [never]
+    ? Base
+    : S extends object
+      ? Omit<Base, keyof SelectedComputed<C, S>> & SelectedComputed<C, S>
+      : Omit<Base, keyof ActiveComputed<C, QO>> & ActiveComputed<C, QO>;
+
   type ExactKeys<T, Shape> = Shape & { [K in Exclude<keyof T, keyof Shape>]?: never };
   type StrictGlobalOmit<O, Config> = Config & {
     [K in keyof O]?: K extends keyof Config

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -1,7 +1,13 @@
 const getOneGassmaController = (schemaName: string, sheetName: string) => {
-  const fr = `Gassma${schemaName}${sheetName}FindResult`;
+  const self = `Gassma${schemaName}${sheetName}`;
+  const fr = `${self}FindResult`;
+  const base = `${fr}<Gassma.StripComputed<T["select"], C>, T["include"], T["omit"], GO, O>`;
+  const res = `Gassma.WithComputed<${base}, C, T["select"], T["omit"]>`;
+  const arg = (dataSuffix: string) =>
+    `T extends ${self}${dataSuffix} & Gassma.ComputedArgs<C>`;
+
   return `
-export declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma${schemaName}${sheetName}Omit = {}, O = {}> {
+export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, C = {}> {
   constructor(sheetName: string, id?: string);
 
   readonly fields: Record<string, Gassma.FieldRef>;
@@ -10,21 +16,21 @@ export declare class Gassma${schemaName}${sheetName}Controller<GO extends Gassma
     startColumnNumber: number,
     endColumnNumber: number
   ): void;
-  createMany(createdData: Gassma${schemaName}${sheetName}CreateManyData): CreateManyReturn;
-  createManyAndReturn<T extends Gassma${schemaName}${sheetName}CreateManyAndReturnData>(createdData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>[];
-  create<T extends Gassma${schemaName}${sheetName}CreateData>(createdData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>;
-  findFirst<T extends Gassma${schemaName}${sheetName}FindFirstData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O> | null;
-  findFirstOrThrow<T extends Gassma${schemaName}${sheetName}FindFirstData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>;
-  findMany<T extends Gassma${schemaName}${sheetName}FindManyData>(findData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>[];
-  update<T extends Gassma${schemaName}${sheetName}UpdateSingleData>(updateData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O> | null;
-  updateMany(updateData: Gassma${schemaName}${sheetName}UpdateData): UpdateManyReturn;
-  updateManyAndReturn(updateData: Gassma${schemaName}${sheetName}UpdateData): ${fr}<undefined, undefined, undefined, GO, O>[];
-  upsert<T extends Gassma${schemaName}${sheetName}UpsertSingleData>(upsertData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O>;
-  delete<T extends Gassma${schemaName}${sheetName}DeleteSingleData>(deleteData: T): ${fr}<T["select"], T["include"], T["omit"], GO, O> | null;
-  deleteMany(deleteData: Gassma${schemaName}${sheetName}DeleteData): DeleteManyReturn;
-  aggregate<T extends Gassma${schemaName}${sheetName}AggregateData>(aggregateData: T): Gassma${schemaName}${sheetName}AggregateResult<T>;
-  count(coutData: Gassma${schemaName}${sheetName}CountData): number;
-  groupBy<T extends Gassma${schemaName}${sheetName}GroupByData>(groupByData: T): Gassma${schemaName}${sheetName}GroupByResult<T>[];
+  createMany(createdData: ${self}CreateManyData): CreateManyReturn;
+  createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: T): ${res}[];
+  create<${arg("CreateData")}>(createdData: T): ${res};
+  findFirst<${arg("FindFirstData")}>(findData: T): ${res} | null;
+  findFirstOrThrow<${arg("FindFirstData")}>(findData: T): ${res};
+  findMany<${arg("FindManyData")}>(findData: T): ${res}[];
+  update<${arg("UpdateSingleData")}>(updateData: T): ${res} | null;
+  updateMany(updateData: ${self}UpdateData): UpdateManyReturn;
+  updateManyAndReturn(updateData: ${self}UpdateData): Gassma.WithComputed<${fr}<undefined, undefined, undefined, GO, O>, C, undefined, undefined>[];
+  upsert<${arg("UpsertSingleData")}>(upsertData: T): ${res};
+  delete<${arg("DeleteSingleData")}>(deleteData: T): ${res} | null;
+  deleteMany(deleteData: ${self}DeleteData): DeleteManyReturn;
+  aggregate<T extends ${self}AggregateData>(aggregateData: T): ${self}AggregateResult<T>;
+  count(coutData: ${self}CountData): number;
+  groupBy<T extends ${self}GroupByData>(groupByData: T): ${self}GroupByResult<T>[];
 }
 `;
 };

--- a/src/generate/typeGenerate/gassmaExtension.ts
+++ b/src/generate/typeGenerate/gassmaExtension.ts
@@ -5,6 +5,7 @@ import {
   toUnion,
 } from "./gassmaExtension/extensionOperations";
 import { getOneGassmaExtension } from "./gassmaExtension/oneGassmaExtension";
+import { getGassmaResultExtension } from "./gassmaExtension/resultExtension";
 
 const getGassmaExtension = (sheetNames: string[], schemaName: string) => {
   const prefix = `Gassma${schemaName}`;
@@ -46,9 +47,10 @@ export type ${prefix}QueryExtension<O extends ${prefix}GlobalOmitConfig = {}> = 
 ${queryExtensionEntries}
   $allModels?: ${prefix}AllModelsQueryHooks;
 };
-
+${getGassmaResultExtension(sheetNames, schemaName)}
 export type ${prefix}Extension<O extends ${prefix}GlobalOmitConfig = {}> = {
   query?: ${prefix}QueryExtension<O>;
+  result?: ${prefix}ResultConfig;
 };
 `;
 };

--- a/src/generate/typeGenerate/gassmaExtension/resultExtension.ts
+++ b/src/generate/typeGenerate/gassmaExtension/resultExtension.ts
@@ -1,0 +1,73 @@
+import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+
+const getGassmaResultExtension = (sheetNames: string[], schemaName: string) => {
+  const prefix = `Gassma${schemaName}`;
+  const selfOf = (sheetName: string) =>
+    `${prefix}${getRemovedCantUseVarChar(sheetName)}`;
+
+  const scalarsBranches = sheetNames
+    .map(
+      (sheetName) =>
+        `  M extends "${sheetName}" ? ${selfOf(sheetName)}DefaultFindResult :`,
+    )
+    .join("\n");
+  const scalarsBody =
+    sheetNames.length > 0
+      ? `${scalarsBranches}\n  { [field: string]: unknown };`
+      : "  { [field: string]: unknown };";
+
+  const computedMapEntries = sheetNames
+    .map(
+      (sheetName) =>
+        `  "${sheetName}": Gassma.MergeShape<Gassma.At<CMap, "${sheetName}">, Gassma.ComputedOf<R, "${sheetName}">>;`,
+    )
+    .join("\n");
+
+  const extendedClientEntries = sheetNames
+    .map((sheetName) => {
+      const self = selfOf(sheetName);
+      const go = `O extends { "${sheetName}": infer UO } ? UO extends ${self}Omit ? UO : {} : {}`;
+      return `  "${sheetName}": ${self}Controller<${go}, O, Gassma.At<CMap, "${sheetName}">>;`;
+    })
+    .join("\n");
+
+  return `
+export type ${prefix}ResultScalars<M> =
+${scalarsBody}
+
+export type ${prefix}ResultShape = {
+  [M in ${prefix}ModelName | "$allModels"]?: unknown;
+};
+
+export type ${prefix}ResultExtension<R_> = {
+  [M in keyof R_]: {
+    [F in keyof R_[M]]?: Gassma.ResultField<${prefix}ResultScalars<M>, R_[M][F]>;
+  };
+};
+
+export type ${prefix}ResultConfig = {
+  [M in ${prefix}ModelName | "$allModels"]?: {
+    [field: string]: {
+      needs?: { [key: string]: boolean };
+      compute: (record: any) => unknown;
+    };
+  };
+};
+
+export type ${prefix}ComputedMap<CMap, R> = {
+${computedMapEntries}
+};
+
+export type ${prefix}ExtendsFn<O extends ${prefix}GlobalOmitConfig, CMap> = <R_ extends ${prefix}ResultShape = {}, R extends ${prefix}ResultConfig = {}>(extension: {
+  query?: ${prefix}QueryExtension<O>;
+  result?: ${prefix}ResultExtension<R_> & R;
+}) => ${prefix}ExtendedClient<O, ${prefix}ComputedMap<CMap, R>>;
+
+export type ${prefix}ExtendedClient<O extends ${prefix}GlobalOmitConfig = {}, CMap = {}> = {
+${extendedClientEntries}
+  $extends: ${prefix}ExtendsFn<O, CMap>;
+};
+`;
+};
+
+export { getGassmaResultExtension };


### PR DESCRIPTION
## 概要

gassma 本体の `$extends({ result })`(computed fields, Tier1, gassma #155)に cli の**型生成**を追随させます。Prisma 最難関の型パズルで、**Prisma 本家の二重推論パターン**を踏襲しました。

## `$extends` のジェネリック化

現状の `$extends(ext): GassmaClient<O>`(query 専用・戻り型固定)を、拡張リテラルを捕捉して結果型に算出フィールドを反映するジェネリックに変更:

```ts
$extends: GassmaExtendsFn<O, CMap>
// = <R_ extends ResultShape = {}, R extends ResultConfig = {}>(extension: {
//     query?: QueryExtension<O>;
//     result?: ResultExtension<R_> & R;
//   }) => ExtendedClient<O, ComputedMap<CMap, R>>
```

- `R_` = **reverse-mapped 推論**で needs 構造を捕捉 → compute の record 引数を文脈型付け
- `R` = **naked capture** で literal 全体(compute 戻り型込み)を捕捉、不正モデル名を拒否
- 返る拡張クライアントは各 controller に computed マップ `C` を割当て、自身の `$extends` で `CMap` をマージしチェーン可能

## controller の変更

`Gassma{schema}{Model}Controller<GO, O, C = {}>`(第3パラメータ C 追加・デフォルト `{}` で後方互換)。レコードを返すメソッドは:

```ts
findMany<T extends ...FindManyData & Gassma.ComputedArgs<C>>(findData: T):
  Gassma.WithComputed<...FindResult<Gassma.StripComputed<T["select"], C>, ...>, C, T["select"], T["omit"]>[];
```

- `ComputedArgs<C>`: 拡張後の select/omit に算出フィールドキーを受理
- `StripComputed`: base FindResult へ渡す select から算出キーを剥がす(ランタイムの adjusted select と同型)
- `WithComputed`: select 指定時=選択した算出フィールドのみ交差／未指定時=全算出フィールド交差(omit 除去)。同名は算出型が上書き
- count/aggregate/groupBy と count を返す write 系は不変

## 型ヘルパー(Gassma namespace)

- `ResultField<Scalars, S>`: needs はスカラーのみ(非スカラーキーを never 化)、compute 引数を needs=true のスカラーで pick
- `ComputedOf<R, M>`: `$allModels` と モデル固有をマージ(**モデル固有優先**)。チェーンは `ComputedMap` で後勝ち(core の resolveResultFields と同順)

## 達成した厳密度

`.Model.findMany()` 結果に算出フィールドが正しい戻り型で出る／compute 引数が needs で型付く／`$allModels` が全モデルに出る／select・omit 連携／既存フィールド上書き／不正モデル名・不正 needs キー拒否／query 併用／チェーン後勝ち／globalOmit 維持。**変異テスト3種(優先順位入替・needs 相関破壊・select 無視)で型テストが Red になることを確認済み**。

## 妥協点

- `select: { <算出>: false }` は型上「未選択」(Prisma 型定義と同じ扱い。ランタイム hasOwnKey は値を見ない)
- select+omit 同時は型上 XOR(ランタイムは既存の衝突エラー・到達不能)
- `$allModels` の compute record 値型は `unknown`(モデル横断のため)
- 手書き `GassmaExtension<O>` 経由だと算出型は index signature に退化(literal 直渡し前提。Prisma 同様)

## ランタイム

**変更不要**。生成 client.js の `this.$extends = (e) => client.$extends(e)`(#115)が extension を core へ委譲、core は #155 で result 対応済み。

## テスト

- 型テスト `src/__test__/types/extends/resultExtends.test-d.ts`: 基本付与/compute 引数型/needs 外エラー/不正モデル名/`$allModels`/上書き優先/select 3態/omit 2態/全9操作付与/非対象6操作/ネスト非伝播/query 併用/チェーン累積・後勝ち/globalOmit 維持/後方互換(素・query-only・空拡張)。Red 先行 + 変異3種で Red 検知確認
- 生成文字列テスト: controller(C 付き署名)・extension(result 型)・clientDts・generator 統合

結果:
- `npm test`: **116 files / 797 tests 全 pass**
- `npm run test:types`: **797 tests / Type Errors 0**
- `npx tsc --noEmit`: clean / `biome check`: clean / `npm run build`(tsup): 成功

## 後方互換

`C = {}` デフォルトで全ヘルパーが base 型に解決。`$extends` 未使用 / query-only の生成物は既存とバイト一致(差分は `$extends` 1行 + 各 controller の C パラメータ/返却ラッパーのみ)。既存の `queryExtends.test-d.ts` の相関テストも無修正で pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)