### PR TITLE
feat: add gassma debug command (prisma debug parity)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1854,6 +1854,22 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -6079,6 +6095,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.3.2",
         "@types/node": "^22.10.2",
+        "ci-info": "^4.4.0",
         "globals": "^15.13.0",
         "package-manager-detector": "^1.8.0",
         "tsdown": "^0.22.12",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -79,6 +79,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.2",
     "@types/node": "^22.10.2",
+    "ci-info": "^4.4.0",
     "globals": "^15.13.0",
     "package-manager-detector": "^1.8.0",
     "tsdown": "^0.22.12",

--- a/packages/cli/src/__test__/command/debugFlag.test.ts
+++ b/packages/cli/src/__test__/command/debugFlag.test.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const projectRoot = path.resolve(__dirname, "../../..");
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+const commandTs = path.join(projectRoot, "src", "command.ts");
+
+describe("gassma debug (e2e)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "gassma-debug-e2e-")),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it(
+    "should exit 0 in an empty directory and print every section",
+    { timeout: 120_000 },
+    () => {
+      const output = execFileSync(
+        process.execPath,
+        [tsxCli, commandTs, "debug"],
+        { cwd: tmpDir, encoding: "utf-8" },
+      );
+
+      expect(output).toContain("gassma debug — gassma v");
+      expect(output).toContain("No config file found (searched: ");
+      expect(output).toContain("-- Gassma schema --");
+      expect(output).toContain("-- Environment variables --");
+      expect(output).toContain("-- clasp --");
+      expect(output).toContain("-- appsscript.json --");
+      expect(output).toContain("-- Generated client --");
+      expect(output).toContain("-- Terminal is interactive? --");
+      expect(output).toContain("-- CI detected? --");
+    },
+  );
+
+  it("should print help for debug --help", { timeout: 120_000 }, () => {
+    const output = execFileSync(
+      process.execPath,
+      [tsxCli, commandTs, "debug", "--help"],
+      { cwd: tmpDir, encoding: "utf-8" },
+    );
+
+    expect(output).toContain("--schema <path>");
+    expect(output).toContain("--config <path>");
+  });
+});

--- a/packages/cli/src/__test__/debug/appsscriptSection.test.ts
+++ b/packages/cli/src/__test__/debug/appsscriptSection.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+import type { DebugFs } from "../../debug/env/debugFs";
+import {
+  buildAppsscriptLines,
+  collectAppsscriptStatus,
+} from "../../debug/sections/appsscriptSection";
+import { createStyler } from "../../debug/styles";
+
+const plain = createStyler(false);
+
+const GASSMA_LIBRARY_ID =
+  "1ZVuWMUYs4hVKDCcP3nVw74AY48VqLm50wRceKIQLFKL0wf4Hyou-FIBH";
+
+const fakeFs = (files: Record<string, string>): DebugFs => ({
+  exists: (filePath) => filePath in files,
+  readText: (filePath) => {
+    const content = files[filePath];
+    if (content === undefined) throw new Error(`missing: ${filePath}`);
+    return content;
+  },
+  mtimeMs: () => undefined,
+});
+
+const manifest = (overrides: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    timeZone: "Asia/Tokyo",
+    dependencies: {
+      libraries: [
+        {
+          userSymbol: "Gassma",
+          version: "0",
+          libraryId: GASSMA_LIBRARY_ID,
+          developmentMode: true,
+        },
+      ],
+    },
+    runtimeVersion: "V8",
+    ...overrides,
+  });
+
+describe("collectAppsscriptStatus", () => {
+  it("should look under the clasp rootDir first", () => {
+    const status = collectAppsscriptStatus({
+      fs: fakeFs({ "/proj/out/appsscript.json": manifest() }),
+      cwd: "/proj",
+      rootDir: "./out",
+    });
+
+    expect(status.kind).toBe("found");
+    if (status.kind === "found") {
+      expect(status.manifestPath).toBe("/proj/out/appsscript.json");
+      expect(status.runtimeVersion).toBe("V8");
+      expect(status.library).toEqual({
+        userSymbol: "Gassma",
+        version: "0",
+        developmentMode: true,
+      });
+    }
+  });
+
+  it("should fall back to ./dist and then the cwd", () => {
+    const fromDist = collectAppsscriptStatus({
+      fs: fakeFs({ "/proj/dist/appsscript.json": manifest() }),
+      cwd: "/proj",
+      rootDir: undefined,
+    });
+    const fromCwd = collectAppsscriptStatus({
+      fs: fakeFs({ "/proj/appsscript.json": manifest() }),
+      cwd: "/proj",
+      rootDir: undefined,
+    });
+
+    expect(fromDist.kind).toBe("found");
+    if (fromDist.kind === "found") {
+      expect(fromDist.manifestPath).toBe("/proj/dist/appsscript.json");
+    }
+    expect(fromCwd.kind).toBe("found");
+    if (fromCwd.kind === "found") {
+      expect(fromCwd.manifestPath).toBe("/proj/appsscript.json");
+    }
+  });
+
+  it("should report the searched candidates when nothing is found", () => {
+    const status = collectAppsscriptStatus({
+      fs: fakeFs({}),
+      cwd: "/proj",
+      rootDir: "./dist",
+    });
+
+    expect(status).toEqual({
+      kind: "notFound",
+      searched: ["/proj/dist/appsscript.json", "/proj/appsscript.json"],
+    });
+  });
+
+  it("should report a parse error", () => {
+    const status = collectAppsscriptStatus({
+      fs: fakeFs({ "/proj/appsscript.json": "{ broken" }),
+      cwd: "/proj",
+      rootDir: undefined,
+    });
+
+    expect(status).toEqual({
+      kind: "parseError",
+      manifestPath: "/proj/appsscript.json",
+    });
+  });
+
+  it("should find the library by libraryId even when the userSymbol differs", () => {
+    const status = collectAppsscriptStatus({
+      fs: fakeFs({
+        "/proj/appsscript.json": manifest({
+          dependencies: {
+            libraries: [
+              {
+                userSymbol: "MyLib",
+                version: "3",
+                libraryId: GASSMA_LIBRARY_ID,
+                developmentMode: false,
+              },
+            ],
+          },
+        }),
+      }),
+      cwd: "/proj",
+      rootDir: undefined,
+    });
+
+    expect(status.kind).toBe("found");
+    if (status.kind === "found") {
+      expect(status.library).toEqual({
+        userSymbol: "MyLib",
+        version: "3",
+        developmentMode: false,
+      });
+    }
+  });
+
+  it("should fall back to matching by userSymbol Gassma", () => {
+    const status = collectAppsscriptStatus({
+      fs: fakeFs({
+        "/proj/appsscript.json": manifest({
+          dependencies: {
+            libraries: [
+              {
+                userSymbol: "Gassma",
+                version: 7,
+                libraryId: "another-library-id",
+              },
+            ],
+          },
+        }),
+      }),
+      cwd: "/proj",
+      rootDir: undefined,
+    });
+
+    expect(status.kind).toBe("found");
+    if (status.kind === "found") {
+      expect(status.library).toEqual({ userSymbol: "Gassma", version: "7" });
+    }
+  });
+
+  it("should report a missing Gassma library entry", () => {
+    const status = collectAppsscriptStatus({
+      fs: fakeFs({
+        "/proj/appsscript.json": manifest({ dependencies: {} }),
+      }),
+      cwd: "/proj",
+      rootDir: undefined,
+    });
+
+    expect(status.kind).toBe("found");
+    if (status.kind === "found") {
+      expect(status.library).toBeUndefined();
+    }
+  });
+});
+
+describe("buildAppsscriptLines", () => {
+  it("should render a healthy manifest", () => {
+    const lines = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/dist/appsscript.json",
+        runtimeVersion: "V8",
+        library: { userSymbol: "Gassma", version: "0", developmentMode: true },
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- appsscript.json --",
+      "Path: dist/appsscript.json",
+      "runtimeVersion: V8",
+      "Gassma library: found",
+      "- userSymbol: Gassma",
+      "- version: 0",
+      "- developmentMode: true",
+    ]);
+  });
+
+  it("should flag a userSymbol mismatch", () => {
+    const lines = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/appsscript.json",
+        runtimeVersion: "V8",
+        library: { userSymbol: "MyLib", version: "3", developmentMode: false },
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toContain(
+      "- userSymbol: MyLib (expected `Gassma` — generated code references `Gassma.GassmaClient`)",
+    );
+  });
+
+  it("should call out a non-V8 runtime and a missing runtimeVersion", () => {
+    const nonV8 = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/appsscript.json",
+        runtimeVersion: "STABLE",
+        library: undefined,
+      },
+      "/proj",
+      plain,
+    );
+    const unset = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/appsscript.json",
+        runtimeVersion: undefined,
+        library: undefined,
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(nonV8).toContain("runtimeVersion: STABLE (not V8)");
+    expect(unset).toContain("runtimeVersion: not set (not V8)");
+    expect(nonV8).toContain(
+      "Gassma library: not found in dependencies.libraries",
+    );
+  });
+
+  it("should render missing library fields as not set", () => {
+    const lines = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/appsscript.json",
+        runtimeVersion: "V8",
+        library: { userSymbol: "Gassma" },
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toContain("- version: (not set)");
+    expect(lines).toContain("- developmentMode: (not set)");
+  });
+
+  it("should render the searched locations when not found", () => {
+    const lines = buildAppsscriptLines(
+      {
+        kind: "notFound",
+        searched: ["/proj/dist/appsscript.json", "/proj/appsscript.json"],
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- appsscript.json --",
+      "Not found (searched: dist/appsscript.json, appsscript.json)",
+    ]);
+  });
+
+  it("should render a parse error", () => {
+    const lines = buildAppsscriptLines(
+      { kind: "parseError", manifestPath: "/proj/appsscript.json" },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- appsscript.json --",
+      "Path: appsscript.json",
+      "Could not parse appsscript.json",
+    ]);
+  });
+});

