### PR TITLE
feat: generate result computed field types for nested include (Tier2)

### DIFF
--- a/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -3,11 +3,11 @@ import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaCon
 
 describe("getOneGassmaController", () => {
   const result = getOneGassmaController("", "User");
-  const res = `Gassma.WithComputed<GassmaUserFindResult<Gassma.StripComputed<T["select"], C>, T["include"], T["omit"], GO, O>, C, T["select"], T["omit"]>`;
+  const res = `GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O, CMap>`;
 
-  it("should generate controller class declaration with GO, O and computed map C", () => {
+  it("should generate controller class declaration with GO, O and computed map CMap", () => {
     expect(result).toContain(
-      "export declare class GassmaUserController<GO extends GassmaUserOmit = {}, O = {}, C = {}>",
+      "export declare class GassmaUserController<GO extends GassmaUserOmit = {}, O = {}, CMap = {}>",
     );
   });
 
@@ -28,13 +28,13 @@ describe("getOneGassmaController", () => {
   it("should include CRUD methods", () => {
     expect(result).toContain("createMany(");
     expect(result).toContain(
-      "create<T extends GassmaUserCreateData & Gassma.ComputedArgs<C>>",
+      `create<T extends GassmaUserCreateData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>`,
     );
     expect(result).toContain(
-      "findFirst<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<C>>",
+      `findFirst<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>`,
     );
     expect(result).toContain(
-      "findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<C>>",
+      `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>`,
     );
     expect(result).toContain("updateMany(");
     expect(result).not.toContain("upsertMany(");
@@ -49,49 +49,49 @@ describe("getOneGassmaController", () => {
 
   it("should have generic delete method with model-specific type", () => {
     expect(result).toContain(
-      `delete<T extends GassmaUserDeleteSingleData & Gassma.ComputedArgs<C>>(deleteData: T): ${res} | null`,
+      `delete<T extends GassmaUserDeleteSingleData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(deleteData: T): ${res} | null`,
     );
   });
 
   it("should have generic upsert method with model-specific type", () => {
     expect(result).toContain(
-      `upsert<T extends GassmaUserUpsertSingleData & Gassma.ComputedArgs<C>>(upsertData: T): ${res}`,
+      `upsert<T extends GassmaUserUpsertSingleData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(upsertData: T): ${res}`,
     );
   });
 
   it("should include createManyAndReturn method with generic type", () => {
     expect(result).toContain(
-      `createManyAndReturn<T extends GassmaUserCreateManyAndReturnData & Gassma.ComputedArgs<C>>(createdData: T): ${res}[]`,
+      `createManyAndReturn<T extends GassmaUserCreateManyAndReturnData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(createdData: T): ${res}[]`,
     );
   });
 
   it("should include updateManyAndReturn method with globalOmit and computed applied", () => {
     expect(result).toContain(
-      "updateManyAndReturn(updateData: GassmaUserUpdateData): Gassma.WithComputed<GassmaUserFindResult<undefined, undefined, undefined, GO, O>, C, undefined, undefined>[]",
+      "updateManyAndReturn(updateData: GassmaUserUpdateData): GassmaUserFindResult<undefined, undefined, undefined, GO, O, CMap>[]",
     );
   });
 
   it("should use FindFirstData for findFirst", () => {
     expect(result).toContain(
-      `findFirst<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<C>>(findData: T): ${res} | null`,
+      `findFirst<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T): ${res} | null`,
     );
   });
 
   it("should use FindFirstData for findFirstOrThrow", () => {
     expect(result).toContain(
-      `findFirstOrThrow<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<C>>(findData: T): ${res}`,
+      `findFirstOrThrow<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T): ${res}`,
     );
   });
 
   it("should have generic create method with FindResult return", () => {
     expect(result).toContain(
-      `create<T extends GassmaUserCreateData & Gassma.ComputedArgs<C>>(createdData: T): ${res}`,
+      `create<T extends GassmaUserCreateData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(createdData: T): ${res}`,
     );
   });
 
   it("should have generic update method with model-specific type", () => {
     expect(result).toContain(
-      `update<T extends GassmaUserUpdateSingleData & Gassma.ComputedArgs<C>>(updateData: T): ${res} | null`,
+      `update<T extends GassmaUserUpdateSingleData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(updateData: T): ${res} | null`,
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
@@ -92,10 +92,10 @@ describe("getGassmaExtension", () => {
       "export type GassmaHogeExtendedClient<O extends GassmaHogeGlobalOmitConfig = {}, CMap = {}> = {",
     );
     expect(result).toContain(
-      '  "User": GassmaHogeUserController<O extends { "User": infer UO } ? UO extends GassmaHogeUserOmit ? UO : {} : {}, O, Gassma.At<CMap, "User">>;',
+      '  "User": GassmaHogeUserController<O extends { "User": infer UO } ? UO extends GassmaHogeUserOmit ? UO : {} : {}, O, CMap>;',
     );
     expect(result).toContain(
-      '  "Post": GassmaHogePostController<O extends { "Post": infer UO } ? UO extends GassmaHogePostOmit ? UO : {} : {}, O, Gassma.At<CMap, "Post">>;',
+      '  "Post": GassmaHogePostController<O extends { "Post": infer UO } ? UO extends GassmaHogePostOmit ? UO : {} : {}, O, CMap>;',
     );
     expect(result).toContain("  $extends: GassmaHogeExtendsFn<O, CMap>;");
   });
@@ -148,16 +148,16 @@ describe("getGassmaExtension", () => {
       "  findMany?: <T extends GassmaHogeUserFindManyData>(params: {",
     );
     expect(result).toContain(
-      '    query: (args: T) => GassmaHogeUserFindResult<T["select"], T["include"], T["omit"], GO, O>[];',
+      '    query: (args: T) => GassmaHogeUserFindResultBase<T["select"], T["include"], T["omit"], GO, O>[];',
     );
     expect(result).toContain(
-      '  }) => GassmaHogeUserFindResult<T["select"], T["include"], T["omit"], GO, O>[];',
+      '  }) => GassmaHogeUserFindResultBase<T["select"], T["include"], T["omit"], GO, O>[];',
     );
     expect(result).toContain(
       "  findFirst?: <T extends GassmaHogeUserFindFirstData>(params: {",
     );
     expect(result).toContain(
-      '  }) => GassmaHogeUserFindResult<T["select"], T["include"], T["omit"], GO, O> | null;',
+      '  }) => GassmaHogeUserFindResultBase<T["select"], T["include"], T["omit"], GO, O> | null;',
     );
     expect(result).toContain(
       "  findFirstOrThrow?: <T extends GassmaHogeUserFindFirstData>(params: {",
@@ -200,7 +200,7 @@ describe("getGassmaExtension", () => {
     );
     expect(result).toContain("  updateManyAndReturn?: (params: {");
     expect(result).toContain(
-      "    query: (args: GassmaHogeUserUpdateData) => GassmaHogeUserFindResult<undefined, undefined, undefined, GO, O>[];",
+      "    query: (args: GassmaHogeUserUpdateData) => GassmaHogeUserFindResultBase<undefined, undefined, undefined, GO, O>[];",
     );
     expect(result).toContain("  deleteMany?: (params: {");
     expect(result).toContain(
@@ -258,7 +258,7 @@ describe("getGassmaExtension", () => {
       '  M extends "My Sheet" ? GassmaMySheetDefaultFindResult :',
     );
     expect(spaced).toContain(
-      '  "My Sheet": GassmaMySheetController<O extends { "My Sheet": infer UO } ? UO extends GassmaMySheetOmit ? UO : {} : {}, O, Gassma.At<CMap, "My Sheet">>;',
+      '  "My Sheet": GassmaMySheetController<O extends { "My Sheet": infer UO } ? UO extends GassmaMySheetOmit ? UO : {} : {}, O, CMap>;',
     );
   });
 

--- a/src/__test__/generate/typeGenerate/gassmaFindResult.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaFindResult.test.ts
@@ -1,16 +1,34 @@
-import { describe, it, expect } from "vitest";
-import { getOneGassmaFindResult } from "../../../generate/typeGenerate/gassmaFindResult/oneGassmaFindResult";
+import { describe, expect, it } from "vitest";
 import type { RelationsConfig } from "../../../generate/read/extractRelations";
+import { getOneGassmaFindResult } from "../../../generate/typeGenerate/gassmaFindResult/oneGassmaFindResult";
 
 describe("getOneGassmaFindResult", () => {
-  it("should generate FindResult with 5 type parameters <S, I, QO, GO, O>", () => {
+  it("should generate a structural FindResultBase with 5 type parameters", () => {
     const result = getOneGassmaFindResult("", "User");
     expect(result).toContain(
-      "export type GassmaUserFindResult<S, I = undefined, QO = undefined, GO = {}, O = {}>",
+      "export type GassmaUserFindResultBase<S, I = undefined, QO = undefined, GO = {}, O = {}>",
     );
   });
 
-  it("should map oneToMany to TargetFindResult[] via SelectOf/IncludeOf/OmitOf", () => {
+  it("should generate a FindResultCore with a CMap type parameter", () => {
+    const result = getOneGassmaFindResult("", "User");
+    expect(result).toContain(
+      "export type GassmaUserFindResultCore<S, I = undefined, QO = undefined, GO = {}, O = {}, CMap = {}>",
+    );
+  });
+
+  it("should wrap FindResult in WithComputed, stripping computed keys from the select", () => {
+    const result = getOneGassmaFindResult("", "User");
+    expect(result).toContain(
+      "export type GassmaUserFindResult<S, I = undefined, QO = undefined, GO = {}, O = {}, CMap = {}> = Gassma.WithComputed<",
+    );
+    expect(result).toContain(
+      'GassmaUserFindResultCore<Gassma.StripComputed<S, Gassma.At<CMap, "User">>, I, QO, GO, O, CMap>',
+    );
+    expect(result).toContain('Gassma.At<CMap, "User">');
+  });
+
+  it("should map oneToMany to computed TargetFindResult[] threading CMap", () => {
     const relations: RelationsConfig = {
       User: {
         posts: {
@@ -23,11 +41,11 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O>[]',
+      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O, CMap>[]',
     );
   });
 
-  it("should map oneToOne to TargetFindResult | null", () => {
+  it("should map oneToOne to computed TargetFindResult | null threading CMap", () => {
     const relations: RelationsConfig = {
       User: {
         profile: {
@@ -40,11 +58,11 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "profile" ? GassmaProfileFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Profile": infer TO } ? TO extends GassmaProfileOmit ? TO : {} : {}, O> | null',
+      'K extends "profile" ? GassmaProfileFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Profile": infer TO } ? TO extends GassmaProfileOmit ? TO : {} : {}, O, CMap> | null',
     );
   });
 
-  it("should map manyToOne to TargetFindResult | null (FK constraints not enforced in spreadsheets)", () => {
+  it("should map manyToOne to computed TargetFindResult | null threading CMap", () => {
     const relations: RelationsConfig = {
       Post: {
         author: {
@@ -57,7 +75,24 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "Post", relations);
     expect(result).toContain(
-      'K extends "author" ? GassmaUserFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "User": infer TO } ? TO extends GassmaUserOmit ? TO : {} : {}, O> | null',
+      'K extends "author" ? GassmaUserFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "User": infer TO } ? TO extends GassmaUserOmit ? TO : {} : {}, O, CMap> | null',
+    );
+  });
+
+  it("should keep FindResultBase relation branches structural (no CMap)", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    };
+    const result = getOneGassmaFindResult("", "User", relations);
+    expect(result).toContain(
+      'K extends "posts" ? GassmaPostFindResultBase<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O>[]',
     );
   });
 
@@ -74,7 +109,7 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<S[K]>, Gassma.IncludeOf<S[K]>, Gassma.OmitOf<S[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O>[]',
+      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<S[K]>, Gassma.IncludeOf<S[K]>, Gassma.OmitOf<S[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O, CMap>[]',
     );
   });
 

--- a/src/__test__/types/extends/resultExtends.test-d.ts
+++ b/src/__test__/types/extends/resultExtends.test-d.ts
@@ -259,7 +259,7 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   expectTypeOf(extended.User.deleteMany({}).count).toEqualTypeOf<number>();
 }
 
-// 算出フィールドはネストしたリレーション結果にも出る（Tier2）
+// 算出フィールドはネストしたリレーション結果にも出る
 {
   const extended = client.$extends({
     result: {

--- a/src/__test__/types/extends/resultExtends.test-d.ts
+++ b/src/__test__/types/extends/resultExtends.test-d.ts
@@ -259,7 +259,7 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   expectTypeOf(extended.User.deleteMany({}).count).toEqualTypeOf<number>();
 }
 
-// 算出フィールドはネストしたリレーション結果には出ない（Tier1）
+// 算出フィールドはネストしたリレーション結果にも出る（Tier2）
 {
   const extended = client.$extends({
     result: {
@@ -270,7 +270,7 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   });
   const rows = extended.User.findMany({ include: { posts: true } });
   expectTypeOf(rows[0].tag).toEqualTypeOf<string>();
-  expectTypeOf(rows[0].posts[0]).not.toHaveProperty("tag");
+  expectTypeOf(rows[0].posts[0].tag).toEqualTypeOf<string>();
   expectTypeOf(rows[0].posts[0].title).toEqualTypeOf<string>();
 }
 

--- a/src/__test__/types/extends/resultExtendsNested.test-d.ts
+++ b/src/__test__/types/extends/resultExtendsNested.test-d.ts
@@ -3,7 +3,7 @@ import { GassmaClient } from "../__generated__/client";
 
 const client = new GassmaClient();
 
-// Tier2: nested include(default)の子モデル computed が正しい戻り型で出る
+// nested include(default)の子モデル computed が正しい戻り型で出る
 {
   const extended = client.$extends({
     result: {
@@ -21,7 +21,7 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].posts[0].id).toEqualTypeOf<number>();
 }
 
-// Tier2: nested computed の戻り型が number でも保たれる
+// nested computed の戻り型が number でも保たれる
 {
   const extended = client.$extends({
     result: {
@@ -37,7 +37,7 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].posts[0].doubleId).toEqualTypeOf<number>();
 }
 
-// Tier2: oneToOne(nullable)の nested computed
+// oneToOne(nullable)の nested computed
 {
   const extended = client.$extends({
     result: {
@@ -54,7 +54,7 @@ const client = new GassmaClient();
   if (profile) expectTypeOf(profile.bioLen).toEqualTypeOf<number>();
 }
 
-// Tier2: manyToOne(nullable)の nested computed
+// manyToOne(nullable)の nested computed
 {
   const extended = client.$extends({
     result: {
@@ -71,7 +71,7 @@ const client = new GassmaClient();
   if (author) expectTypeOf(author.fullName).toEqualTypeOf<string>();
 }
 
-// Tier2: 深いネスト(User→posts→tags)で各階層の computed
+// 深いネスト(User→posts→tags)で各階層の computed
 {
   const extended = client.$extends({
     result: {
@@ -96,7 +96,7 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].posts[0].tags[0].upper).toEqualTypeOf<string>();
 }
 
-// Tier2: $allModels が nested にも付く
+// $allModels が nested にも付く
 {
   const extended = client.$extends({
     result: {
@@ -110,7 +110,7 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].posts[0].tag).toEqualTypeOf<string>();
 }
 
-// Tier2: nested でもモデル固有が $allModels に勝つ
+// nested でもモデル固有が $allModels に勝つ
 {
   const extended = client.$extends({
     result: {
@@ -123,7 +123,7 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].posts[0].tag).toEqualTypeOf<number>();
 }
 
-// Tier2: 自己リレーション(Category tree)の nested computed
+// 自己リレーション(Category tree)の nested computed
 {
   const extended = client.$extends({
     result: {
@@ -140,7 +140,7 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].children[0].label).toEqualTypeOf<string>();
 }
 
-// Tier2: チェーン $extends の computed が nested にも累積する
+// チェーン $extends の computed が nested にも累積する
 {
   const extended = client
     .$extends({
@@ -170,7 +170,7 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].posts[0].tags[0].upper).toEqualTypeOf<string>();
 }
 
-// Tier2: nested select は computed を選ばなければ computed を出さない
+// nested select は computed を選ばなければ computed を出さない
 {
   const extended = client.$extends({
     result: {
@@ -190,7 +190,7 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].posts[0]).not.toHaveProperty("id");
 }
 
-// Tier2: nested omit はスカラーを落としつつ computed を残す
+// nested omit はスカラーを落としつつ computed を残す
 {
   const extended = client.$extends({
     result: {
@@ -210,14 +210,14 @@ const client = new GassmaClient();
   expectTypeOf(rows[0].posts[0]).not.toHaveProperty("content");
 }
 
-// Tier2 後方互換: 拡張なしなら nested に computed は出ない
+// 後方互換: 拡張なしなら nested に computed は出ない
 {
   const rows = client.User.findMany({ include: { posts: true } });
   expectTypeOf(rows[0].posts[0].title).toEqualTypeOf<string>();
   expectTypeOf(rows[0].posts[0]).not.toHaveProperty("headline");
 }
 
-// Tier2 後方互換: query-only 拡張は nested も従来型
+// 後方互換: query-only 拡張は nested も従来型
 {
   const queryOnly = client.$extends({
     query: { User: { findMany: ({ args, query }) => query(args) } },

--- a/src/__test__/types/extends/resultExtendsNested.test-d.ts
+++ b/src/__test__/types/extends/resultExtendsNested.test-d.ts
@@ -1,0 +1,228 @@
+import { expectTypeOf } from "vitest";
+import { GassmaClient } from "../__generated__/client";
+
+const client = new GassmaClient();
+
+// Tier2: nested include(default)の子モデル computed が正しい戻り型で出る
+{
+  const extended = client.$extends({
+    result: {
+      Post: {
+        headline: {
+          needs: { title: true },
+          compute: (post) => `# ${post.title}`,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({ include: { posts: true } });
+  expectTypeOf(rows[0].posts[0].headline).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0].title).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0].id).toEqualTypeOf<number>();
+}
+
+// Tier2: nested computed の戻り型が number でも保たれる
+{
+  const extended = client.$extends({
+    result: {
+      Post: {
+        doubleId: {
+          needs: { id: true },
+          compute: (post) => post.id * 2,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({ include: { posts: true } });
+  expectTypeOf(rows[0].posts[0].doubleId).toEqualTypeOf<number>();
+}
+
+// Tier2: oneToOne(nullable)の nested computed
+{
+  const extended = client.$extends({
+    result: {
+      Profile: {
+        bioLen: {
+          needs: { bio: true },
+          compute: (profile) => profile.bio.length,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({ include: { profile: true } });
+  const profile = rows[0].profile;
+  if (profile) expectTypeOf(profile.bioLen).toEqualTypeOf<number>();
+}
+
+// Tier2: manyToOne(nullable)の nested computed
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  const rows = extended.Post.findMany({ include: { author: true } });
+  const author = rows[0].author;
+  if (author) expectTypeOf(author.fullName).toEqualTypeOf<string>();
+}
+
+// Tier2: 深いネスト(User→posts→tags)で各階層の computed
+{
+  const extended = client.$extends({
+    result: {
+      Post: {
+        headline: {
+          needs: { title: true },
+          compute: (post) => `# ${post.title}`,
+        },
+      },
+      Tag: {
+        upper: {
+          needs: { name: true },
+          compute: (tag) => tag.name.toUpperCase(),
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({
+    include: { posts: { include: { tags: true } } },
+  });
+  expectTypeOf(rows[0].posts[0].headline).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0].tags[0].upper).toEqualTypeOf<string>();
+}
+
+// Tier2: $allModels が nested にも付く
+{
+  const extended = client.$extends({
+    result: {
+      $allModels: {
+        tag: { compute: () => "t" },
+      },
+    },
+  });
+  const rows = extended.User.findMany({ include: { posts: true } });
+  expectTypeOf(rows[0].tag).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0].tag).toEqualTypeOf<string>();
+}
+
+// Tier2: nested でもモデル固有が $allModels に勝つ
+{
+  const extended = client.$extends({
+    result: {
+      $allModels: { tag: { compute: () => "t" } },
+      Post: { tag: { compute: () => 123 } },
+    },
+  });
+  const rows = extended.User.findMany({ include: { posts: true } });
+  expectTypeOf(rows[0].tag).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0].tag).toEqualTypeOf<number>();
+}
+
+// Tier2: 自己リレーション(Category tree)の nested computed
+{
+  const extended = client.$extends({
+    result: {
+      Category: {
+        label: {
+          needs: { name: true },
+          compute: (category) => category.name,
+        },
+      },
+    },
+  });
+  const rows = extended.Category.findMany({ include: { children: true } });
+  expectTypeOf(rows[0].label).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].children[0].label).toEqualTypeOf<string>();
+}
+
+// Tier2: チェーン $extends の computed が nested にも累積する
+{
+  const extended = client
+    .$extends({
+      result: {
+        Post: {
+          headline: {
+            needs: { title: true },
+            compute: (post) => `# ${post.title}`,
+          },
+        },
+      },
+    })
+    .$extends({
+      result: {
+        Tag: {
+          upper: {
+            needs: { name: true },
+            compute: (tag) => tag.name.toUpperCase(),
+          },
+        },
+      },
+    });
+  const rows = extended.User.findMany({
+    include: { posts: { include: { tags: true } } },
+  });
+  expectTypeOf(rows[0].posts[0].headline).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0].tags[0].upper).toEqualTypeOf<string>();
+}
+
+// Tier2: nested select は computed を選ばなければ computed を出さない
+{
+  const extended = client.$extends({
+    result: {
+      Post: {
+        headline: {
+          needs: { title: true },
+          compute: (post) => `# ${post.title}`,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({
+    include: { posts: { select: { title: true } } },
+  });
+  expectTypeOf(rows[0].posts[0].title).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0]).not.toHaveProperty("headline");
+  expectTypeOf(rows[0].posts[0]).not.toHaveProperty("id");
+}
+
+// Tier2: nested omit はスカラーを落としつつ computed を残す
+{
+  const extended = client.$extends({
+    result: {
+      Post: {
+        headline: {
+          needs: { title: true },
+          compute: (post) => `# ${post.title}`,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany({
+    include: { posts: { omit: { content: true } } },
+  });
+  expectTypeOf(rows[0].posts[0].headline).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0].title).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0]).not.toHaveProperty("content");
+}
+
+// Tier2 後方互換: 拡張なしなら nested に computed は出ない
+{
+  const rows = client.User.findMany({ include: { posts: true } });
+  expectTypeOf(rows[0].posts[0].title).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0]).not.toHaveProperty("headline");
+}
+
+// Tier2 後方互換: query-only 拡張は nested も従来型
+{
+  const queryOnly = client.$extends({
+    query: { User: { findMany: ({ args, query }) => query(args) } },
+  });
+  const rows = queryOnly.User.findMany({ include: { posts: true } });
+  expectTypeOf(rows[0].posts[0].title).toEqualTypeOf<string>();
+  expectTypeOf(rows[0].posts[0]).not.toHaveProperty("headline");
+}

--- a/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -1,13 +1,13 @@
 const getOneGassmaController = (schemaName: string, sheetName: string) => {
   const self = `Gassma${schemaName}${sheetName}`;
   const fr = `${self}FindResult`;
-  const base = `${fr}<Gassma.StripComputed<T["select"], C>, T["include"], T["omit"], GO, O>`;
-  const res = `Gassma.WithComputed<${base}, C, T["select"], T["omit"]>`;
+  const c = `Gassma.At<CMap, "${sheetName}">`;
+  const res = `${fr}<T["select"], T["include"], T["omit"], GO, O, CMap>`;
   const arg = (dataSuffix: string) =>
-    `T extends ${self}${dataSuffix} & Gassma.ComputedArgs<C>`;
+    `T extends ${self}${dataSuffix} & Gassma.ComputedArgs<${c}>`;
 
   return `
-export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, C = {}> {
+export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, CMap = {}> {
   constructor(sheetName: string, id?: string);
 
   readonly fields: Record<string, Gassma.FieldRef>;
@@ -24,7 +24,7 @@ export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, C = 
   findMany<${arg("FindManyData")}>(findData: T): ${res}[];
   update<${arg("UpdateSingleData")}>(updateData: T): ${res} | null;
   updateMany(updateData: ${self}UpdateData): UpdateManyReturn;
-  updateManyAndReturn(updateData: ${self}UpdateData): Gassma.WithComputed<${fr}<undefined, undefined, undefined, GO, O>, C, undefined, undefined>[];
+  updateManyAndReturn(updateData: ${self}UpdateData): ${fr}<undefined, undefined, undefined, GO, O, CMap>[];
   upsert<${arg("UpsertSingleData")}>(upsertData: T): ${res};
   delete<${arg("DeleteSingleData")}>(deleteData: T): ${res} | null;
   deleteMany(deleteData: ${self}DeleteData): DeleteManyReturn;

--- a/src/generate/typeGenerate/gassmaExtension/extensionOperations.ts
+++ b/src/generate/typeGenerate/gassmaExtension/extensionOperations.ts
@@ -6,7 +6,7 @@ type ExtensionOperation = {
 };
 
 const genericFindResult = (self: string) =>
-  `${self}FindResult<T["select"], T["include"], T["omit"], GO, O>`;
+  `${self}FindResultBase<T["select"], T["include"], T["omit"], GO, O>`;
 
 const EXTENSION_OPERATIONS: ExtensionOperation[] = [
   {
@@ -62,7 +62,7 @@ const EXTENSION_OPERATIONS: ExtensionOperation[] = [
     dataSuffix: "UpdateData",
     generic: false,
     result: (self) =>
-      `${self}FindResult<undefined, undefined, undefined, GO, O>[]`,
+      `${self}FindResultBase<undefined, undefined, undefined, GO, O>[]`,
   },
   {
     name: "upsert",

--- a/src/generate/typeGenerate/gassmaExtension/resultExtension.ts
+++ b/src/generate/typeGenerate/gassmaExtension/resultExtension.ts
@@ -27,7 +27,7 @@ const getGassmaResultExtension = (sheetNames: string[], schemaName: string) => {
     .map((sheetName) => {
       const self = selfOf(sheetName);
       const go = `O extends { "${sheetName}": infer UO } ? UO extends ${self}Omit ? UO : {} : {}`;
-      return `  "${sheetName}": ${self}Controller<${go}, O, Gassma.At<CMap, "${sheetName}">>;`;
+      return `  "${sheetName}": ${self}Controller<${go}, O, CMap>;`;
     })
     .join("\n");
 

--- a/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -15,52 +15,64 @@ const getOneGassmaFindResult = (
       ? `${relNames.map((r) => `"${r}"`).join(" | ")} | "_count"`
       : `"_count"`;
 
-  const relationBranch = (source: string) =>
+  const relationBranch = (
+    source: string,
+    childName: string,
+    childArgs: string,
+  ) =>
     relNames
       .map((relationName) => {
         const def = modelRelations[relationName];
-        const targetFR = `${prefix}${def.to}FindResult`;
+        const targetFR = `${prefix}${def.to}${childName}`;
         const targetGO = `O extends { "${def.to}": infer TO } ? TO extends ${prefix}${def.to}Omit ? TO : {} : {}`;
-        const inner = `${targetFR}<Gassma.SelectOf<${source}[K]>, Gassma.IncludeOf<${source}[K]>, Gassma.OmitOf<${source}[K]>, ${targetGO}, O>`;
+        const inner = `${targetFR}<Gassma.SelectOf<${source}[K]>, Gassma.IncludeOf<${source}[K]>, Gassma.OmitOf<${source}[K]>, ${targetGO}, O${childArgs}>`;
         const isList = def.type === "oneToMany" || def.type === "manyToMany";
         const result = isList ? `${inner}[]` : `${inner} | null`;
         return `          K extends "${relationName}" ? ${result} :`;
       })
       .join("\n");
 
-  const selectResult = `{
+  const structural = (childName: string, childArgs: string) => {
+    const selectResult = `{
       [K in keyof S as S[K] extends false | undefined
         ? never
         : K & (keyof ${self}DefaultFindResult | ${relKeyUnion})]:
-${relationBranch("S")}
+${relationBranch("S", childName, childArgs)}
           K extends "_count" ? Gassma.CountResult<S[K]> :
           ${self}DefaultFindResult[K & keyof ${self}DefaultFindResult];
     }`;
-
-  const omitResult = `{
+    const omitResult = `{
       [K in keyof ${self}DefaultFindResult as K extends Gassma.ResolveOmitKeys<GO, QO>
         ? never
         : K]: ${self}DefaultFindResult[K];
     }`;
-
-  const baseResult = `(S extends ${self}FindSelect
-  ? ${selectResult}
-  : ${omitResult})`;
-
-  const includeBranches = relationBranch("I");
-
-  const includePart = `(I extends undefined
+    const includePart = `(I extends undefined
     ? {}
     : {
         [K in keyof I as K extends ${relKeyUnion} ? K : never]:
-${includeBranches}
+${relationBranch("I", childName, childArgs)}
           K extends "_count" ? Gassma.CountResult<I[K]> :
           never;
       })`;
+    return `(S extends ${self}FindSelect
+  ? ${selectResult}
+  : ${omitResult}) &
+  ${includePart}`;
+  };
+
+  const at = `Gassma.At<CMap, "${sheetName}">`;
 
   return `
-export type ${self}FindResult<S, I = undefined, QO = undefined, GO = {}, O = {}> = ${baseResult} &
-  ${includePart};
+export type ${self}FindResultBase<S, I = undefined, QO = undefined, GO = {}, O = {}> = ${structural("FindResultBase", "")};
+
+export type ${self}FindResultCore<S, I = undefined, QO = undefined, GO = {}, O = {}, CMap = {}> = ${structural("FindResult", ", CMap")};
+
+export type ${self}FindResult<S, I = undefined, QO = undefined, GO = {}, O = {}, CMap = {}> = Gassma.WithComputed<
+  ${self}FindResultCore<Gassma.StripComputed<S, ${at}>, I, QO, GO, O, CMap>,
+  ${at},
+  S,
+  QO
+>;
 `;
 };
 


### PR DESCRIPTION
## 概要

gassma 本体 Tier2(nested include の結果にも算出フィールド、gassma #162)に **cli の型生成**を追随させます。本プロジェクト最難関の型パズルで、Opus 4.8 max-effort で実装しました。

## 実装: FindResult を3型分割し per-model 算出マップ CMap を再帰スレッド

Tier1 は controller が `WithComputed<FindResult<...>, C, ...>` で**トップレベルのみ** computed 交差していました。Tier2 は交差を **FindResult 内部の全階層**へ移行:

- **`FindResultBase`**: 構造のみ。**query hook 専用**(generic include の循環リレーション展開で "Type instantiation is excessively deep" を回避)
- **`FindResultCore`**: 構造。**子リレーションは `子FindResult<…, CMap>` を参照**し CMap を素通し → 子は `At<CMap, 子モデル>` を自階層で交差
- **`FindResult<S,I,QO,GO,O,CMap>`** = `WithComputed<FindResultCore<StripComputed<S, At<CMap,M>>, …, CMap>, At<CMap,M>, S, QO>`

controller は `FindResult<…, GO, O, CMap>` を返すだけ(トップレベルラップ撤去)。ExtendedClient が全モデル分の CMap を注入し、**controller→FindResult→Core→子FindResult と単一の per-model CMap を1本流し、各階層で `At<CMap, 当該モデル>` を交差**します。

## 達成範囲

- **nested default include で子モデルの computed が正しい戻り型で出る(Tier2 の主眼)**、深いネスト(多段)、oneToMany/manyToMany=`T[]`・manyToOne/oneToOne=`T|null` の要素/非null 側に交差
- `$allModels` のネスト適用、モデル固有 > `$allModels`、自己リレーション、チェーン累積
- 各階層の select/omit × computed: nested select 非選択 computed 除外、nested scalar-omit × computed 残存、override(同名は computed 型が勝つ)

## 妥協点(best-effort)

- **nested の select/omit に computed の「キー」を書く入力**は型エラー(`子FindSelect`/`子Omit` が computed キーを持たないため。全入力型生成器へ CMap を通すのは大規模で範囲外)。出力側(FindResult)は対応済みで、入力が許せば正しく解決。**トップレベルの select/omit × computed は従来どおり厳密**。ランタイム(gassma #162)は全対応済み

## テスト

- `resultExtendsNested.test-d.ts`(TDD Red 先行): nested default computed / number computed / oneToOne・manyToOne nullable / 深いネスト / `$allModels` ネスト / モデル固有勝ち / 自己リレーション / チェーン / nested select 除外 / nested omit 残存 / 後方互換
- 生成文字列テスト(FindResult/controller/resultExtension)追随

結果:
- `npm test`: **116 files / 801 tests 全 pass**
- `npm run test:types`: **143 files / 801 tests / Type Errors 0**
- `npx tsc --noEmit`: clean / `biome check`: clean / `npm run build`(tsup): 成功

## 後方互換

`CMap` 既定 `{}` → `At<{},M>={}` → `WithComputed` は Base 素通し → 完全 Tier1。query-only / 空拡張 / 非拡張クライアントは従来どおり。既存 `resultExtends.test-d.ts` はネスト非出現→出現の1ブロックのみ意図的最小修正、`queryExtends.test-d.ts` は無修正 pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)