### PR TITLE
chore: declare typescript >=5.2 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "engines": {
     "node": ">=20"
   },
+  "peerDependencies": {
+    "typescript": ">=5.2"
+  },
   "dependencies": {
     "@loancrate/prisma-schema-parser": "^3.0.0",
     "@prisma/internals": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
   "peerDependencies": {
     "typescript": ">=5.2"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@loancrate/prisma-schema-parser": "^3.0.0",
     "@prisma/internals": "^7.5.0",


### PR DESCRIPTION
## 概要

gassma-cli の `package.json` に TypeScript の peer 依存を追記します。生成クライアント型は利用者の TypeScript 上で消費されるため、対応 TS を明示します。

```json
"peerDependencies": {
  "typescript": ">=5.2"
},
"peerDependenciesMeta": {
  "typescript": { "optional": true }
}
```

- **下限 `>=5.2`**(ご指示「5.2 から対応」)。**上限なし**: gassma-test が生成型を **TS 7.0.2** で動作させており、生成 .d.ts が TS7 まで消費可能なことを確認済み(TS 5.2 〜 7 対応)
- **optional 化**: TS 未導入の利用者にインストール警告を出さないため(生成型には TS が要るが、ランタイムのクライアントには不要)

## 影響

メタデータのみ。`npm ci` 整合(cli 自身の devDeps typescript ^6.0.3 が peer を満たす)、lock 変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)