--- a/packages/cli/src/__test__/debug/claspSection.test.ts
+++ b/packages/cli/src/__test__/debug/claspSection.test.ts
@@ -1,0 +1,296 @@
+import path from "path";
+import { describe, expect, it } from "vitest";
+import type { DebugFs } from "../../debug/env/debugFs";
+import type { TimedExecFn } from "../../debug/env/execWithTimeout";
+import {
+  buildClaspLines,
+  collectClaspStatus,
+  maskScriptId,
+} from "../../debug/sections/claspSection";
+import { createStyler } from "../../debug/styles";
+
+const plain = createStyler(false);
+
+const fakeFs = (files: Record<string, string>): DebugFs => ({
+  exists: (filePath) => filePath in files,
+  readText: (filePath) => {
+    const content = files[filePath];
+    if (content === undefined) throw new Error(`missing: ${filePath}`);
+    return content;
+  },
+  mtimeMs: () => undefined,
+});
+
+const okExec =
+  (stdout: string): TimedExecFn =>
+  (_command, _args, _timeoutMs) =>
+    Promise.resolve({
+      ok: true,
+      exitCode: 0,
+      stdout,
+      stderr: "",
+      timedOut: false,
+    });
+
+const baseDeps = {
+  homedir: "/home/user",
+  cwd: "/proj",
+  timeoutMs: 3000,
+};
+
+describe("collectClaspStatus", () => {
+  it("should run clasp -v and pick the version from stdout", async () => {
+    const calls: { command: string; args: string[]; timeoutMs: number }[] = [];
+    const exec: TimedExecFn = (command, args, timeoutMs) => {
+      calls.push({ command, args, timeoutMs });
+      return Promise.resolve({
+        ok: true,
+        exitCode: 0,
+        stdout: "3.3.0\n",
+        stderr: "",
+        timedOut: false,
+      });
+    };
+
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec,
+      fs: fakeFs({}),
+    });
+
+    expect(calls).toEqual([
+      { command: "clasp", args: ["-v"], timeoutMs: 3000 },
+    ]);
+    expect(status.version).toEqual({ kind: "found", version: "3.3.0" });
+  });
+
+  it("should report timedOut when clasp -v times out", async () => {
+    const exec: TimedExecFn = () =>
+      Promise.resolve({
+        ok: false,
+        exitCode: null,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+      });
+
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec,
+      fs: fakeFs({}),
+    });
+
+    expect(status.version).toEqual({ kind: "timedOut" });
+  });
+
+  it("should report notFound when clasp cannot be spawned", async () => {
+    const exec: TimedExecFn = () =>
+      Promise.resolve({
+        ok: false,
+        exitCode: null,
+        stdout: "",
+        stderr: "spawn clasp ENOENT",
+        timedOut: false,
+      });
+
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec,
+      fs: fakeFs({}),
+    });
+
+    expect(status.version).toEqual({ kind: "notFound" });
+  });
+
+  it("should report failed when clasp -v exits with a non-zero code", async () => {
+    const exec: TimedExecFn = () =>
+      Promise.resolve({
+        ok: false,
+        exitCode: 1,
+        stdout: "",
+        stderr: "boom",
+        timedOut: false,
+      });
+
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec,
+      fs: fakeFs({}),
+    });
+
+    expect(status.version).toEqual({ kind: "failed" });
+  });
+
+  it("should detect login by the existence of ~/.clasprc.json without reading it", async () => {
+    const clasprcPath = path.join("/home/user", ".clasprc.json");
+    const store = fakeFs({ [clasprcPath]: "SECRET" });
+    const readPaths: string[] = [];
+    const spyFs: DebugFs = {
+      ...store,
+      readText: (filePath) => {
+        readPaths.push(filePath);
+        return store.readText(filePath);
+      },
+    };
+
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec: okExec("3.3.0"),
+      fs: spyFs,
+    });
+
+    expect(status.loggedIn).toBe(true);
+    expect(readPaths).not.toContain(clasprcPath);
+  });
+
+  it("should report not logged in when ~/.clasprc.json is missing", async () => {
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec: okExec("3.3.0"),
+      fs: fakeFs({}),
+    });
+
+    expect(status.loggedIn).toBe(false);
+  });
+
+  it("should read rootDir and scriptId from .clasp.json in the cwd", async () => {
+    const claspJsonPath = path.join("/proj", ".clasp.json");
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec: okExec("3.3.0"),
+      fs: fakeFs({
+        [claspJsonPath]: JSON.stringify({
+          scriptId: "1CpxmbnFDga5jHgY7GPGQxcD41nNvygrAJ8d6hXtAI0nn",
+          rootDir: "./dist",
+        }),
+      }),
+    });
+
+    expect(status.project).toEqual({
+      exists: true,
+      rootDir: "./dist",
+      scriptId: "1CpxmbnFDga5jHgY7GPGQxcD41nNvygrAJ8d6hXtAI0nn",
+    });
+  });
+
+  it("should report a missing .clasp.json", async () => {
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec: okExec("3.3.0"),
+      fs: fakeFs({}),
+    });
+
+    expect(status.project).toEqual({ exists: false });
+  });
+
+  it("should report an unparsable .clasp.json", async () => {
+    const claspJsonPath = path.join("/proj", ".clasp.json");
+    const status = await collectClaspStatus({
+      ...baseDeps,
+      exec: okExec("3.3.0"),
+      fs: fakeFs({ [claspJsonPath]: "{ broken" }),
+    });
+
+    expect(status.project).toEqual({ exists: true, parseError: true });
+  });
+});
+
+describe("maskScriptId", () => {
+  it("should keep only the first four characters", () => {
+    expect(maskScriptId("1CpxmbnFDga5jHgY7GPGQ")).toBe("1Cpx…");
+  });
+
+  it("should not reveal a short id beyond its first four characters", () => {
+    expect(maskScriptId("1Cp")).toBe("1Cp…");
+  });
+});
+
+describe("buildClaspLines", () => {
+  it("should render a fully working environment", () => {
+    const lines = buildClaspLines(
+      {
+        version: { kind: "found", version: "3.3.0" },
+        loggedIn: true,
+        project: {
+          exists: true,
+          rootDir: "./dist",
+          scriptId: "1CpxmbnFDga5jHgY7GPGQ",
+        },
+      },
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- clasp --",
+      "clasp: found in PATH (version 3.3.0)",
+      "Auth: logged in (~/.clasprc.json exists)",
+      "Project: .clasp.json found (rootDir: ./dist, scriptId: 1Cpx…)",
+    ]);
+  });
+
+  it("should render a machine without clasp", () => {
+    const lines = buildClaspLines(
+      {
+        version: { kind: "notFound" },
+        loggedIn: false,
+        project: { exists: false },
+      },
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- clasp --",
+      "clasp: not detected (not found in PATH)",
+      "Auth: not logged in (~/.clasprc.json not found)",
+      "Project: .clasp.json not found",
+    ]);
+  });
+
+  it("should render timeout and failure as not detected", () => {
+    const timedOut = buildClaspLines(
+      {
+        version: { kind: "timedOut" },
+        loggedIn: false,
+        project: { exists: false },
+      },
+      plain,
+    );
+    const failed = buildClaspLines(
+      {
+        version: { kind: "failed" },
+        loggedIn: false,
+        project: { exists: false },
+      },
+      plain,
+    );
+
+    expect(timedOut[1]).toBe("clasp: not detected (`clasp -v` timed out)");
+    expect(failed[1]).toBe("clasp: not detected (`clasp -v` failed)");
+  });
+
+  it("should render a parse error and missing fields of .clasp.json", () => {
+    const parseError = buildClaspLines(
+      {
+        version: { kind: "found", version: "3.3.0" },
+        loggedIn: true,
+        project: { exists: true, parseError: true },
+      },
+      plain,
+    );
+    const noFields = buildClaspLines(
+      {
+        version: { kind: "found", version: "3.3.0" },
+        loggedIn: true,
+        project: { exists: true },
+      },
+      plain,
+    );
+
+    expect(parseError[3]).toBe(
+      "Project: .clasp.json found (could not be parsed)",
+    );
+    expect(noFields[3]).toBe(
+      "Project: .clasp.json found (rootDir: (not set), scriptId: (not set))",
+    );
+  });
+});

--- a/packages/cli/src/__test__/debug/configSection.test.ts
+++ b/packages/cli/src/__test__/debug/configSection.test.ts
@@ -1,0 +1,78 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildConfigLine,
+  collectConfigStatus,
+} from "../../debug/sections/configSection";
+
+describe("collectConfigStatus", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(fs.mkdtempSync(path.join(os.tmpdir(), "gassma-debug-conf-")));
+    tmpDir = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should report loaded with the config file path", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma.config.ts"),
+      `export default { schema: "gassma" };`,
+    );
+
+    const status = collectConfigStatus(undefined);
+
+    expect(status).toEqual({
+      kind: "loaded",
+      filePath: path.join(tmpDir, "gassma.config.ts"),
+    });
+  });
+
+  it("should report notFound when no config file exists", () => {
+    expect(collectConfigStatus(undefined)).toEqual({ kind: "notFound" });
+  });
+
+  it("should report a one-line error when the config cannot be loaded", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma.config.ts"),
+      `export default { schema: 123 };`,
+    );
+
+    const status = collectConfigStatus(undefined);
+
+    expect(status.kind).toBe("error");
+    if (status.kind === "error") {
+      expect(status.message).not.toContain("\n");
+      expect(status.message).toContain("GASsmaConfigLoadError");
+    }
+  });
+
+  it("should report an error when --config points to a missing file", () => {
+    const status = collectConfigStatus("missing.config.ts");
+
+    expect(status.kind).toBe("error");
+  });
+});
+
+describe("buildConfigLine", () => {
+  it("should describe the searched locations when no config is found", () => {
+    expect(buildConfigLine({ kind: "notFound" })).toBe(
+      "No config file found (searched: gassma.config.{js,ts,mjs,cjs,mts,cts}, " +
+        ".config/gassma.{js,ts,mjs,cjs,mts,cts})",
+    );
+  });
+
+  it("should describe a load error in one line", () => {
+    expect(buildConfigLine({ kind: "error", message: "boom" })).toBe(
+      "Failed to load config: boom",
+    );
+  });
+});

--- a/packages/cli/src/__test__/debug/debugCommand.test.ts
+++ b/packages/cli/src/__test__/debug/debugCommand.test.ts
@@ -1,0 +1,201 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { debugCommand } from "../../debug/debugCommand";
+import type { TimedExecFn } from "../../debug/env/execWithTimeout";
+import { getVersion } from "../../version/getVersion";
+
+const claspExec =
+  (stdout: string): TimedExecFn =>
+  () =>
+    Promise.resolve({
+      ok: true,
+      exitCode: 0,
+      stdout,
+      stderr: "",
+      timedOut: false,
+    });
+
+const noClaspExec: TimedExecFn = () =>
+  Promise.resolve({
+    ok: false,
+    exitCode: null,
+    stdout: "",
+    stderr: "spawn clasp ENOENT",
+    timedOut: false,
+  });
+
+const SCHEMA_TEXT = `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+
+describe("debugCommand", () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let originalCwd: string;
+  let logged: string[];
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(fs.mkdtempSync(path.join(os.tmpdir(), "gassma-debug-cmd-")));
+    tmpDir = process.cwd();
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-debug-home-"));
+    logged = [];
+    vi.spyOn(console, "log").mockImplementation((line: unknown) => {
+      logged.push(String(line));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  const baseOverrides = () => ({
+    env: {},
+    homedir: homeDir,
+    stdinIsTty: false,
+    stdoutIsTty: false,
+  });
+
+  it("should render every section for a fully set up project", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma.config.ts"),
+      `export default { schema: "gassma" };`,
+    );
+    fs.mkdirSync(path.join(tmpDir, "gassma"));
+    fs.writeFileSync(path.join(tmpDir, "gassma", "schema.prisma"), SCHEMA_TEXT);
+    fs.mkdirSync(path.join(tmpDir, "generated"));
+    fs.writeFileSync(path.join(tmpDir, "generated", "schemaClient.js"), "js");
+    fs.writeFileSync(path.join(tmpDir, "generated", "schemaClient.d.ts"), "ts");
+    fs.writeFileSync(
+      path.join(tmpDir, ".clasp.json"),
+      JSON.stringify({ scriptId: "1CpxSecretSecret", rootDir: "./out" }),
+    );
+    fs.mkdirSync(path.join(tmpDir, "out"));
+    fs.writeFileSync(
+      path.join(tmpDir, "out", "appsscript.json"),
+      JSON.stringify({
+        runtimeVersion: "V8",
+        dependencies: {
+          libraries: [
+            {
+              userSymbol: "Gassma",
+              version: "12",
+              libraryId:
+                "1ZVuWMUYs4hVKDCcP3nVw74AY48VqLm50wRceKIQLFKL0wf4Hyou-FIBH",
+            },
+          ],
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(homeDir, ".clasprc.json"), "{}");
+
+    await debugCommand({}, { ...baseOverrides(), exec: claspExec("3.3.0\n") });
+
+    const output = logged.join("\n");
+    expect(logged[0]).toBe(`gassma debug — gassma v${getVersion()}`);
+    expect(output).toContain("⚙️ Loaded config from gassma.config.ts");
+    expect(output).toContain("-- Gassma schema --");
+    expect(output).toContain(
+      `Path: ${path.join(tmpDir, "gassma", "schema.prisma")}`,
+    );
+    expect(output).toContain("Preview features: (none)");
+    expect(output).toContain("-- Environment variables --");
+    expect(output).toContain("For general debugging");
+    expect(output).toContain("- CI:");
+    expect(output).toContain("-- clasp --");
+    expect(output).toContain("clasp: found in PATH (version 3.3.0)");
+    expect(output).toContain("Auth: logged in (~/.clasprc.json exists)");
+    expect(output).toContain(
+      "Project: .clasp.json found (rootDir: ./out, scriptId: 1Cpx…)",
+    );
+    expect(output).not.toContain("1CpxSecretSecret");
+    expect(output).toContain("-- appsscript.json --");
+    expect(output).toContain(`Path: ${path.join("out", "appsscript.json")}`);
+    expect(output).toContain("runtimeVersion: V8");
+    expect(output).toContain("- version: 12");
+    expect(output).toContain("-- Generated client --");
+    expect(output).toContain("Output: generated");
+    expect(output).toContain("schemaClient.js: found");
+    expect(output).toContain("Status: up to date");
+    expect(output).toContain("-- Terminal is interactive? --");
+    expect(output).toContain("-- CI detected? --");
+  });
+
+  it("should complete with informative lines in an empty directory", async () => {
+    await debugCommand({}, { ...baseOverrides(), exec: noClaspExec });
+
+    const output = logged.join("\n");
+    expect(output).toContain("No config file found (searched: ");
+    expect(output).toContain("Could not resolve schema: ");
+    expect(output).toContain("clasp: not detected (not found in PATH)");
+    expect(output).toContain("Auth: not logged in (~/.clasprc.json not found)");
+    expect(output).toContain("Project: .clasp.json not found");
+    expect(output).toContain("Not found (searched: ");
+    expect(output).toContain("Skipped (schema not found)");
+  });
+
+  it("should reflect the injected environment variables", async () => {
+    await debugCommand(
+      {},
+      {
+        ...baseOverrides(),
+        env: { CI: "true", TERM: "dumb" },
+        exec: noClaspExec,
+        stdinIsTty: true,
+      },
+    );
+
+    const output = logged.join("\n");
+    expect(output).toContain("- CI: `true`");
+    expect(output).toContain("- TERM: `dumb`");
+    const interactiveIndex = logged.indexOf("-- Terminal is interactive? --");
+    expect(logged[interactiveIndex + 1]).toBe("false");
+    const ciIndex = logged.indexOf("-- CI detected? --");
+    expect(logged[ciIndex + 1]).toBe("true");
+  });
+
+  it("should not throw even when the exec dependency rejects", async () => {
+    const rejectingExec: TimedExecFn = () => Promise.reject(new Error("boom"));
+
+    await expect(
+      debugCommand({}, { ...baseOverrides(), exec: rejectingExec }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should honor the --config option", async () => {
+    fs.mkdirSync(path.join(tmpDir, "conf", "schemas"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "conf", "schemas", "main.prisma"),
+      SCHEMA_TEXT,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "conf", "custom.config.ts"),
+      `export default { schema: "schemas/main.prisma" };`,
+    );
+
+    await debugCommand(
+      { config: "conf/custom.config.ts" },
+      { ...baseOverrides(), exec: noClaspExec },
+    );
+
+    const output = logged.join("\n");
+    expect(output).toContain(
+      `⚙️ Loaded config from ${path.join("conf", "custom.config.ts")}`,
+    );
+    expect(output).toContain(
+      `Path: ${path.join(tmpDir, "conf", "schemas", "main.prisma")}`,
+    );
+  });
+});

--- a/packages/cli/src/__test__/debug/debugCommand.test.ts
+++ b/packages/cli/src/__test__/debug/debugCommand.test.ts
@@ -66,6 +66,7 @@ describe("debugCommand", () => {
     homedir: homeDir,
     stdinIsTty: false,
     stdoutIsTty: false,
+    detectCi: () => false,
   });
 
   it("should render every section for a fully set up project", async () => {
@@ -146,7 +147,7 @@ describe("debugCommand", () => {
     expect(output).toContain("Skipped (schema not found)");
   });
 
-  it("should reflect the injected environment variables", async () => {
+  it("should reflect the injected environment and CI detector", async () => {
     await debugCommand(
       {},
       {
@@ -154,6 +155,7 @@ describe("debugCommand", () => {
         env: { CI: "true", TERM: "dumb" },
         exec: noClaspExec,
         stdinIsTty: true,
+        detectCi: () => true,
       },
     );
 

--- a/packages/cli/src/__test__/debug/debugFs.test.ts
+++ b/packages/cli/src/__test__/debug/debugFs.test.ts
@@ -1,0 +1,41 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDebugFs } from "../../debug/env/debugFs";
+
+describe("createDebugFs", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-debug-fs-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should report existence and read text", () => {
+    const filePath = path.join(tmpDir, "a.txt");
+    fs.writeFileSync(filePath, "hello");
+    const debugFs = createDebugFs();
+
+    expect(debugFs.exists(filePath)).toBe(true);
+    expect(debugFs.exists(path.join(tmpDir, "missing.txt"))).toBe(false);
+    expect(debugFs.readText(filePath)).toBe("hello");
+  });
+
+  it("should return the mtime in milliseconds for an existing file", () => {
+    const filePath = path.join(tmpDir, "a.txt");
+    fs.writeFileSync(filePath, "hello");
+    const debugFs = createDebugFs();
+
+    expect(debugFs.mtimeMs(filePath)).toBe(fs.statSync(filePath).mtimeMs);
+  });
+
+  it("should return undefined mtime for a missing file", () => {
+    const debugFs = createDebugFs();
+
+    expect(debugFs.mtimeMs(path.join(tmpDir, "missing.txt"))).toBeUndefined();
+  });
+});

--- a/packages/cli/src/__test__/debug/detectCi.test.ts
+++ b/packages/cli/src/__test__/debug/detectCi.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ci-info's vendor table is not re-tested here; these probes only prove
+// the wiring: detectCi reflects ci-info's env-based detection, which the
+// old CI-variable check could not (e.g. TeamCity sets no CI variable).
+const freshDetectCi = async (): Promise<() => boolean> => {
+  vi.resetModules();
+  const module = await import("../../debug/env/detectCi");
+  return module.detectCi;
+};
+
+describe("detectCi", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("should detect TeamCity via TEAMCITY_VERSION without the CI variable", async () => {
+    vi.stubEnv("CI", undefined);
+    vi.stubEnv("GITHUB_ACTIONS", undefined);
+    vi.stubEnv("TEAMCITY_VERSION", "2025.07");
+
+    const detectCi = await freshDetectCi();
+
+    expect(detectCi()).toBe(true);
+  });
+
+  it("should stay false when no CI indicator is present", async () => {
+    vi.stubEnv("CI", undefined);
+    vi.stubEnv("GITHUB_ACTIONS", undefined);
+    vi.stubEnv("TEAMCITY_VERSION", undefined);
+
+    const detectCi = await freshDetectCi();
+
+    expect(detectCi()).toBe(false);
+  });
+});

--- a/packages/cli/src/__test__/debug/envVarsSection.test.ts
+++ b/packages/cli/src/__test__/debug/envVarsSection.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { buildEnvVarsLines } from "../../debug/sections/envVarsSection";
+import { createStyler } from "../../debug/styles";
+
+const plain = createStyler(false);
+
+describe("buildEnvVarsLines", () => {
+  it("should start with the heading and the two description lines", () => {
+    const lines = buildEnvVarsLines({}, plain);
+
+    expect(lines[0]).toBe("-- Environment variables --");
+    expect(lines[1]).toBe(
+      "When not set, the line is dimmed and no value is displayed.",
+    );
+    expect(lines[2]).toBe(
+      "When set, the line is bold and the value is inside the `` backticks.",
+    );
+    expect(lines[3]).toBe("");
+    expect(lines[4]).toBe("For general debugging");
+  });
+
+  it("should list the general debugging variables in the fixed order", () => {
+    const lines = buildEnvVarsLines({}, plain);
+
+    expect(lines.slice(5)).toEqual([
+      "- CI:",
+      "- DEBUG:",
+      "- NODE_ENV:",
+      "- NO_COLOR:",
+      "- TERM:",
+      "- NODE_TLS_REJECT_UNAUTHORIZED:",
+      "- NO_PROXY:",
+      "- http_proxy:",
+      "- HTTP_PROXY:",
+      "- https_proxy:",
+      "- HTTPS_PROXY:",
+    ]);
+  });
+
+  it("should show set variables with their value inside backticks", () => {
+    const lines = buildEnvVarsLines({ TERM: "xterm-256color" }, plain);
+
+    expect(lines).toContain("- TERM: `xterm-256color`");
+  });
+
+  it("should dim unset variables and bold set variables", () => {
+    const styler = createStyler(true);
+    const lines = buildEnvVarsLines({ TERM: "dumb" }, styler);
+
+    expect(lines).toContain("\u001b[2m- CI:\u001b[22m");
+    expect(lines).toContain("\u001b[1m- TERM: `dumb`\u001b[22m");
+  });
+
+  it("should treat an empty string value as unset", () => {
+    const lines = buildEnvVarsLines({ DEBUG: "" }, plain);
+
+    expect(lines).toContain("- DEBUG:");
+    expect(lines).not.toContain("- DEBUG: ``");
+  });
+});

--- a/packages/cli/src/__test__/debug/execWithTimeout.test.ts
+++ b/packages/cli/src/__test__/debug/execWithTimeout.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { createTimedExec } from "../../debug/env/execWithTimeout";
+
+describe("createTimedExec", () => {
+  it("should capture stdout of a fast command", async () => {
+    const exec = createTimedExec();
+
+    const result = await exec(
+      process.execPath,
+      ["-e", "console.log('hi')"],
+      5000,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.stdout).toContain("hi");
+  });
+
+  it("should time out a slow command and report timedOut", async () => {
+    const exec = createTimedExec();
+
+    const result = await exec(
+      process.execPath,
+      ["-e", "setTimeout(() => {}, 10000)"],
+      200,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(true);
+  });
+
+  it("should report a spawn failure without timing out", async () => {
+    const exec = createTimedExec();
+
+    const result = await exec("gassma-no-such-command-xyz", [], 5000);
+
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(null);
+  });
+
+  it("should report a non-zero exit as not ok with the exit code", async () => {
+    const exec = createTimedExec();
+
+    const result = await exec(
+      process.execPath,
+      ["-e", "process.exit(3)"],
+      5000,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(3);
+  });
+});

--- a/packages/cli/src/__test__/debug/firstLine.test.ts
+++ b/packages/cli/src/__test__/debug/firstLine.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { firstLine } from "../../debug/util/firstLine";
+
+describe("firstLine", () => {
+  it("should return a single-line string as is", () => {
+    expect(firstLine("hello")).toBe("hello");
+  });
+
+  it("should return only the first line of a multi-line string", () => {
+    expect(firstLine("first\nsecond\nthird")).toBe("first");
+  });
+
+  it("should trim trailing carriage returns", () => {
+    expect(firstLine("first\r\nsecond")).toBe("first");
+  });
+});

--- a/packages/cli/src/__test__/debug/generatedClientSection.test.ts
+++ b/packages/cli/src/__test__/debug/generatedClientSection.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import type { DebugFs } from "../../debug/env/debugFs";
+import {
+  buildGeneratedClientLines,
+  collectGeneratedClientStatus,
+} from "../../debug/sections/generatedClientSection";
+import type { SchemaStatus } from "../../debug/sections/schemaSection";
+import { createStyler } from "../../debug/styles";
+
+const plain = createStyler(false);
+
+const SCHEMA_TEXT = `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated"
+}
+
+model User {
+  id Int @id
+}
+`;
+
+const foundSchema = (
+  overrides: Partial<{
+    mergedText: string;
+    schemaName: string;
+    files: { filePath: string; displayName: string }[];
+  }> = {},
+): SchemaStatus => ({
+  kind: "found",
+  files: overrides.files ?? [
+    { filePath: "/proj/gassma/schema.prisma", displayName: "schema.prisma" },
+  ],
+  baseDir: "/proj/gassma",
+  schemaName: overrides.schemaName ?? "Schema",
+  mergedText: overrides.mergedText ?? SCHEMA_TEXT,
+  previewFeatures: [],
+});
+
+const fakeFs = (mtimes: Record<string, number>): DebugFs => ({
+  exists: (filePath) => filePath in mtimes,
+  readText: () => {
+    throw new Error("readText should not be called");
+  },
+  mtimeMs: (filePath) => mtimes[filePath],
+});
+
+describe("collectGeneratedClientStatus", () => {
+  it("should skip when the schema could not be resolved", () => {
+    const status = collectGeneratedClientStatus(
+      { fs: fakeFs({}), cwd: "/proj" },
+      { kind: "error", message: "nope" },
+    );
+
+    expect(status).toEqual({ kind: "skipped" });
+  });
+
+  it("should report a missing output path", () => {
+    const status = collectGeneratedClientStatus(
+      { fs: fakeFs({}), cwd: "/proj" },
+      foundSchema({ mergedText: "model User {\n  id Int @id\n}\n" }),
+    );
+
+    expect(status).toEqual({ kind: "noOutput" });
+  });
+
+  it("should resolve the generated file paths from the schema name", () => {
+    const status = collectGeneratedClientStatus(
+      {
+        fs: fakeFs({
+          "/proj/gassma/schema.prisma": 100,
+          "/proj/generated/schemaClient.js": 200,
+          "/proj/generated/schemaClient.d.ts": 200,
+        }),
+        cwd: "/proj",
+      },
+      foundSchema(),
+    );
+
+    expect(status).toEqual({
+      kind: "resolved",
+      outputDir: "/proj/generated",
+      jsName: "schemaClient.js",
+      dtsName: "schemaClient.d.ts",
+      jsExists: true,
+      dtsExists: true,
+      stale: false,
+    });
+  });
+
+  it("should mark the client possibly stale when the schema is newer", () => {
+    const status = collectGeneratedClientStatus(
+      {
+        fs: fakeFs({
+          "/proj/gassma/schema.prisma": 300,
+          "/proj/generated/schemaClient.js": 200,
+          "/proj/generated/schemaClient.d.ts": 250,
+        }),
+        cwd: "/proj",
+      },
+      foundSchema(),
+    );
+
+    expect(status.kind).toBe("resolved");
+    if (status.kind === "resolved") {
+      expect(status.stale).toBe(true);
+    }
+  });
+
+  it("should leave staleness undefined when a generated file is missing", () => {
+    const status = collectGeneratedClientStatus(
+      {
+        fs: fakeFs({
+          "/proj/gassma/schema.prisma": 100,
+          "/proj/generated/schemaClient.js": 200,
+        }),
+        cwd: "/proj",
+      },
+      foundSchema(),
+    );
+
+    expect(status.kind).toBe("resolved");
+    if (status.kind === "resolved") {
+      expect(status.jsExists).toBe(true);
+      expect(status.dtsExists).toBe(false);
+      expect(status.stale).toBeUndefined();
+    }
+  });
+
+  it("should lower-case the first letter of the schema name for file names", () => {
+    const status = collectGeneratedClientStatus(
+      {
+        fs: fakeFs({}),
+        cwd: "/proj",
+      },
+      foundSchema({ schemaName: "Gassma" }),
+    );
+
+    expect(status.kind).toBe("resolved");
+    if (status.kind === "resolved") {
+      expect(status.jsName).toBe("gassmaClient.js");
+      expect(status.dtsName).toBe("gassmaClient.d.ts");
+    }
+  });
+});
+
+describe("buildGeneratedClientLines", () => {
+  it("should render an up-to-date client", () => {
+    const lines = buildGeneratedClientLines(
+      {
+        kind: "resolved",
+        outputDir: "/proj/generated",
+        jsName: "schemaClient.js",
+        dtsName: "schemaClient.d.ts",
+        jsExists: true,
+        dtsExists: true,
+        stale: false,
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- Generated client --",
+      "Output: generated",
+      "schemaClient.js: found",
+      "schemaClient.d.ts: found",
+      "Status: up to date",
+    ]);
+  });
+
+  it("should render the possibly-stale info line", () => {
+    const lines = buildGeneratedClientLines(
+      {
+        kind: "resolved",
+        outputDir: "/proj/generated",
+        jsName: "schemaClient.js",
+        dtsName: "schemaClient.d.ts",
+        jsExists: true,
+        dtsExists: true,
+        stale: true,
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toContain(
+      "Status: possibly stale (schema is newer than the generated client — run `gassma generate`)",
+    );
+  });
+
+  it("should render missing files without a status line", () => {
+    const lines = buildGeneratedClientLines(
+      {
+        kind: "resolved",
+        outputDir: "/proj/generated",
+        jsName: "schemaClient.js",
+        dtsName: "schemaClient.d.ts",
+        jsExists: false,
+        dtsExists: false,
+        stale: undefined,
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- Generated client --",
+      "Output: generated",
+      "schemaClient.js: not found",
+      "schemaClient.d.ts: not found",
+    ]);
+  });
+
+  it("should render skipped and noOutput cases", () => {
+    expect(
+      buildGeneratedClientLines({ kind: "skipped" }, "/proj", plain),
+    ).toEqual(["-- Generated client --", "Skipped (schema not found)"]);
+    expect(
+      buildGeneratedClientLines({ kind: "noOutput" }, "/proj", plain),
+    ).toEqual([
+      "-- Generated client --",
+      "Output path not found in the generator block",
+    ]);
+  });
+});

--- a/packages/cli/src/__test__/debug/runtimeSection.test.ts
+++ b/packages/cli/src/__test__/debug/runtimeSection.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   buildCiLines,
   buildInteractiveLines,
-  isCiEnv,
   isInteractive,
 } from "../../debug/sections/runtimeSection";
 import { createStyler } from "../../debug/styles";
@@ -24,25 +23,6 @@ describe("isInteractive", () => {
 
   it("should be false when TERM is dumb", () => {
     expect(isInteractive(true, "dumb")).toBe(false);
-  });
-});
-
-describe("isCiEnv", () => {
-  it("should be false when CI is not set", () => {
-    expect(isCiEnv(undefined)).toBe(false);
-  });
-
-  it("should be false when CI is empty", () => {
-    expect(isCiEnv("")).toBe(false);
-  });
-
-  it("should be false when CI is the string false", () => {
-    expect(isCiEnv("false")).toBe(false);
-  });
-
-  it("should be true when CI is truthy", () => {
-    expect(isCiEnv("true")).toBe(true);
-    expect(isCiEnv("1")).toBe(true);
   });
 });
 

--- a/packages/cli/src/__test__/debug/runtimeSection.test.ts
+++ b/packages/cli/src/__test__/debug/runtimeSection.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCiLines,
+  buildInteractiveLines,
+  isCiEnv,
+  isInteractive,
+} from "../../debug/sections/runtimeSection";
+import { createStyler } from "../../debug/styles";
+
+const plain = createStyler(false);
+
+describe("isInteractive", () => {
+  it("should be true for a TTY stdin with a normal TERM", () => {
+    expect(isInteractive(true, "xterm-256color")).toBe(true);
+  });
+
+  it("should be true for a TTY stdin without TERM", () => {
+    expect(isInteractive(true, undefined)).toBe(true);
+  });
+
+  it("should be false when stdin is not a TTY", () => {
+    expect(isInteractive(false, "xterm-256color")).toBe(false);
+  });
+
+  it("should be false when TERM is dumb", () => {
+    expect(isInteractive(true, "dumb")).toBe(false);
+  });
+});
+
+describe("isCiEnv", () => {
+  it("should be false when CI is not set", () => {
+    expect(isCiEnv(undefined)).toBe(false);
+  });
+
+  it("should be false when CI is empty", () => {
+    expect(isCiEnv("")).toBe(false);
+  });
+
+  it("should be false when CI is the string false", () => {
+    expect(isCiEnv("false")).toBe(false);
+  });
+
+  it("should be true when CI is truthy", () => {
+    expect(isCiEnv("true")).toBe(true);
+    expect(isCiEnv("1")).toBe(true);
+  });
+});
+
+describe("buildInteractiveLines", () => {
+  it("should render the heading and the boolean value", () => {
+    expect(buildInteractiveLines(true, plain)).toEqual([
+      "-- Terminal is interactive? --",
+      "true",
+    ]);
+    expect(buildInteractiveLines(false, plain)).toEqual([
+      "-- Terminal is interactive? --",
+      "false",
+    ]);
+  });
+});
+
+describe("buildCiLines", () => {
+  it("should render the heading and the boolean value", () => {
+    expect(buildCiLines(false, plain)).toEqual(["-- CI detected? --", "false"]);
+    expect(buildCiLines(true, plain)).toEqual(["-- CI detected? --", "true"]);
+  });
+});

--- a/packages/cli/src/__test__/debug/schemaSection.test.ts
+++ b/packages/cli/src/__test__/debug/schemaSection.test.ts
@@ -1,0 +1,175 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildSchemaLines,
+  collectSchemaStatus,
+} from "../../debug/sections/schemaSection";
+import { createStyler } from "../../debug/styles";
+
+const plain = createStyler(false);
+
+const SCHEMA_WITH_OUTPUT = `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+
+describe("collectSchemaStatus", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(
+      fs.mkdtempSync(path.join(os.tmpdir(), "gassma-debug-schema-")),
+    );
+    tmpDir = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should resolve a single schema file from the default directory", () => {
+    fs.mkdirSync(path.join(tmpDir, "gassma"));
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma", "schema.prisma"),
+      SCHEMA_WITH_OUTPUT,
+    );
+
+    const status = collectSchemaStatus({});
+
+    expect(status.kind).toBe("found");
+    if (status.kind === "found") {
+      expect(status.files).toHaveLength(1);
+      expect(status.schemaName).toBe("Schema");
+      expect(status.previewFeatures).toEqual([]);
+      expect(status.mergedText).toContain("model User");
+    }
+  });
+
+  it("should resolve multiple schema files and derive the name from the directory", () => {
+    fs.mkdirSync(path.join(tmpDir, "gassma"));
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma", "a.prisma"),
+      SCHEMA_WITH_OUTPUT,
+    );
+    fs.writeFileSync(path.join(tmpDir, "gassma", "b.prisma"), "model B { }\n");
+
+    const status = collectSchemaStatus({});
+
+    expect(status.kind).toBe("found");
+    if (status.kind === "found") {
+      expect(status.files).toHaveLength(2);
+      expect(status.schemaName).toBe("Gassma");
+    }
+  });
+
+  it("should extract preview features from the schema", () => {
+    fs.mkdirSync(path.join(tmpDir, "gassma"));
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma", "schema.prisma"),
+      `generator client {
+  provider        = "prisma-client-js"
+  output          = "./generated"
+  previewFeatures = ["strictUndefinedChecks"]
+}
+`,
+    );
+
+    const status = collectSchemaStatus({});
+
+    expect(status.kind).toBe("found");
+    if (status.kind === "found") {
+      expect(status.previewFeatures).toEqual(["strictUndefinedChecks"]);
+    }
+  });
+
+  it("should fall back to empty preview features when the schema cannot be parsed", () => {
+    fs.mkdirSync(path.join(tmpDir, "gassma"));
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma", "schema.prisma"),
+      "model Broken {",
+    );
+
+    const status = collectSchemaStatus({});
+
+    expect(status.kind).toBe("found");
+    if (status.kind === "found") {
+      expect(status.previewFeatures).toEqual([]);
+    }
+  });
+
+  it("should report a one-line error when the schema directory is missing", () => {
+    const status = collectSchemaStatus({});
+
+    expect(status.kind).toBe("error");
+    if (status.kind === "error") {
+      expect(status.message).not.toContain("\n");
+      expect(status.message).toContain("directory not found");
+    }
+  });
+});
+
+describe("buildSchemaLines", () => {
+  it("should list one Path line per schema file plus preview features", () => {
+    const lines = buildSchemaLines(
+      {
+        kind: "found",
+        files: [
+          { filePath: "/abs/gassma/a.prisma", displayName: "a.prisma" },
+          { filePath: "/abs/gassma/b.prisma", displayName: "b.prisma" },
+        ],
+        baseDir: "/abs/gassma",
+        schemaName: "Gassma",
+        mergedText: "",
+        previewFeatures: ["strictUndefinedChecks"],
+      },
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- Gassma schema --",
+      "Path: /abs/gassma/a.prisma",
+      "Path: /abs/gassma/b.prisma",
+      "Preview features: strictUndefinedChecks",
+    ]);
+  });
+
+  it("should dim the preview features line when none are set", () => {
+    const styler = createStyler(true);
+    const lines = buildSchemaLines(
+      {
+        kind: "found",
+        files: [{ filePath: "/abs/gassma/a.prisma", displayName: "a.prisma" }],
+        baseDir: "/abs/gassma",
+        schemaName: "A",
+        mergedText: "",
+        previewFeatures: [],
+      },
+      styler,
+    );
+
+    expect(lines[2]).toBe("\u001b[2mPreview features: (none)\u001b[22m");
+  });
+
+  it("should render the not-found message on error", () => {
+    const lines = buildSchemaLines(
+      { kind: "error", message: "./gassma/ directory not found." },
+      plain,
+    );
+
+    expect(lines).toEqual([
+      "-- Gassma schema --",
+      "Could not resolve schema: ./gassma/ directory not found.",
+    ]);
+  });
+});

--- a/packages/cli/src/__test__/debug/styles.test.ts
+++ b/packages/cli/src/__test__/debug/styles.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createStyler, resolveColorEnabled } from "../../debug/styles";
+
+describe("createStyler", () => {
+  it("should wrap headings with underline codes when enabled", () => {
+    const styler = createStyler(true);
+    expect(styler.heading("-- X --")).toBe("\u001b[4m-- X --\u001b[24m");
+  });
+
+  it("should wrap dim text with dim codes when enabled", () => {
+    const styler = createStyler(true);
+    expect(styler.dim("- CI:")).toBe("\u001b[2m- CI:\u001b[22m");
+  });
+
+  it("should wrap bold text with bold codes when enabled", () => {
+    const styler = createStyler(true);
+    expect(styler.bold("- TERM: `x`")).toBe("\u001b[1m- TERM: `x`\u001b[22m");
+  });
+
+  it("should return plain text when disabled", () => {
+    const styler = createStyler(false);
+    expect(styler.heading("-- X --")).toBe("-- X --");
+    expect(styler.dim("- CI:")).toBe("- CI:");
+    expect(styler.bold("- TERM:")).toBe("- TERM:");
+  });
+});
+
+describe("resolveColorEnabled", () => {
+  it("should enable color on a TTY without NO_COLOR", () => {
+    expect(resolveColorEnabled({}, true)).toBe(true);
+  });
+
+  it("should disable color when NO_COLOR is set", () => {
+    expect(resolveColorEnabled({ NO_COLOR: "1" }, true)).toBe(false);
+  });
+
+  it("should disable color when NO_COLOR is set to an empty string", () => {
+    expect(resolveColorEnabled({ NO_COLOR: "" }, true)).toBe(false);
+  });
+
+  it("should disable color when stdout is not a TTY", () => {
+    expect(resolveColorEnabled({}, false)).toBe(false);
+  });
+});

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { bootstrap } from "./bootstrap/bootstrapCommand";
+import { debugCommand } from "./debug/debugCommand";
 import { ArgumentError } from "./error/mainError";
 import { format } from "./format/formatCommand";
 import { generate } from "./generate/generate";
@@ -92,6 +93,15 @@ program
   .option("--config <path>", "Custom path to your GASsma config file")
   .action(async (options) => {
     await studioCommand({ config: options.config });
+  });
+
+program
+  .command("debug")
+  .description("Print information helpful for debugging and bug reports")
+  .option("--schema <path>", "Path to a specific .prisma file to inspect")
+  .option("--config <path>", "Custom path to your GASsma config file")
+  .action(async (options) => {
+    await debugCommand({ schema: options.schema, config: options.config });
   });
 
 program

--- a/packages/cli/src/config/findConfigFile.ts
+++ b/packages/cli/src/config/findConfigFile.ts
@@ -17,4 +17,4 @@ const buildCandidates = (cwd: string): string[] => {
 const findConfigFile = (cwd: string): string | undefined =>
   buildCandidates(cwd).find((candidate) => fs.existsSync(candidate));
 
-export { findConfigFile };
+export { CONFIG_EXTENSIONS, findConfigFile };

--- a/packages/cli/src/debug/debugCommand.ts
+++ b/packages/cli/src/debug/debugCommand.ts
@@ -1,0 +1,131 @@
+import os from "os";
+import { logLoadedConfig } from "../config/logLoadedConfig";
+import { getVersion } from "../version/getVersion";
+import { createDebugFs } from "./env/debugFs";
+import type { DebugFs } from "./env/debugFs";
+import { createTimedExec } from "./env/execWithTimeout";
+import type { TimedExecFn } from "./env/execWithTimeout";
+import {
+  buildAppsscriptLines,
+  collectAppsscriptStatus,
+} from "./sections/appsscriptSection";
+import { buildClaspLines, collectClaspStatus } from "./sections/claspSection";
+import { buildConfigLine, collectConfigStatus } from "./sections/configSection";
+import { buildEnvVarsLines } from "./sections/envVarsSection";
+import {
+  buildGeneratedClientLines,
+  collectGeneratedClientStatus,
+} from "./sections/generatedClientSection";
+import {
+  buildCiLines,
+  buildInteractiveLines,
+  isCiEnv,
+  isInteractive,
+} from "./sections/runtimeSection";
+import {
+  buildSchemaLines,
+  collectSchemaStatus,
+} from "./sections/schemaSection";
+import { createStyler, resolveColorEnabled } from "./styles";
+import { firstLine } from "./util/firstLine";
+
+type DebugOptions = {
+  schema?: string;
+  config?: string;
+};
+
+type DebugOverrides = {
+  exec?: TimedExecFn;
+  fs?: DebugFs;
+  env?: Record<string, string | undefined>;
+  homedir?: string;
+  stdinIsTty?: boolean;
+  stdoutIsTty?: boolean;
+};
+
+const CLASP_TIMEOUT_MS = 3000;
+
+const printLines = (lines: string[]): void => {
+  lines.forEach((line) => console.log(line));
+};
+
+const printConfigSection = (configPath: string | undefined): void => {
+  const status = collectConfigStatus(configPath);
+  if (status.kind === "loaded") {
+    logLoadedConfig(status.filePath);
+    return;
+  }
+  console.log(buildConfigLine(status));
+};
+
+const runDebug = async (
+  options: DebugOptions,
+  overrides: DebugOverrides,
+): Promise<void> => {
+  const env = overrides.env ?? process.env;
+  const fs = overrides.fs ?? createDebugFs();
+  const exec = overrides.exec ?? createTimedExec();
+  const homedir = overrides.homedir ?? os.homedir();
+  const stdinIsTty = overrides.stdinIsTty ?? process.stdin.isTTY === true;
+  const stdoutIsTty = overrides.stdoutIsTty ?? process.stdout.isTTY === true;
+  const cwd = process.cwd();
+  const styler = createStyler(resolveColorEnabled(env, stdoutIsTty));
+
+  console.log(`gassma debug — gassma v${getVersion()}`);
+  console.log("");
+  printConfigSection(options.config);
+  console.log("");
+
+  const schemaStatus = collectSchemaStatus(options);
+  printLines(buildSchemaLines(schemaStatus, styler));
+  console.log("");
+
+  printLines(buildEnvVarsLines(env, styler));
+  console.log("");
+
+  const claspStatus = await collectClaspStatus({
+    exec,
+    fs,
+    homedir,
+    cwd,
+    timeoutMs: CLASP_TIMEOUT_MS,
+  });
+  printLines(buildClaspLines(claspStatus, styler));
+  console.log("");
+
+  const appsscriptStatus = collectAppsscriptStatus({
+    fs,
+    cwd,
+    rootDir: claspStatus.project.rootDir,
+  });
+  printLines(buildAppsscriptLines(appsscriptStatus, cwd, styler));
+  console.log("");
+
+  const generatedStatus = collectGeneratedClientStatus(
+    { fs, cwd },
+    schemaStatus,
+  );
+  printLines(buildGeneratedClientLines(generatedStatus, cwd, styler));
+  console.log("");
+
+  printLines(
+    buildInteractiveLines(isInteractive(stdinIsTty, env.TERM), styler),
+  );
+  console.log("");
+  printLines(buildCiLines(isCiEnv(env.CI), styler));
+};
+
+const debugCommand = async (
+  options: DebugOptions = {},
+  overrides: DebugOverrides = {},
+): Promise<void> => {
+  try {
+    await runDebug(options, overrides);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`debug: unexpected error (${firstLine(message)})`);
+  }
+};
+
+export { debugCommand };
+export type { DebugOptions, DebugOverrides };

--- a/packages/cli/src/debug/debugCommand.ts
+++ b/packages/cli/src/debug/debugCommand.ts
@@ -3,6 +3,7 @@ import { logLoadedConfig } from "../config/logLoadedConfig";
 import { getVersion } from "../version/getVersion";
 import { createDebugFs } from "./env/debugFs";
 import type { DebugFs } from "./env/debugFs";
+import { detectCi as defaultDetectCi } from "./env/detectCi";
 import { createTimedExec } from "./env/execWithTimeout";
 import type { TimedExecFn } from "./env/execWithTimeout";
 import {
@@ -19,7 +20,6 @@ import {
 import {
   buildCiLines,
   buildInteractiveLines,
-  isCiEnv,
   isInteractive,
 } from "./sections/runtimeSection";
 import {
@@ -41,6 +41,7 @@ type DebugOverrides = {
   homedir?: string;
   stdinIsTty?: boolean;
   stdoutIsTty?: boolean;
+  detectCi?: () => boolean;
 };
 
 const CLASP_TIMEOUT_MS = 3000;
@@ -68,6 +69,7 @@ const runDebug = async (
   const homedir = overrides.homedir ?? os.homedir();
   const stdinIsTty = overrides.stdinIsTty ?? process.stdin.isTTY === true;
   const stdoutIsTty = overrides.stdoutIsTty ?? process.stdout.isTTY === true;
+  const detectCi = overrides.detectCi ?? defaultDetectCi;
   const cwd = process.cwd();
   const styler = createStyler(resolveColorEnabled(env, stdoutIsTty));
 
@@ -112,7 +114,7 @@ const runDebug = async (
     buildInteractiveLines(isInteractive(stdinIsTty, env.TERM), styler),
   );
   console.log("");
-  printLines(buildCiLines(isCiEnv(env.CI), styler));
+  printLines(buildCiLines(detectCi(), styler));
 };
 
 const debugCommand = async (

--- a/packages/cli/src/debug/env/debugFs.ts
+++ b/packages/cli/src/debug/env/debugFs.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+
+type DebugFs = {
+  exists: (filePath: string) => boolean;
+  readText: (filePath: string) => string;
+  mtimeMs: (filePath: string) => number | undefined;
+};
+
+const createDebugFs = (): DebugFs => ({
+  exists: (filePath) => fs.existsSync(filePath),
+  readText: (filePath) => fs.readFileSync(filePath, "utf-8"),
+  mtimeMs: (filePath) => {
+    try {
+      return fs.statSync(filePath).mtimeMs;
+    } catch {
+      return undefined;
+    }
+  },
+});
+
+export { createDebugFs };
+export type { DebugFs };

--- a/packages/cli/src/debug/env/detectCi.ts
+++ b/packages/cli/src/debug/env/detectCi.ts
@@ -1,0 +1,5 @@
+import { isCI } from "ci-info";
+
+const detectCi = (): boolean => isCI;
+
+export { detectCi };

--- a/packages/cli/src/debug/env/execWithTimeout.ts
+++ b/packages/cli/src/debug/env/execWithTimeout.ts
@@ -1,0 +1,59 @@
+import { spawn } from "child_process";
+import type { ExecResult } from "../../bootstrap/env/execCommand";
+
+type TimedExecResult = ExecResult & { timedOut: boolean };
+
+type TimedExecFn = (
+  command: string,
+  args: string[],
+  timeoutMs: number,
+) => Promise<TimedExecResult>;
+
+const createTimedExec = (): TimedExecFn => (command, args, timeoutMs) =>
+  new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: "pipe", shell: false });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const finish = (result: TimedExecResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      finish({ ok: false, exitCode: null, stdout, stderr, timedOut: true });
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => {
+      finish({
+        ok: false,
+        exitCode: null,
+        stdout,
+        stderr: error.message,
+        timedOut: false,
+      });
+    });
+    child.on("close", (code) => {
+      finish({
+        ok: code === 0,
+        exitCode: code,
+        stdout,
+        stderr,
+        timedOut: false,
+      });
+    });
+  });
+
+export { createTimedExec };
+export type { TimedExecFn, TimedExecResult };

--- a/packages/cli/src/debug/sections/appsscriptSection.ts
+++ b/packages/cli/src/debug/sections/appsscriptSection.ts
@@ -1,0 +1,160 @@
+import path from "path";
+import { GASSMA_LIBRARY } from "../../bootstrap/const/gassmaLibrary";
+import { isRecord } from "../../bootstrap/util/isRecord";
+import type { DebugFs } from "../env/debugFs";
+import type { Styler } from "../styles";
+
+type AppsscriptLibrary = {
+  userSymbol?: string;
+  version?: string;
+  developmentMode?: boolean;
+};
+
+type AppsscriptStatus =
+  | { kind: "notFound"; searched: string[] }
+  | { kind: "parseError"; manifestPath: string }
+  | {
+      kind: "found";
+      manifestPath: string;
+      runtimeVersion?: string;
+      library?: AppsscriptLibrary;
+    };
+
+type AppsscriptDeps = {
+  fs: DebugFs;
+  cwd: string;
+  rootDir: string | undefined;
+};
+
+const buildCandidates = (deps: AppsscriptDeps): string[] => {
+  const candidates = [
+    ...(deps.rootDir === undefined
+      ? []
+      : [path.resolve(deps.cwd, deps.rootDir, "appsscript.json")]),
+    path.resolve(deps.cwd, "dist", "appsscript.json"),
+    path.resolve(deps.cwd, "appsscript.json"),
+  ];
+  return [...new Set(candidates)];
+};
+
+const readLibraryEntries = (manifest: Record<string, unknown>): unknown[] => {
+  const dependencies = manifest.dependencies;
+  if (!isRecord(dependencies)) return [];
+  const libraries = dependencies.libraries;
+  return Array.isArray(libraries) ? libraries : [];
+};
+
+const toLibrary = (entry: Record<string, unknown>): AppsscriptLibrary => ({
+  ...(typeof entry.userSymbol === "string"
+    ? { userSymbol: entry.userSymbol }
+    : {}),
+  ...(typeof entry.version === "string" || typeof entry.version === "number"
+    ? { version: String(entry.version) }
+    : {}),
+  ...(typeof entry.developmentMode === "boolean"
+    ? { developmentMode: entry.developmentMode }
+    : {}),
+});
+
+const findGassmaLibrary = (
+  manifest: Record<string, unknown>,
+): AppsscriptLibrary | undefined => {
+  const entries = readLibraryEntries(manifest).filter(isRecord);
+  const byId = entries.find((e) => e.libraryId === GASSMA_LIBRARY.scriptId);
+  const bySymbol = entries.find(
+    (e) => e.userSymbol === GASSMA_LIBRARY.userSymbol,
+  );
+  const entry = byId ?? bySymbol;
+  return entry === undefined ? undefined : toLibrary(entry);
+};
+
+const collectAppsscriptStatus = (deps: AppsscriptDeps): AppsscriptStatus => {
+  const searched = buildCandidates(deps);
+  const manifestPath = searched.find((candidate) => deps.fs.exists(candidate));
+  if (manifestPath === undefined) return { kind: "notFound", searched };
+
+  try {
+    const manifest: unknown = JSON.parse(deps.fs.readText(manifestPath));
+    if (!isRecord(manifest)) return { kind: "parseError", manifestPath };
+    return {
+      kind: "found",
+      manifestPath,
+      ...(typeof manifest.runtimeVersion === "string"
+        ? { runtimeVersion: manifest.runtimeVersion }
+        : {}),
+      ...(() => {
+        const library = findGassmaLibrary(manifest);
+        return library === undefined ? {} : { library };
+      })(),
+    };
+  } catch {
+    return { kind: "parseError", manifestPath };
+  }
+};
+
+const buildRuntimeVersionLine = (
+  runtimeVersion: string | undefined,
+): string => {
+  if (runtimeVersion === "V8") return "runtimeVersion: V8";
+  if (runtimeVersion === undefined) return "runtimeVersion: not set (not V8)";
+  return `runtimeVersion: ${runtimeVersion} (not V8)`;
+};
+
+const buildUserSymbolLine = (userSymbol: string | undefined): string => {
+  const expected = GASSMA_LIBRARY.userSymbol;
+  if (userSymbol === expected) return `- userSymbol: ${userSymbol}`;
+  return (
+    `- userSymbol: ${userSymbol ?? "(not set)"} ` +
+    `(expected \`${expected}\` — generated code references \`${expected}.GassmaClient\`)`
+  );
+};
+
+const buildLibraryLines = (
+  library: AppsscriptLibrary | undefined,
+): string[] => {
+  if (library === undefined) {
+    return ["Gassma library: not found in dependencies.libraries"];
+  }
+  return [
+    "Gassma library: found",
+    buildUserSymbolLine(library.userSymbol),
+    `- version: ${library.version ?? "(not set)"}`,
+    `- developmentMode: ${
+      library.developmentMode === undefined
+        ? "(not set)"
+        : String(library.developmentMode)
+    }`,
+  ];
+};
+
+const buildAppsscriptLines = (
+  status: AppsscriptStatus,
+  cwd: string,
+  styler: Styler,
+): string[] => {
+  const heading = styler.heading("-- appsscript.json --");
+  const rel = (filePath: string): string => path.relative(cwd, filePath);
+
+  if (status.kind === "notFound") {
+    return [
+      heading,
+      `Not found (searched: ${status.searched.map(rel).join(", ")})`,
+    ];
+  }
+  if (status.kind === "parseError") {
+    return [
+      heading,
+      `Path: ${rel(status.manifestPath)}`,
+      "Could not parse appsscript.json",
+    ];
+  }
+  return [
+    heading,
+    `Path: ${rel(status.manifestPath)}`,
+    buildRuntimeVersionLine(status.runtimeVersion),
+    ...buildLibraryLines(status.library),
+  ];
+};
+
+export { buildAppsscriptLines, collectAppsscriptStatus };
+export type { AppsscriptStatus };

--- a/packages/cli/src/debug/sections/claspSection.ts
+++ b/packages/cli/src/debug/sections/claspSection.ts
@@ -1,0 +1,111 @@
+import path from "path";
+import { isRecord } from "../../bootstrap/util/isRecord";
+import type { DebugFs } from "../env/debugFs";
+import type { TimedExecFn } from "../env/execWithTimeout";
+import type { Styler } from "../styles";
+import { firstLine } from "../util/firstLine";
+
+type ClaspVersion =
+  | { kind: "found"; version: string }
+  | { kind: "notFound" }
+  | { kind: "timedOut" }
+  | { kind: "failed" };
+
+type ClaspProject = {
+  exists: boolean;
+  parseError?: boolean;
+  rootDir?: string;
+  scriptId?: string;
+};
+
+type ClaspStatus = {
+  version: ClaspVersion;
+  loggedIn: boolean;
+  project: ClaspProject;
+};
+
+type ClaspDeps = {
+  exec: TimedExecFn;
+  fs: DebugFs;
+  homedir: string;
+  cwd: string;
+  timeoutMs: number;
+};
+
+const detectClaspVersion = async (deps: ClaspDeps): Promise<ClaspVersion> => {
+  const result = await deps.exec("clasp", ["-v"], deps.timeoutMs);
+  if (result.timedOut) return { kind: "timedOut" };
+  if (result.ok) {
+    const version = firstLine(result.stdout.trim());
+    return { kind: "found", version: version === "" ? "unknown" : version };
+  }
+  if (result.exitCode === null) return { kind: "notFound" };
+  return { kind: "failed" };
+};
+
+const readClaspProject = (deps: ClaspDeps): ClaspProject => {
+  const claspJsonPath = path.join(deps.cwd, ".clasp.json");
+  if (!deps.fs.exists(claspJsonPath)) return { exists: false };
+
+  try {
+    const parsed: unknown = JSON.parse(deps.fs.readText(claspJsonPath));
+    if (!isRecord(parsed)) return { exists: true, parseError: true };
+    return {
+      exists: true,
+      ...(typeof parsed.rootDir === "string"
+        ? { rootDir: parsed.rootDir }
+        : {}),
+      ...(typeof parsed.scriptId === "string"
+        ? { scriptId: parsed.scriptId }
+        : {}),
+    };
+  } catch {
+    return { exists: true, parseError: true };
+  }
+};
+
+const collectClaspStatus = async (deps: ClaspDeps): Promise<ClaspStatus> => ({
+  version: await detectClaspVersion(deps),
+  loggedIn: deps.fs.exists(path.join(deps.homedir, ".clasprc.json")),
+  project: readClaspProject(deps),
+});
+
+const maskScriptId = (scriptId: string): string => `${scriptId.slice(0, 4)}…`;
+
+const buildVersionLine = (version: ClaspVersion): string => {
+  if (version.kind === "found") {
+    return `clasp: found in PATH (version ${version.version})`;
+  }
+  if (version.kind === "notFound") {
+    return "clasp: not detected (not found in PATH)";
+  }
+  if (version.kind === "timedOut") {
+    return "clasp: not detected (`clasp -v` timed out)";
+  }
+  return "clasp: not detected (`clasp -v` failed)";
+};
+
+const buildProjectLine = (project: ClaspProject): string => {
+  if (!project.exists) return "Project: .clasp.json not found";
+  if (project.parseError === true) {
+    return "Project: .clasp.json found (could not be parsed)";
+  }
+  const rootDir = project.rootDir ?? "(not set)";
+  const scriptId =
+    project.scriptId === undefined
+      ? "(not set)"
+      : maskScriptId(project.scriptId);
+  return `Project: .clasp.json found (rootDir: ${rootDir}, scriptId: ${scriptId})`;
+};
+
+const buildClaspLines = (status: ClaspStatus, styler: Styler): string[] => [
+  styler.heading("-- clasp --"),
+  buildVersionLine(status.version),
+  status.loggedIn
+    ? "Auth: logged in (~/.clasprc.json exists)"
+    : "Auth: not logged in (~/.clasprc.json not found)",
+  buildProjectLine(status.project),
+];
+
+export { buildClaspLines, collectClaspStatus, maskScriptId };
+export type { ClaspStatus };

--- a/packages/cli/src/debug/sections/configSection.ts
+++ b/packages/cli/src/debug/sections/configSection.ts
@@ -1,0 +1,36 @@
+import { CONFIG_EXTENSIONS } from "../../config/findConfigFile";
+import { loadConfig } from "../../config/loadConfig";
+import { firstLine } from "../util/firstLine";
+
+type ConfigStatus =
+  | { kind: "loaded"; filePath: string }
+  | { kind: "notFound" }
+  | { kind: "error"; message: string };
+
+const collectConfigStatus = (configPath: string | undefined): ConfigStatus => {
+  try {
+    const loaded = loadConfig(configPath);
+    if (loaded === undefined) return { kind: "notFound" };
+    return { kind: "loaded", filePath: loaded.filePath };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { kind: "error", message: firstLine(message) };
+  }
+};
+
+const describeSearchedLocations = (): string => {
+  const exts = CONFIG_EXTENSIONS.map((ext) => ext.slice(1)).join(",");
+  return `gassma.config.{${exts}}, .config/gassma.{${exts}}`;
+};
+
+const buildConfigLine = (
+  status: Exclude<ConfigStatus, { kind: "loaded" }>,
+): string => {
+  if (status.kind === "notFound") {
+    return `No config file found (searched: ${describeSearchedLocations()})`;
+  }
+  return `Failed to load config: ${status.message}`;
+};
+
+export { buildConfigLine, collectConfigStatus };
+export type { ConfigStatus };

--- a/packages/cli/src/debug/sections/envVarsSection.ts
+++ b/packages/cli/src/debug/sections/envVarsSection.ts
@@ -1,0 +1,40 @@
+import type { Styler } from "../styles";
+
+const GENERAL_DEBUG_ENV_VARS = [
+  "CI",
+  "DEBUG",
+  "NODE_ENV",
+  "NO_COLOR",
+  "TERM",
+  "NODE_TLS_REJECT_UNAUTHORIZED",
+  "NO_PROXY",
+  "http_proxy",
+  "HTTP_PROXY",
+  "https_proxy",
+  "HTTPS_PROXY",
+];
+
+const buildEnvVarLine = (
+  name: string,
+  value: string | undefined,
+  styler: Styler,
+): string => {
+  if (value === undefined || value === "") return styler.dim(`- ${name}:`);
+  return styler.bold(`- ${name}: \`${value}\``);
+};
+
+const buildEnvVarsLines = (
+  env: Record<string, string | undefined>,
+  styler: Styler,
+): string[] => [
+  styler.heading("-- Environment variables --"),
+  "When not set, the line is dimmed and no value is displayed.",
+  "When set, the line is bold and the value is inside the `` backticks.",
+  "",
+  "For general debugging",
+  ...GENERAL_DEBUG_ENV_VARS.map((name) =>
+    buildEnvVarLine(name, env[name], styler),
+  ),
+];
+
+export { buildEnvVarsLines };

--- a/packages/cli/src/debug/sections/generatedClientSection.ts
+++ b/packages/cli/src/debug/sections/generatedClientSection.ts
@@ -1,0 +1,121 @@
+import path from "path";
+import type { SchemaFile } from "../../config/resolveSchemaFiles";
+import { extractOutputPath } from "../../generate/read/extractOutputPath";
+import type { DebugFs } from "../env/debugFs";
+import type { Styler } from "../styles";
+import type { SchemaStatus } from "./schemaSection";
+
+type GeneratedClientStatus =
+  | { kind: "skipped" }
+  | { kind: "noOutput" }
+  | {
+      kind: "resolved";
+      outputDir: string;
+      jsName: string;
+      dtsName: string;
+      jsExists: boolean;
+      dtsExists: boolean;
+      stale: boolean | undefined;
+    };
+
+type GeneratedClientDeps = {
+  fs: DebugFs;
+  cwd: string;
+};
+
+const safeExtractOutputPath = (mergedText: string): string | null => {
+  try {
+    return extractOutputPath(mergedText);
+  } catch {
+    return null;
+  }
+};
+
+const collectMtimes = (fs: DebugFs, filePaths: string[]): number[] =>
+  filePaths
+    .map((filePath) => fs.mtimeMs(filePath))
+    .filter((mtime): mtime is number => mtime !== undefined);
+
+const computeStale = (
+  fs: DebugFs,
+  schemaFiles: SchemaFile[],
+  generatedPaths: string[],
+  bothExist: boolean,
+): boolean | undefined => {
+  if (!bothExist) return undefined;
+  const schemaTimes = collectMtimes(
+    fs,
+    schemaFiles.map((f) => path.resolve(f.filePath)),
+  );
+  const generatedTimes = collectMtimes(fs, generatedPaths);
+  if (schemaTimes.length === 0 || generatedTimes.length === 0) return undefined;
+  return Math.max(...schemaTimes) > Math.min(...generatedTimes);
+};
+
+const collectGeneratedClientStatus = (
+  deps: GeneratedClientDeps,
+  schemaStatus: SchemaStatus,
+): GeneratedClientStatus => {
+  if (schemaStatus.kind !== "found") return { kind: "skipped" };
+
+  const outputPath = safeExtractOutputPath(schemaStatus.mergedText);
+  if (outputPath === null) return { kind: "noOutput" };
+
+  const outputDir = path.resolve(deps.cwd, outputPath);
+  const schemaName = schemaStatus.schemaName;
+  const baseName = schemaName.charAt(0).toLowerCase() + schemaName.slice(1);
+  const jsName = `${baseName}Client.js`;
+  const dtsName = `${baseName}Client.d.ts`;
+  const jsPath = path.join(outputDir, jsName);
+  const dtsPath = path.join(outputDir, dtsName);
+  const jsExists = deps.fs.exists(jsPath);
+  const dtsExists = deps.fs.exists(dtsPath);
+
+  return {
+    kind: "resolved",
+    outputDir,
+    jsName,
+    dtsName,
+    jsExists,
+    dtsExists,
+    stale: computeStale(
+      deps.fs,
+      schemaStatus.files,
+      [jsPath, dtsPath],
+      jsExists && dtsExists,
+    ),
+  };
+};
+
+const buildStatusLine = (stale: boolean | undefined): string[] => {
+  if (stale === undefined) return [];
+  if (stale) {
+    return [
+      "Status: possibly stale (schema is newer than the generated client — run `gassma generate`)",
+    ];
+  }
+  return ["Status: up to date"];
+};
+
+const buildGeneratedClientLines = (
+  status: GeneratedClientStatus,
+  cwd: string,
+  styler: Styler,
+): string[] => {
+  const heading = styler.heading("-- Generated client --");
+  if (status.kind === "skipped") return [heading, "Skipped (schema not found)"];
+  if (status.kind === "noOutput") {
+    return [heading, "Output path not found in the generator block"];
+  }
+  const relOutput = path.relative(cwd, status.outputDir);
+  return [
+    heading,
+    `Output: ${relOutput === "" ? "." : relOutput}`,
+    `${status.jsName}: ${status.jsExists ? "found" : "not found"}`,
+    `${status.dtsName}: ${status.dtsExists ? "found" : "not found"}`,
+    ...buildStatusLine(status.stale),
+  ];
+};
+
+export { buildGeneratedClientLines, collectGeneratedClientStatus };
+export type { GeneratedClientStatus };

