### PR TITLE
feat: allow computed-field dependencies in result needs (Prisma parity)

### DIFF
--- a/src/__test__/generate/generator.test.ts
+++ b/src/__test__/generate/generator.test.ts
@@ -110,7 +110,9 @@ describe("generater", () => {
 
   it("should include result extension types", () => {
     expect(result).toContain("export type GassmaResultScalars<M> =");
-    expect(result).toContain("export type GassmaResultExtension<R_> = {");
+    expect(result).toContain(
+      "export type GassmaResultExtension<R_, RC_, CMap> = {",
+    );
     expect(result).toContain("export type GassmaComputedMap<CMap, R> = {");
     expect(result).toContain("export type GassmaExtendsFn<O extends");
     expect(result).toContain("export type GassmaExtendedClient<O extends");

--- a/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
@@ -28,9 +28,32 @@ describe("getGassmaExtension", () => {
     expect(result).toContain(
       '  [M in GassmaHogeModelName | "$allModels"]?: unknown;',
     );
-    expect(result).toContain("export type GassmaHogeResultExtension<R_> = {");
     expect(result).toContain(
-      "    [F in keyof R_[M]]?: Gassma.ResultField<GassmaHogeResultScalars<M>, R_[M][F]>;",
+      "export type GassmaHogeResultExtension<R_, RC_, CMap> = {",
+    );
+    expect(result).toContain(
+      "    [F in keyof R_[M]]?: Gassma.ResultField<GassmaHogeResultScalars<M>, R_[M][F], GassmaHogeResultComputedKeys<R_, CMap, M>, GassmaHogeResultComputedTypes<RC_, CMap, M>>;",
+    );
+  });
+
+  it("should generate computed-needs helper types", () => {
+    expect(result).toContain(
+      "export type GassmaHogeResultComputeSlots<RC_> = {",
+    );
+    expect(result).toContain(
+      "  [M in keyof RC_]?: { [F in keyof RC_[M]]?: { compute: RC_[M][F] } };",
+    );
+    expect(result).toContain(
+      "export type GassmaHogeResultComputedKeys<R_, CMap, M> =",
+    );
+    expect(result).toContain(
+      '  keyof Gassma.At<R_, M> | keyof Gassma.At<R_, "$allModels"> | keyof Gassma.At<CMap, M>;',
+    );
+    expect(result).toContain(
+      "export type GassmaHogeResultComputedTypes<RC_, CMap, M> = Gassma.MergeShape<",
+    );
+    expect(result).toContain(
+      '  Gassma.MergeShape<Gassma.SlotReturns<Gassma.At<RC_, "$allModels">>, Gassma.SlotReturns<Gassma.At<RC_, M>>>',
     );
   });
 
@@ -53,10 +76,12 @@ describe("getGassmaExtension", () => {
 
   it("should generate generic ExtendsFn capturing result literal", () => {
     expect(result).toContain(
-      "export type GassmaHogeExtendsFn<O extends GassmaHogeGlobalOmitConfig, CMap> = <R_ extends GassmaHogeResultShape = {}, R extends GassmaHogeResultConfig = {}>(extension: {",
+      "export type GassmaHogeExtendsFn<O extends GassmaHogeGlobalOmitConfig, CMap> = <R_ extends GassmaHogeResultShape = {}, RC_ extends GassmaHogeResultShape = {}, R extends GassmaHogeResultConfig = {}>(extension: {",
     );
     expect(result).toContain("  query?: GassmaHogeQueryExtension<O>;");
-    expect(result).toContain("  result?: GassmaHogeResultExtension<R_> & R;");
+    expect(result).toContain(
+      "  result?: GassmaHogeResultExtension<R_, RC_, CMap> & GassmaHogeResultComputeSlots<RC_> & R;",
+    );
     expect(result).toContain(
       "}) => GassmaHogeExtendedClient<O, GassmaHogeComputedMap<CMap, R>>;",
     );

--- a/src/__test__/types/extends/resultExtends.test-d.ts
+++ b/src/__test__/types/extends/resultExtends.test-d.ts
@@ -41,14 +41,40 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   });
 }
 
-// needs にスカラー以外のキーは書けない
+// needs にはスカラーと同 extension 内の算出フィールド名だけが書ける
 {
   client.$extends({
     result: {
       User: {
+        ok: {
+          needs: { email: true },
+          compute: (user) => user.email,
+        },
+        okComputed: {
+          needs: { ok: true },
+          compute: () => 1,
+        },
         bad: {
-          // @ts-expect-error nope というスカラーは存在しない
+          // @ts-expect-error nope はスカラーでも算出フィールドでもない
           needs: { nope: true },
+          compute: () => 1,
+        },
+      },
+    },
+  });
+}
+
+// 他モデルの算出フィールドは needs に書けない
+{
+  client.$extends({
+    result: {
+      User: {
+        userOnly: { needs: { email: true }, compute: (user) => user.email },
+      },
+      Post: {
+        bad: {
+          // @ts-expect-error userOnly は User の算出フィールド
+          needs: { userOnly: true },
           compute: () => 1,
         },
       },
@@ -339,4 +365,177 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
 
   const empty = client.$extends({});
   expectTypeOf(empty.User.findMany({})[0].id).toEqualTypeOf<number>();
+}
+
+// 算出フィールド依存: 依存先の compute 戻り型が依存元の compute 引数に現れる
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        emailLen: {
+          needs: { email: true },
+          compute: (user: { email: string }) => user.email.length,
+        },
+        doubledLen: {
+          needs: { emailLen: true },
+          compute: (user) => {
+            expectTypeOf(user.emailLen).toEqualTypeOf<number>();
+            // @ts-expect-error emailLen は number なので toUpperCase は呼べない
+            user.emailLen.toUpperCase();
+            return user.emailLen * 2;
+          },
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({});
+  expectTypeOf(rows[0].emailLen).toEqualTypeOf<number>();
+  expectTypeOf(rows[0].doubledLen).toEqualTypeOf<number>();
+}
+
+// 宣言順非依存: 依存元を依存先より先に宣言しても型が付く
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        doubledFirst: {
+          needs: { lenLater: true },
+          compute: (user) => {
+            expectTypeOf(user.lenLater).toEqualTypeOf<number>();
+            return user.lenLater * 2;
+          },
+        },
+        lenLater: {
+          needs: { email: true },
+          compute: (user: { email: string }) => user.email.length,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({});
+  expectTypeOf(rows[0].doubledFirst).toEqualTypeOf<number>();
+  expectTypeOf(rows[0].lenLater).toEqualTypeOf<number>();
+}
+
+// $allModels の算出フィールドへモデル固有算出から依存できる
+{
+  const extended = client.$extends({
+    result: {
+      $allModels: {
+        tag: { compute: () => "t" },
+      },
+      User: {
+        tagged: {
+          needs: { tag: true },
+          compute: (user) => {
+            expectTypeOf(user.tag).toEqualTypeOf<string>();
+            return `#${user.tag}`;
+          },
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({});
+  expectTypeOf(rows[0].tagged).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].tag).toEqualTypeOf<string>();
+}
+
+// 未注釈（context-sensitive）な依存先: needs は通り結果型も正しい。
+// compute 引数の値型のみ TS 推論の限界で never（依存先に注釈を付ければ実型になる）。
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        rawLen: {
+          needs: { email: true },
+          compute: (user) => user.email.length,
+        },
+        viaRaw: {
+          needs: { rawLen: true },
+          compute: (user) => {
+            expectTypeOf(user.rawLen).toBeNever();
+            return 1;
+          },
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({});
+  expectTypeOf(rows[0].rawLen).toEqualTypeOf<number>();
+  expectTypeOf(rows[0].viaRaw).toEqualTypeOf<number>();
+}
+
+// チェーン $extends 越しの算出フィールド依存（Prisma docs パターン）は完全に型が付く
+{
+  const extended = client
+    .$extends({
+      result: {
+        User: {
+          fullName: {
+            needs: { email: true },
+            compute: (user) => `x${user.email}`,
+          },
+        },
+      },
+    })
+    .$extends({
+      result: {
+        User: {
+          titled: {
+            needs: { fullName: true, id: true },
+            compute: (user) => {
+              expectTypeOf(user.fullName).toEqualTypeOf<string>();
+              expectTypeOf(user.id).toEqualTypeOf<number>();
+              // @ts-expect-error fullName は string なので toFixed は呼べない
+              user.fullName.toFixed();
+              return `${user.id}: ${user.fullName}`;
+            },
+          },
+        },
+      },
+    });
+  const rows = extended.User.findMany({});
+  expectTypeOf(rows[0].titled).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].fullName).toEqualTypeOf<string>();
+}
+
+// チェーン先で無関係キーは引き続き不可
+{
+  client
+    .$extends({
+      result: {
+        User: {
+          fullName: {
+            needs: { email: true },
+            compute: (user) => `x${user.email}`,
+          },
+        },
+      },
+    })
+    .$extends({
+      result: {
+        User: {
+          bad: {
+            // @ts-expect-error nope はスカラーでも算出フィールドでもない
+            needs: { nope: true },
+            compute: () => 1,
+          },
+        },
+      },
+    });
+}
+
+// 自己参照（循環）は型上は素直に許容する（ランタイムは打ち切りガード済み）
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        selfy: {
+          needs: { selfy: true, id: true },
+          compute: (user) => user.id,
+        },
+      },
+    },
+  });
+  expectTypeOf(extended.User.findMany({})[0].selfy).toEqualTypeOf<number>();
 }

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -49,9 +49,12 @@ const getGassmaCommonTypes = (strict?: boolean) => {
     [F in keyof Fields]: Fields[F] extends { compute: (...args: never[]) => infer V } ? V : never;
   };
   type ComputedOf<R, M> = MergeShape<ComputedReturns<At<R, "$allModels">>, ComputedReturns<At<R, M>>>;
-  type ResultField<Scalars, S> = {
-    needs?: { [K in keyof S]: K extends keyof Scalars ? S[K] : never } & { [K in keyof Scalars]?: boolean };
-    compute(record: { [K in keyof S as S[K] extends true ? K & keyof Scalars : never]: Scalars[K & keyof Scalars] }): unknown;
+  type SlotReturns<Slots> = {
+    [F in keyof Slots]: Slots[F] extends (...args: never[]) => infer V ? V : never;
+  };
+  type ResultField<Scalars, S, CKeys extends PropertyKey = never, CTypes = {}> = {
+    needs?: { [K in keyof S]: K extends keyof Scalars | CKeys ? S[K] : never } & { [K in keyof Scalars]?: boolean } & { [K in CKeys]?: boolean };
+    compute(record: { [K in keyof S as S[K] extends true ? K & (keyof Scalars | CKeys) : never]: K extends keyof CTypes ? CTypes[K] : K extends keyof Scalars ? Scalars[K] : never }): unknown;
   };
   type ComputedArgs<C> = [keyof C] extends [never] ? {} : {
     select?: { [K in keyof C]?: true };

--- a/src/generate/typeGenerate/gassmaExtension/resultExtension.ts
+++ b/src/generate/typeGenerate/gassmaExtension/resultExtension.ts
@@ -39,9 +39,21 @@ export type ${prefix}ResultShape = {
   [M in ${prefix}ModelName | "$allModels"]?: unknown;
 };
 
-export type ${prefix}ResultExtension<R_> = {
+export type ${prefix}ResultComputeSlots<RC_> = {
+  [M in keyof RC_]?: { [F in keyof RC_[M]]?: { compute: RC_[M][F] } };
+};
+
+export type ${prefix}ResultComputedKeys<R_, CMap, M> =
+  keyof Gassma.At<R_, M> | keyof Gassma.At<R_, "$allModels"> | keyof Gassma.At<CMap, M>;
+
+export type ${prefix}ResultComputedTypes<RC_, CMap, M> = Gassma.MergeShape<
+  Gassma.At<CMap, M>,
+  Gassma.MergeShape<Gassma.SlotReturns<Gassma.At<RC_, "$allModels">>, Gassma.SlotReturns<Gassma.At<RC_, M>>>
+>;
+
+export type ${prefix}ResultExtension<R_, RC_, CMap> = {
   [M in keyof R_]: {
-    [F in keyof R_[M]]?: Gassma.ResultField<${prefix}ResultScalars<M>, R_[M][F]>;
+    [F in keyof R_[M]]?: Gassma.ResultField<${prefix}ResultScalars<M>, R_[M][F], ${prefix}ResultComputedKeys<R_, CMap, M>, ${prefix}ResultComputedTypes<RC_, CMap, M>>;
   };
 };
 
@@ -58,9 +70,9 @@ export type ${prefix}ComputedMap<CMap, R> = {
 ${computedMapEntries}
 };
 
-export type ${prefix}ExtendsFn<O extends ${prefix}GlobalOmitConfig, CMap> = <R_ extends ${prefix}ResultShape = {}, R extends ${prefix}ResultConfig = {}>(extension: {
+export type ${prefix}ExtendsFn<O extends ${prefix}GlobalOmitConfig, CMap> = <R_ extends ${prefix}ResultShape = {}, RC_ extends ${prefix}ResultShape = {}, R extends ${prefix}ResultConfig = {}>(extension: {
   query?: ${prefix}QueryExtension<O>;
-  result?: ${prefix}ResultExtension<R_> & R;
+  result?: ${prefix}ResultExtension<R_, RC_, CMap> & ${prefix}ResultComputeSlots<RC_> & R;
 }) => ${prefix}ExtendedClient<O, ${prefix}ComputedMap<CMap, R>>;
 
 export type ${prefix}ExtendedClient<O extends ${prefix}GlobalOmitConfig = {}, CMap = {}> = {


### PR DESCRIPTION
## 概要

`$extends({ result })` の生成型で、`needs` に**算出フィールド同士の依存**を許可します(Prisma 完全準拠)。

これまで cli 生成型は `needs` のキーをモデルスカラー限定にしており、`needs: { <別の算出フィールド>: true }` を型エラーにしていました。一方 core ランタイム(gassma #155)と Prisma は computed→computed 依存を許可しており、**型が spec/ランタイムより厳しい**状態でした。

## Prisma 実機検証の結果

`prisma-test` で確認したところ、**Prisma 自身も「同一 call 内の sibling 依存」は型レベルでは非サポート(`never`)**で、**チェーン `$extends` 越しの依存のみ完全型付け**(ランタイムは両方動く)。本 PR はこの Prisma の挙動を正確に踏襲します。

## 実装

`ResultField` に型引数 `CKeys`/`CTypes` を追加(デフォルト `never`/`{}` で後方互換):

```ts
type ResultField<Scalars, S, CKeys extends PropertyKey = never, CTypes = {}> = {
  needs?: { [K in keyof S]: K extends keyof Scalars | CKeys ? S[K] : never }
        & { [K in keyof Scalars]?: boolean } & { [K in CKeys]?: boolean };
  compute(record: { [K in keyof S as S[K] extends true ? K & (keyof Scalars | CKeys) : never]:
    K extends keyof CTypes ? CTypes[K] : K extends keyof Scalars ? Scalars[K] : never }): unknown;
};
```

- **needs キー集合** = `keyof ResultScalars<M> ∪ keyof R_[M] ∪ keyof R_["$allModels"] ∪ keyof CMap[M]`(宣言順非依存)
- **compute 引数の値型** = 算出依存はその算出フィールドの compute 戻り型(`CTypes` 優先)、スカラーはスカラー型
- compute 戻り型を専用の reverse-mapped チャネル `RC_`(`ResultComputeSlots`)で捕捉。`R` を param 型に出現させると context-sensitive compute で推論が `{}` に崩壊するため、3チャネル(needs 構造 `R_` / compute 戻り `RC_` / literal `R`)に分解

## 達成範囲

- チェーン `$extends` 越しの依存: **完全型付け**(Prisma docs パターン)
- 同一 call 内: **キーは受理・needs/結果型は正確**。依存先が非 context-sensitive(引数注釈あり or 引数なし)なら値型も正確。依存先が context-sensitive(未注釈)compute のときのみ、その依存の値型が `never`(TS 原理的限界。Prisma が同一 call 依存を型サポートしない理由と同一)
- `$allModels` 算出への依存も対応
- 無関係キー(スカラーでも算出でもない)は**引き続き型エラー**

## テスト

- `resultExtends.test-d.ts`: 「スカラー以外不可」assert を computed 依存可へ書き換え + 9ブロック追加(同 ext 依存で依存先戻り型が compute 引数に出る/宣言順非依存/$allModels 依存/チェーン依存/無関係キー拒否/他モデル computed 拒否/自己参照/誤用 `@ts-expect-error`)。Red 先行 + 「わざと壊す」3種で Red 再確認
- 生成文字列テストも追随

結果:
- `npm test`: **116 files / 798 tests 全 pass**
- `npm run test:types`: **142 files / 798 tests / Type Errors 0**
- `npx tsc --noEmit`: clean / `biome check`: clean / `npm run build`(tsup): 成功

## 後方互換

`ResultField` の追加型引数はデフォルト付き。既存型テスト(`queryExtends.test-d.ts` 含む 141→142 ファイル)・全ユニットテスト無修正で pass。scalar-only needs / query-only / 拡張なしは従来どおり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)