### PR TITLE
fix: generated changeSettings accepts column letters (number | string)

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -15,8 +15,14 @@ describe("getOneGassmaController", () => {
     expect(result).toContain("constructor(sheetName: string, id?: string)");
   });
 
-  it("should include changeSettings method", () => {
-    expect(result).toContain("changeSettings(");
+  it("should include changeSettings method accepting column letters", () => {
+    expect(result).toContain(
+      `changeSettings(
+    startRowNumber: number,
+    startColumnValue: number | string,
+    endColumnValue: number | string
+  ): void;`,
+    );
   });
 
   it("should include CRUD methods", () => {

--- a/src/__test__/types/config/changeSettings.test-d.ts
+++ b/src/__test__/types/config/changeSettings.test-d.ts
@@ -1,0 +1,22 @@
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// 列指定は列番号でも列文字でも指定できる
+{
+  client.User.changeSettings(2, "BA", "BC");
+  client.User.changeSettings(2, 1, 3);
+  client.User.changeSettings(2, "A", 5);
+}
+
+// 列指定に boolean は指定できない
+{
+  // @ts-expect-error 列指定に boolean は指定できない
+  client.User.changeSettings(2, true, 3);
+}
+
+// startRowNumber は number のみ
+{
+  // @ts-expect-error startRowNumber は number のみ
+  client.User.changeSettings("2", 1, 3);
+}

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -13,8 +13,8 @@ export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, C = 
   readonly fields: Record<string, Gassma.FieldRef>;
   changeSettings(
     startRowNumber: number,
-    startColumnNumber: number,
-    endColumnNumber: number
+    startColumnValue: number | string,
+    endColumnValue: number | string
   ): void;
   createMany(createdData: ${self}CreateManyData): CreateManyReturn;
   createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: T): ${res}[];


### PR DESCRIPTION
## 概要

core の changeSettings 公開型修正(akahoshi1421/gassma#157)への追随です。生成 GassmaClient の changeSettings シグネチャの第2・第3引数を `number | string` に広げ、引数名も実装と一致する `startColumnValue` / `endColumnValue` にします("BA" 等の列文字指定。base-26 変換は core #146 で修正済み)。

## テスト

- 単体テスト: changeSettings の完全シグネチャ一致ピンに強化
- 新規 test-d: "BA" / "A" / 数値の正例、boolean と string 行番号の負例
- **逆検証実測**: 修正前生成器で単体テスト+test-d の "BA"/"A" 正例が fail
- 797 テスト / test:types 型エラー0 / tsc / lint / format 全 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX