### PR TITLE
fix: un-annotated result compute param no longer infers to any

### DIFF
--- a/src/__test__/generate/generator.test.ts
+++ b/src/__test__/generate/generator.test.ts
@@ -110,9 +110,7 @@ describe("generater", () => {
 
   it("should include result extension types", () => {
     expect(result).toContain("export type GassmaResultScalars<M> =");
-    expect(result).toContain(
-      "export type GassmaResultExtension<R_, RC_, CMap> = {",
-    );
+    expect(result).toContain("export type GassmaResultExtension<R_, CMap> = {");
     expect(result).toContain("export type GassmaComputedMap<CMap, R> = {");
     expect(result).toContain("export type GassmaExtendsFn<O extends");
     expect(result).toContain("export type GassmaExtendedClient<O extends");

--- a/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
+++ b/src/__test__/generate/typeGenerate/gassmaExtension.test.ts
@@ -29,20 +29,14 @@ describe("getGassmaExtension", () => {
       '  [M in GassmaHogeModelName | "$allModels"]?: unknown;',
     );
     expect(result).toContain(
-      "export type GassmaHogeResultExtension<R_, RC_, CMap> = {",
+      "export type GassmaHogeResultExtension<R_, CMap> = {",
     );
     expect(result).toContain(
-      "    [F in keyof R_[M]]?: Gassma.ResultField<GassmaHogeResultScalars<M>, R_[M][F], GassmaHogeResultComputedKeys<R_, CMap, M>, GassmaHogeResultComputedTypes<RC_, CMap, M>>;",
+      "    [F in keyof R_[M]]?: Gassma.ResultField<GassmaHogeResultScalars<M>, R_[M][F], GassmaHogeResultComputedKeys<R_, CMap, M>, GassmaHogeResultComputedTypes<CMap, M>>;",
     );
   });
 
   it("should generate computed-needs helper types", () => {
-    expect(result).toContain(
-      "export type GassmaHogeResultComputeSlots<RC_> = {",
-    );
-    expect(result).toContain(
-      "  [M in keyof RC_]?: { [F in keyof RC_[M]]?: { compute: RC_[M][F] } };",
-    );
     expect(result).toContain(
       "export type GassmaHogeResultComputedKeys<R_, CMap, M> =",
     );
@@ -50,11 +44,13 @@ describe("getGassmaExtension", () => {
       '  keyof Gassma.At<R_, M> | keyof Gassma.At<R_, "$allModels"> | keyof Gassma.At<CMap, M>;',
     );
     expect(result).toContain(
-      "export type GassmaHogeResultComputedTypes<RC_, CMap, M> = Gassma.MergeShape<",
+      "export type GassmaHogeResultComputedTypes<CMap, M> = Gassma.At<CMap, M>;",
     );
-    expect(result).toContain(
-      '  Gassma.MergeShape<Gassma.SlotReturns<Gassma.At<RC_, "$allModels">>, Gassma.SlotReturns<Gassma.At<RC_, M>>>',
-    );
+  });
+
+  it("should not reintroduce the RC_ compute-slot channel that clobbers compute param inference", () => {
+    expect(result).not.toContain("ResultComputeSlots");
+    expect(result).not.toContain("RC_");
   });
 
   it("should generate loose ResultConfig for annotations", () => {
@@ -76,11 +72,11 @@ describe("getGassmaExtension", () => {
 
   it("should generate generic ExtendsFn capturing result literal", () => {
     expect(result).toContain(
-      "export type GassmaHogeExtendsFn<O extends GassmaHogeGlobalOmitConfig, CMap> = <R_ extends GassmaHogeResultShape = {}, RC_ extends GassmaHogeResultShape = {}, R extends GassmaHogeResultConfig = {}>(extension: {",
+      "export type GassmaHogeExtendsFn<O extends GassmaHogeGlobalOmitConfig, CMap> = <R_ extends GassmaHogeResultShape = {}, R extends GassmaHogeResultConfig = {}>(extension: {",
     );
     expect(result).toContain("  query?: GassmaHogeQueryExtension<O>;");
     expect(result).toContain(
-      "  result?: GassmaHogeResultExtension<R_, RC_, CMap> & GassmaHogeResultComputeSlots<RC_> & R;",
+      "  result?: GassmaHogeResultExtension<R_, CMap> & R;",
     );
     expect(result).toContain(
       "}) => GassmaHogeExtendedClient<O, GassmaHogeComputedMap<CMap, R>>;",

--- a/src/__test__/types/extends/resultExtends.test-d.ts
+++ b/src/__test__/types/extends/resultExtends.test-d.ts
@@ -41,6 +41,27 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   });
 }
 
+// implicit-any 回帰ガード: 注釈なし compute の param は needs から文脈型付けされ any にならない
+// （any に戻ると toEqualTypeOf は壊れ、@ts-expect-error も未使用になって落ちる。#118 で TS<=5.6 が壊れた回帰）
+{
+  client.$extends({
+    result: {
+      User: {
+        greeting: {
+          needs: { name: true },
+          compute: (user) => {
+            expectTypeOf(user).toEqualTypeOf<{ name: string | null }>();
+            expectTypeOf(user.name).toEqualTypeOf<string | null>();
+            // @ts-expect-error needs 外の email は参照できない（any なら未使用ディレクティブで落ちる）
+            user.email;
+            return `Hi ${user.name}`;
+          },
+        },
+      },
+    },
+  });
+}
+
 // needs にはスカラーと同 extension 内の算出フィールド名だけが書ける
 {
   client.$extends({
@@ -367,22 +388,22 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   expectTypeOf(empty.User.findMany({})[0].id).toEqualTypeOf<number>();
 }
 
-// 算出フィールド依存: 依存先の compute 戻り型が依存元の compute 引数に現れる
+// 同一 call 内の算出フィールド依存: needs キーは通り結果型も正しいが、
+// compute 引数の「値型」は never に縮退する（Prisma と同じ TS 推論の制約。
+// チェーン $extends 越しの依存は下のテストのとおり完全に型が付く）。
 {
   const extended = client.$extends({
     result: {
       User: {
         emailLen: {
           needs: { email: true },
-          compute: (user: { email: string }) => user.email.length,
+          compute: (user) => user.email.length,
         },
         doubledLen: {
           needs: { emailLen: true },
           compute: (user) => {
-            expectTypeOf(user.emailLen).toEqualTypeOf<number>();
-            // @ts-expect-error emailLen は number なので toUpperCase は呼べない
-            user.emailLen.toUpperCase();
-            return user.emailLen * 2;
+            expectTypeOf(user.emailLen).toBeNever();
+            return 2;
           },
         },
       },
@@ -393,7 +414,7 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   expectTypeOf(rows[0].doubledLen).toEqualTypeOf<number>();
 }
 
-// 宣言順非依存: 依存元を依存先より先に宣言しても型が付く
+// 宣言順非依存: 依存元を依存先より後に宣言しても needs キーは通り結果型は正しい（値型は never に縮退）
 {
   const extended = client.$extends({
     result: {
@@ -401,13 +422,13 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
         doubledFirst: {
           needs: { lenLater: true },
           compute: (user) => {
-            expectTypeOf(user.lenLater).toEqualTypeOf<number>();
-            return user.lenLater * 2;
+            expectTypeOf(user.lenLater).toBeNever();
+            return 2;
           },
         },
         lenLater: {
           needs: { email: true },
-          compute: (user: { email: string }) => user.email.length,
+          compute: (user) => user.email.length,
         },
       },
     },
@@ -417,7 +438,7 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   expectTypeOf(rows[0].lenLater).toEqualTypeOf<number>();
 }
 
-// $allModels の算出フィールドへモデル固有算出から依存できる
+// $allModels の算出フィールドをモデル固有算出が同一 call で needs に指定できる（値型は never に縮退、結果型は正しい）
 {
   const extended = client.$extends({
     result: {
@@ -428,8 +449,8 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
         tagged: {
           needs: { tag: true },
           compute: (user) => {
-            expectTypeOf(user.tag).toEqualTypeOf<string>();
-            return `#${user.tag}`;
+            expectTypeOf(user.tag).toBeNever();
+            return "#";
           },
         },
       },
@@ -438,31 +459,6 @@ const omitClient = new GassmaClient({ omit: { User: { email: true } } });
   const rows = extended.User.findMany({});
   expectTypeOf(rows[0].tagged).toEqualTypeOf<string>();
   expectTypeOf(rows[0].tag).toEqualTypeOf<string>();
-}
-
-// 未注釈（context-sensitive）な依存先: needs は通り結果型も正しい。
-// compute 引数の値型のみ TS 推論の限界で never（依存先に注釈を付ければ実型になる）。
-{
-  const extended = client.$extends({
-    result: {
-      User: {
-        rawLen: {
-          needs: { email: true },
-          compute: (user) => user.email.length,
-        },
-        viaRaw: {
-          needs: { rawLen: true },
-          compute: (user) => {
-            expectTypeOf(user.rawLen).toBeNever();
-            return 1;
-          },
-        },
-      },
-    },
-  });
-  const rows = extended.User.findMany({});
-  expectTypeOf(rows[0].rawLen).toEqualTypeOf<number>();
-  expectTypeOf(rows[0].viaRaw).toEqualTypeOf<number>();
 }
 
 // チェーン $extends 越しの算出フィールド依存（Prisma docs パターン）は完全に型が付く

--- a/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -49,9 +49,6 @@ const getGassmaCommonTypes = (strict?: boolean) => {
     [F in keyof Fields]: Fields[F] extends { compute: (...args: never[]) => infer V } ? V : never;
   };
   type ComputedOf<R, M> = MergeShape<ComputedReturns<At<R, "$allModels">>, ComputedReturns<At<R, M>>>;
-  type SlotReturns<Slots> = {
-    [F in keyof Slots]: Slots[F] extends (...args: never[]) => infer V ? V : never;
-  };
   type ResultField<Scalars, S, CKeys extends PropertyKey = never, CTypes = {}> = {
     needs?: { [K in keyof S]: K extends keyof Scalars | CKeys ? S[K] : never } & { [K in keyof Scalars]?: boolean } & { [K in CKeys]?: boolean };
     compute(record: { [K in keyof S as S[K] extends true ? K & (keyof Scalars | CKeys) : never]: K extends keyof CTypes ? CTypes[K] : K extends keyof Scalars ? Scalars[K] : never }): unknown;

--- a/src/generate/typeGenerate/gassmaExtension/resultExtension.ts
+++ b/src/generate/typeGenerate/gassmaExtension/resultExtension.ts
@@ -39,21 +39,14 @@ export type ${prefix}ResultShape = {
   [M in ${prefix}ModelName | "$allModels"]?: unknown;
 };
 
-export type ${prefix}ResultComputeSlots<RC_> = {
-  [M in keyof RC_]?: { [F in keyof RC_[M]]?: { compute: RC_[M][F] } };
-};
-
 export type ${prefix}ResultComputedKeys<R_, CMap, M> =
   keyof Gassma.At<R_, M> | keyof Gassma.At<R_, "$allModels"> | keyof Gassma.At<CMap, M>;
 
-export type ${prefix}ResultComputedTypes<RC_, CMap, M> = Gassma.MergeShape<
-  Gassma.At<CMap, M>,
-  Gassma.MergeShape<Gassma.SlotReturns<Gassma.At<RC_, "$allModels">>, Gassma.SlotReturns<Gassma.At<RC_, M>>>
->;
+export type ${prefix}ResultComputedTypes<CMap, M> = Gassma.At<CMap, M>;
 
-export type ${prefix}ResultExtension<R_, RC_, CMap> = {
+export type ${prefix}ResultExtension<R_, CMap> = {
   [M in keyof R_]: {
-    [F in keyof R_[M]]?: Gassma.ResultField<${prefix}ResultScalars<M>, R_[M][F], ${prefix}ResultComputedKeys<R_, CMap, M>, ${prefix}ResultComputedTypes<RC_, CMap, M>>;
+    [F in keyof R_[M]]?: Gassma.ResultField<${prefix}ResultScalars<M>, R_[M][F], ${prefix}ResultComputedKeys<R_, CMap, M>, ${prefix}ResultComputedTypes<CMap, M>>;
   };
 };
 
@@ -70,9 +63,9 @@ export type ${prefix}ComputedMap<CMap, R> = {
 ${computedMapEntries}
 };
 
-export type ${prefix}ExtendsFn<O extends ${prefix}GlobalOmitConfig, CMap> = <R_ extends ${prefix}ResultShape = {}, RC_ extends ${prefix}ResultShape = {}, R extends ${prefix}ResultConfig = {}>(extension: {
+export type ${prefix}ExtendsFn<O extends ${prefix}GlobalOmitConfig, CMap> = <R_ extends ${prefix}ResultShape = {}, R extends ${prefix}ResultConfig = {}>(extension: {
   query?: ${prefix}QueryExtension<O>;
-  result?: ${prefix}ResultExtension<R_, RC_, CMap> & ${prefix}ResultComputeSlots<RC_> & R;
+  result?: ${prefix}ResultExtension<R_, CMap> & R;
 }) => ${prefix}ExtendedClient<O, ${prefix}ComputedMap<CMap, R>>;
 
 export type ${prefix}ExtendedClient<O extends ${prefix}GlobalOmitConfig = {}, CMap = {}> = {


### PR DESCRIPTION
## 概要

strict tsconfig + **TypeScript 5.4〜5.6** で、Prisma 準拠の自然な書き方:

```ts
client.$extends({ result: { User: { greeting: { needs: { name: true }, compute: (user) => `Hi ${user.name}` } } } })
```

の **注釈なし `compute: (user) => ...` の `user` が implicit any になり TS7006** を出すリグレッションを修正します。

## なぜ見逃されたか(バージョン依存)

- このバグは **TS 5.4〜5.6 でのみ発現**、**TS 5.7+ では TS の推論改善により出ない**
- cli の開発環境は **TS 5.9.3** → `tsc`/`vitest --typecheck` が常に green で**すり抜けていた**
- 利用側の **gassma-test は TS 5.2.2** → TS7006 が顕在化(私が先日ユーザーに示した `compute: (u) => ...` の例そのものが壊れていた)

## 原因

`ExtendsFn` の `result?: ResultExtension<R_, RC_, CMap> & ResultComputeSlots<RC_> & R` のうち、#118 で追加された `ResultComputeSlots<RC_> = { [M]?: { [F]?: { compute: RC_[M][F] } } }` が **`compute` を「裸の型変数への推論サイト」**にしていた。注釈なし arrow の param 推論時にこのサイトが `ResultField` の needs 由来の文脈型付けを先取り・上書きし、param を any に固定していた。

## 修正(Prisma 踏襲・単一チャネル化)

Prisma 本家は `result?: DynamicResultExtensionArgs<R_, TypeMap> & R` の単一チャネルで、compute 引数は具体型(当プロジェクトの `ResultField` 相当)のみで文脈型付けし、compute を裸型変数に推論するチャネルを持ちません。これに合わせ **`RC_` チャネルを完全撤去**(`ResultComputeSlots` / `RC_` ジェネリック / dead な `SlotReturns` を削除)。

## computed→computed 依存の維持/縮退

- **維持**: needs に別算出フィールド名を書ける(`ResultComputedKeys` = scalars ∪ 同モデル算出 ∪ $allModels 算出 ∪ CMap で算出、RC_ 不要)。**チェーン `$extends` 越し依存の戻り型付け(CMap 経由)は完全維持**。結果型も維持
- **縮退**: **同一 `$extends` call 内**の算出→算出依存の**引数値型**が `never` に縮退。ただし Prisma も同一 call 内 sibling は型付けしない(never)ため、**むしろ Prisma parity に一致**。未注釈依存元は #118 でも既に never

## 回帰防止テスト

1. **生成物ガード(バージョン非依存)**: 生成文字列に `ResultComputeSlots` / `RC_` が**含まれないこと**を assert(毒化パターンの再混入を TS バージョンに関係なく検出)
2. **型レベルガード**: 注釈なし compute の param が needs 型(`{ name: string | null }`、any でない)であることを検証 + needs 外アクセスを `@ts-expect-error`

## 検証

- `npm test`: **802 pass** / `npm run test:types`: **802 pass・Type Errors 0** / `tsc --noEmit`: clean / `biome check`(変更5ファイル): clean / `npm run build`: 成功
- 再生成した `client.d.ts`(RC_ 出現 0)に対し、注釈なし compute の使用スニペットを **TS 5.4.5 / 5.5.4 / 5.6.3 / 5.7.3 / 5.8.3 / 5.9.3 全てで `tsc --strict` 実行 → TS7006 ゼロ**

## 後方互換

拡張なし/query-only/スカラーのみ needs/select・omit/nested(#119)/$allModels/チェーン、既存全テスト通過。生成物差分は result 拡張型のシグネチャのみ。

## 提案(別途・承認事項)

完全自動検出には CI に **TS ≤5.6 のマトリクス**追加が望ましい(devDependency 追加を伴うため保留)。生成物ガードはバージョン非依存で再混入を捕捉します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)