--- a/packages/cli/src/debug/sections/runtimeSection.ts
+++ b/packages/cli/src/debug/sections/runtimeSection.ts
@@ -1,0 +1,21 @@
+import type { Styler } from "../styles";
+
+const isInteractive = (
+  stdinIsTty: boolean,
+  term: string | undefined,
+): boolean => stdinIsTty && term !== "dumb";
+
+const isCiEnv = (ciValue: string | undefined): boolean =>
+  ciValue !== undefined && ciValue !== "" && ciValue.toLowerCase() !== "false";
+
+const buildInteractiveLines = (value: boolean, styler: Styler): string[] => [
+  styler.heading("-- Terminal is interactive? --"),
+  String(value),
+];
+
+const buildCiLines = (value: boolean, styler: Styler): string[] => [
+  styler.heading("-- CI detected? --"),
+  String(value),
+];
+
+export { buildCiLines, buildInteractiveLines, isCiEnv, isInteractive };

--- a/packages/cli/src/debug/sections/runtimeSection.ts
+++ b/packages/cli/src/debug/sections/runtimeSection.ts
@@ -5,9 +5,6 @@ const isInteractive = (
   term: string | undefined,
 ): boolean => stdinIsTty && term !== "dumb";
 
-const isCiEnv = (ciValue: string | undefined): boolean =>
-  ciValue !== undefined && ciValue !== "" && ciValue.toLowerCase() !== "false";
-
 const buildInteractiveLines = (value: boolean, styler: Styler): string[] => [
   styler.heading("-- Terminal is interactive? --"),
   String(value),
@@ -18,4 +15,4 @@ const buildCiLines = (value: boolean, styler: Styler): string[] => [
   String(value),
 ];
 
-export { buildCiLines, buildInteractiveLines, isCiEnv, isInteractive };
+export { buildCiLines, buildInteractiveLines, isInteractive };

--- a/packages/cli/src/debug/sections/schemaSection.ts
+++ b/packages/cli/src/debug/sections/schemaSection.ts
@@ -1,0 +1,87 @@
+import path from "path";
+import { filterOutputFiles } from "../../config/filterOutputFiles";
+import { resolveSchemaFiles } from "../../config/resolveSchemaFiles";
+import type { SchemaFile } from "../../config/resolveSchemaFiles";
+import { deriveSchemaName, findBaseDir } from "../../generate/generate";
+import { mergeSchemaFiles } from "../../generate/mergeSchemaFiles";
+import { extractPreviewFeatures } from "../../generate/read/extractPreviewFeatures";
+import type { Styler } from "../styles";
+import { firstLine } from "../util/firstLine";
+
+type SchemaStatus =
+  | {
+      kind: "found";
+      files: SchemaFile[];
+      baseDir: string;
+      schemaName: string;
+      mergedText: string;
+      previewFeatures: string[];
+    }
+  | { kind: "error"; message: string };
+
+const safeExtractPreviewFeatures = (mergedText: string): string[] => {
+  try {
+    return extractPreviewFeatures(mergedText);
+  } catch {
+    return [];
+  }
+};
+
+const safeFilterOutputFiles = (
+  allFiles: SchemaFile[],
+  baseDir: string,
+): SchemaFile[] => {
+  try {
+    return filterOutputFiles(allFiles, baseDir);
+  } catch {
+    return allFiles;
+  }
+};
+
+const collectSchemaStatus = (options: {
+  schema?: string;
+  config?: string;
+}): SchemaStatus => {
+  try {
+    const allFiles = resolveSchemaFiles(options);
+    const baseDir = findBaseDir(allFiles.map((f) => f.filePath));
+    const files = safeFilterOutputFiles(allFiles, baseDir);
+    const mergedText = mergeSchemaFiles(files.map((f) => f.filePath));
+    return {
+      kind: "found",
+      files,
+      baseDir,
+      schemaName: deriveSchemaName(baseDir, files),
+      mergedText,
+      previewFeatures: safeExtractPreviewFeatures(mergedText),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { kind: "error", message: firstLine(message) };
+  }
+};
+
+const buildPreviewFeaturesLine = (
+  previewFeatures: string[],
+  styler: Styler,
+): string => {
+  if (previewFeatures.length === 0) {
+    return styler.dim("Preview features: (none)");
+  }
+  return `Preview features: ${previewFeatures.join(", ")}`;
+};
+
+const buildSchemaLines = (status: SchemaStatus, styler: Styler): string[] => {
+  const heading = styler.heading("-- Gassma schema --");
+  if (status.kind === "error") {
+    return [heading, `Could not resolve schema: ${status.message}`];
+  }
+  return [
+    heading,
+    ...status.files.map((f) => `Path: ${path.resolve(f.filePath)}`),
+    buildPreviewFeaturesLine(status.previewFeatures, styler),
+  ];
+};
+
+export { buildSchemaLines, collectSchemaStatus };
+export type { SchemaStatus };

--- a/packages/cli/src/debug/styles.ts
+++ b/packages/cli/src/debug/styles.ts
@@ -1,0 +1,33 @@
+type Styler = {
+  heading: (text: string) => string;
+  dim: (text: string) => string;
+  bold: (text: string) => string;
+};
+
+const ESC = "\u001b";
+
+const wrap = (open: string, close: string, text: string): string =>
+  `${ESC}[${open}${text}${ESC}[${close}`;
+
+const createStyler = (enabled: boolean): Styler => {
+  if (!enabled) {
+    return {
+      heading: (text) => text,
+      dim: (text) => text,
+      bold: (text) => text,
+    };
+  }
+  return {
+    heading: (text) => wrap("4m", "24m", text),
+    dim: (text) => wrap("2m", "22m", text),
+    bold: (text) => wrap("1m", "22m", text),
+  };
+};
+
+const resolveColorEnabled = (
+  env: Record<string, string | undefined>,
+  stdoutIsTty: boolean,
+): boolean => !("NO_COLOR" in env) && stdoutIsTty;
+
+export { createStyler, resolveColorEnabled };
+export type { Styler };

--- a/packages/cli/src/debug/util/firstLine.ts
+++ b/packages/cli/src/debug/util/firstLine.ts
@@ -1,0 +1,3 @@
+const firstLine = (text: string): string => text.split("\n")[0].trimEnd();
+
+export { firstLine };

--- a/packages/cli/src/generate/generate.ts
+++ b/packages/cli/src/generate/generate.ts
@@ -144,5 +144,5 @@ function generateFromSchema(
   console.log("✅ Generated type definitions successfully");
 }
 
-export { generate };
+export { deriveSchemaName, findBaseDir, generate };
 export type { GenerateOptions };

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/__test__/**/*.test.ts"],
+    server: {
+      // ci-info computes isCI at import time; inlining lets vi.resetModules
+      // re-evaluate it under a stubbed env in the detectCi wiring probes.
+      deps: {
+        inline: ["ci-info"],
+      },
+    },
     typecheck: {
       enabled: false,
       include: ["src/__test__/types/**/*.test-d.ts"],


### PR DESCRIPTION
## 概要

**`npx gassma debug`** を追加します(`prisma debug` 相当。ユーザー発案・仕様承認済み)。バグ報告・トラブルシュート用の**読み取り専用の環境レポート**を出力するコマンドです。

設計は prisma-test の Prisma 7.4.1 で `prisma debug` の**実出力を実測**した上で、出力規約(`-- Section --` 見出し / unset=薄字・set=太字+バッククォート / 常に exit 0 / `--config`・`--schema` フラグ)をパリティ維持しつつ、エンジン中心のセクションを **gassma の実際の故障点**に置き換えています。

## 出力セクション(順)

1. **CLI version** 1行(getVersion 再利用)
2. **config ロード状態**(generate と同じ `⚙️ Loaded config from ...`。**未発見時は探索場所を列挙** — findConfigFile の実装と同期)
3. **`-- Gassma schema --`**: multi-file 対応の解決パス列挙 + previewFeatures
4. **`-- Environment variables --`**: general debugging 群11変数(CI/DEBUG/NODE_ENV/NO_COLOR/TERM/proxy 系等。エンジン系は gassma に無いため非搭載)
5. **`-- clasp --`**: PATH 検出+version(**3秒タイムアウトのサブプロセス**)/ `~/.clasprc.json` は**存在のみ**(読まないことをテストで保証)/ `.clasp.json`(rootDir、**scriptId は先頭4文字+マスク**)
6. **`-- appsscript.json --`**: rootDir→dist→cwd の順で探索。runtimeVersion(V8 判定)、**Gassma ライブラリエントリを libraryId 優先で特定**(userSymbol 改名事故を検出可能に)、version、developmentMode
7. **`-- Generated client --`**: generator output 解決(**generate 自身のヘルパーを再利用** — debug と generate の解釈が食い違えない設計)、js/.d.ts 存在、**mtime による "possibly stale" 情報表示**
8. **Terminal is interactive?**(stdin TTY && TERM≠dumb — prisma debug が実際に使う判定と同一。バンドル解析で `is-interactive` パッケージでなく Prisma 自前の stdin 版が使われていることを確認済み)/ **CI detected?**(2コミット目参照)

各セクションは独立に degrade(config 壊れ・スキーマ無し・clasp 無しでも他セクションは出力)し、**コマンド全体は絶対に throw しない**。色は素の ANSI 最小実装、NO_COLOR/非TTY で無色。

## 2コミット目: CI 検出を ci-info に置換(承認済み)

初版の「`CI` 環境変数のみ」判定では Jenkins / TeamCity / Azure Pipelines(`CI` を設定しないベンダー)を拾えないため、**prisma debug の CI セクションと同じ ci-info** に置換。`package-manager-detector` と同じ devDep バンドル焼き込み方式で **runtime 依存は不変**(ci-info を node_modules から退避した状態でビルド済み bin の動作を実証)。注入シームは boolean プロバイダに再設計し、配線プローブ2本のみ(ライブラリのベンダーテーブルは再テストしない)。継承した挙動差: 明示否定は小文字 `CI="false"` のみ。

## テスト(TDD 5バッチ+置換、各バッチ Red 実測)

996 → **1086(+90)**: 実サブプロセスでの timeout kill 実測 / fs・exec 注入シームによる clasp・appsscript フェイク / console spy 統合 / tsx e2e(コマンド登録・全ケース exit 0・--help)/ ci-info 配線プローブ(`TEAMCITY_VERSION` → true)。擬似 TTY で ANSI 出力(underline 見出し・dim/bold)が prisma 実物と一致することも照合済み。

test:types 型エラー0 / typecheck / lint / format / build(tsdown)全 green。gassma-test ディレクトリでの実機実行(読み取りのみ)で full 環境の出力も確認済み。

## スコープ外(記録)

- reference(型ファイルの動的生成.md)への `### gassma debug` 節追記はリリース時セットで対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX