### PR TITLE
feat: expose $transaction on the generated client (core #168 follow-up)

### DIFF
--- a/packages/cli/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/packages/cli/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -37,6 +37,24 @@ describe("generateClientDts", () => {
     expect(result).toContain("  $extends: GassmaHogeExtendsFn<O, {}>;");
   });
 
+  it("should declare $transaction on the client interface", () => {
+    const result = generateClientDts("Hoge");
+
+    expect(result).toContain(
+      "  $transaction<T>(fn: (tx: GassmaHogeTransactionClient<O>) => T, options?: Gassma.GassmaTransactionOptions): T;",
+    );
+  });
+
+  it("should export a TransactionClient type without $transaction", () => {
+    const result = generateClientDts("Hoge");
+
+    expect(result).toContain(
+      `export type GassmaHogeTransactionClient<O extends Gassma.StrictGlobalOmit<O, GassmaHogeGlobalOmitConfig> = {}> = GassmaHogeSheet<O> & {
+  $extends: GassmaHogeExtendsFn<O, {}>;
+};`,
+    );
+  });
+
   it("should work with different schema names", () => {
     const result = generateClientDts("Fuga");
 
@@ -46,6 +64,10 @@ describe("generateClientDts", () => {
     expect(result).toContain(
       "export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, GassmaFugaGlobalOmitConfig> = {}> extends GassmaFugaSheet<O>",
     );
+    expect(result).toContain(
+      "  $transaction<T>(fn: (tx: GassmaFugaTransactionClient<O>) => T, options?: Gassma.GassmaTransactionOptions): T;",
+    );
+    expect(result).toContain("export type GassmaFugaTransactionClient");
   });
 
   it("should export enum constants and types", () => {
@@ -109,6 +131,6 @@ describe("generateClientDts", () => {
     const result = generateClientDts("Test", {});
 
     expect(result).not.toContain("export declare const");
-    expect(result).not.toContain("export type");
+    expect(result).not.toContain("[keyof typeof");
   });
 });

--- a/packages/cli/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/packages/cli/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -87,6 +87,61 @@ describe("generateClientJs", () => {
     expect(received).toEqual([extension]);
   });
 
+  it("should delegate $transaction to the core client instance", () => {
+    const result = generateClientJs({}, "Hoge");
+
+    expect(result).toContain(
+      "    this.$transaction = (fn, options) => client.$transaction(fn, options);",
+    );
+  });
+
+  it("should expose a working $transaction even though core defines it on the prototype", () => {
+    const code = generateClientJs({}, "Hoge");
+    const coreInstances: unknown[] = [];
+    const received: { self: unknown; fn: unknown; options: unknown }[] = [];
+    const txStub = { User: { findMany: () => [] } };
+    class FakeCoreClient {
+      User = { findMany: () => [] };
+      constructor() {
+        coreInstances.push(this);
+      }
+      $transaction(fn: (tx: unknown) => unknown, options?: unknown) {
+        received.push({ self: this, fn, options });
+        return fn(txStub);
+      }
+    }
+    const exportsObject: {
+      GassmaClient?: new (
+        options?: unknown,
+      ) => {
+        $transaction?: (
+          fn: (tx: unknown) => unknown,
+          options?: unknown,
+        ) => unknown;
+      };
+    } = {};
+    const run = new Function("Gassma", "exports", code);
+    run({ GassmaClient: FakeCoreClient }, exportsObject);
+
+    const GeneratedClient = exportsObject.GassmaClient;
+    if (!GeneratedClient) throw new Error("GassmaClient not exported");
+    const instance = new GeneratedClient({});
+    expect(typeof instance.$transaction).toBe("function");
+
+    const seenTx: unknown[] = [];
+    const options = { maxWait: 100, timeout: 200 };
+    const result = instance.$transaction?.((tx) => {
+      seenTx.push(tx);
+      return "tx-result";
+    }, options);
+
+    expect(result).toBe("tx-result");
+    expect(seenTx).toEqual([txStub]);
+    expect(received).toHaveLength(1);
+    expect(received[0].options).toBe(options);
+    expect(received[0].self).toBe(coreInstances[0]);
+  });
+
   it("should include onDelete and onUpdate when present", () => {
     const relations = {
       Post: {

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -34,6 +34,14 @@ describe("getGassmaCommonTypes", () => {
     expect(result).toContain("gte?: T | FieldRef");
   });
 
+  it("should generate GassmaTransactionOptions type", () => {
+    expect(result).toContain("type GassmaTransactionOptions = {");
+    expect(result).toContain("maxWait?: number");
+    expect(result).toContain("timeout?: number");
+    expect(result).not.toContain("rollback");
+    expect(result).not.toContain("isolationLevel");
+  });
+
   it("should generate ManyReturn types", () => {
     expect(result).toContain("type ManyReturn =");
     expect(result).toContain("count: number");

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -4,6 +4,22 @@ import { getGassmaErrorClasses } from "../../../generate/typeGenerate/gassmaErro
 describe("getGassmaErrorClasses", () => {
   const result = getGassmaErrorClasses();
 
+  it("should include transaction error classes", () => {
+    expect(result).toContain(
+      "class GassmaTransactionLockTimeoutError extends Error",
+    );
+    expect(result).toContain("constructor(maxWaitMs: number)");
+    expect(result).toContain(
+      "class GassmaTransactionTimeoutError extends Error",
+    );
+    expect(result).toContain(
+      'constructor(phase: "query" | "commit", timeoutMs: number, elapsedMs: number)',
+    );
+    expect(result).toContain(
+      "class GassmaNestedTransactionError extends Error",
+    );
+  });
+
   it("should include GassmaSkipNegativeError", () => {
     expect(result).toContain("class GassmaSkipNegativeError extends Error");
     expect(result).toContain("constructor(value: number)");

--- a/packages/cli/src/__test__/types/transaction/transaction.test-d.ts
+++ b/packages/cli/src/__test__/types/transaction/transaction.test-d.ts
@@ -1,0 +1,123 @@
+import { expectTypeOf } from "vitest";
+import type { Gassma, GassmaTransactionClient } from "../__generated__/client";
+import { GassmaClient } from "../__generated__/client";
+import { GassmaClient as StrictGassmaClient } from "../__generated__/clientStrict";
+
+declare const client: GassmaClient;
+declare const omitClient: GassmaClient<{ User: { email: true } }>;
+declare const strictClient: StrictGassmaClient;
+
+// 戻り値の型はコールバックの戻り値がそのまま伝播する
+{
+  const num = client.$transaction(() => 42);
+  expectTypeOf(num).toEqualTypeOf<number>();
+
+  const rows = client.$transaction((tx) => tx.User.findMany({}));
+  expectTypeOf(rows).toEqualTypeOf(client.User.findMany({}));
+}
+
+// tx のモデルは通常クライアントと同一の型
+{
+  client.$transaction((tx) => {
+    expectTypeOf(tx.User).toEqualTypeOf<typeof client.User>();
+    expectTypeOf(tx.Post).toEqualTypeOf<typeof client.Post>();
+  });
+}
+
+// @@map モデルはコード名（Member）でアクセスでき、シート名では見えない
+{
+  client.$transaction((tx) => {
+    const m = tx.Member.findFirstOrThrow({ where: { id: 1 } });
+    expectTypeOf(m.role).toEqualTypeOf<"ADMIN" | "USER" | "MODERATOR">();
+    // @ts-expect-error シート名（メンバー一覧）は型に存在しない
+    tx["メンバー一覧"];
+  });
+}
+
+// tx 型は GassmaTransactionClient として公開されている
+{
+  client.$transaction((tx) => {
+    expectTypeOf(tx).toEqualTypeOf<GassmaTransactionClient>();
+  });
+}
+
+// tx 内で $transaction は使えない（ネスト禁止）
+{
+  client.$transaction((tx) => {
+    // @ts-expect-error tx に $transaction は存在しない
+    tx.$transaction(() => 1);
+  });
+}
+
+// options は maxWait / timeout のみ
+{
+  client.$transaction(() => 1, {});
+  client.$transaction(() => 1, { maxWait: 1000 });
+  client.$transaction(() => 1, { maxWait: 1000, timeout: 2000 });
+
+  // @ts-expect-error rollback オプションは存在しない
+  client.$transaction(() => 1, { rollback: false });
+
+  // @ts-expect-error isolationLevel オプションは存在しない
+  client.$transaction(() => 1, { isolationLevel: "Serializable" });
+}
+
+// 配列形（バッチ）は受け付けない
+{
+  // @ts-expect-error 配列形の $transaction は未サポート
+  client.$transaction([client.User.findMany({})]);
+}
+
+// tx 内でも $extends が使え、戻り値は拡張クライアント
+{
+  client.$transaction((tx) => {
+    const extended = tx.$extends({});
+    expectTypeOf(extended.User.findMany).toEqualTypeOf<
+      typeof client.User.findMany
+    >();
+  });
+}
+
+// $extends の戻り値には $transaction がない
+{
+  const extended = client.$extends({});
+  // @ts-expect-error 拡張クライアントに $transaction は存在しない
+  extended.$transaction;
+}
+
+// グローバル omit は tx にも引き継がれる
+{
+  omitClient.$transaction((tx) => {
+    expectTypeOf(tx.User).toEqualTypeOf<typeof omitClient.User>();
+    const user = tx.User.findFirstOrThrow({ where: { id: 1 } });
+    // @ts-expect-error omit された email は結果に存在しない
+    user.email;
+  });
+}
+
+// strict fixture でも同様に $transaction が使える
+{
+  const num = strictClient.$transaction(() => 42);
+  expectTypeOf(num).toEqualTypeOf<number>();
+
+  strictClient.$transaction((tx) => {
+    expectTypeOf(tx.User).toEqualTypeOf<typeof strictClient.User>();
+    // @ts-expect-error tx に $transaction は存在しない
+    tx.$transaction(() => 1);
+  });
+}
+
+// トランザクション系エラーは Gassma namespace から利用できる
+{
+  expectTypeOf<Gassma.GassmaTransactionLockTimeoutError>().toExtend<Error>();
+  expectTypeOf<Gassma.GassmaTransactionTimeoutError>().toExtend<Error>();
+  expectTypeOf<Gassma.GassmaNestedTransactionError>().toExtend<Error>();
+  expectTypeOf<
+    ConstructorParameters<typeof Gassma.GassmaTransactionLockTimeoutError>
+  >().toEqualTypeOf<[maxWaitMs: number]>();
+  expectTypeOf<
+    ConstructorParameters<typeof Gassma.GassmaTransactionTimeoutError>
+  >().toEqualTypeOf<
+    [phase: "query" | "commit", timeoutMs: number, elapsedMs: number]
+  >();
+}

--- a/packages/cli/src/generate/jsGenerate/generateClientDts.ts
+++ b/packages/cli/src/generate/jsGenerate/generateClientDts.ts
@@ -1,8 +1,12 @@
 import type { EnumsConfig } from "../read/extractEnums";
 
 const generateClientDts = (schemaName: string, enums?: EnumsConfig): string => {
-  let result = `export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> extends Gassma${schemaName}Sheet<O> {
+  let result = `export type Gassma${schemaName}TransactionClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> = Gassma${schemaName}Sheet<O> & {
   $extends: Gassma${schemaName}ExtendsFn<O, {}>;
+};
+export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> extends Gassma${schemaName}Sheet<O> {
+  $extends: Gassma${schemaName}ExtendsFn<O, {}>;
+  $transaction<T>(fn: (tx: Gassma${schemaName}TransactionClient<O>) => T, options?: Gassma.GassmaTransactionOptions): T;
 }
 export declare class GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> {
   constructor(options?: Gassma${schemaName}ClientOptions<O>);

--- a/packages/cli/src/generate/jsGenerate/generateClientJs.ts
+++ b/packages/cli/src/generate/jsGenerate/generateClientJs.ts
@@ -173,6 +173,7 @@ ${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}${ignoreSheetsDecl}${mapSh
     const client = new Gassma.GassmaClient(mergedOptions);
     Object.assign(this, client);
     this.$extends = (extension) => client.$extends(extension);
+    this.$transaction = (fn, options) => client.$transaction(fn, options);
   }
 }
 

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -84,6 +84,11 @@ const getGassmaCommonTypes = (strict?: boolean) => {
     ? { [P in keyof S]: number }
     : { [key: string]: number };
 
+  type GassmaTransactionOptions = {
+    maxWait?: number;
+    timeout?: number;
+  };
+
   type ManyReturn = {
     count: number;
   };

--- a/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -162,6 +162,17 @@ const errorClassDefinitions: ErrorClassDef[] = [
     extends: "Error",
     params: "sheetName: string, field: string, value: unknown",
   },
+  {
+    name: "GassmaTransactionLockTimeoutError",
+    extends: "Error",
+    params: "maxWaitMs: number",
+  },
+  {
+    name: "GassmaTransactionTimeoutError",
+    extends: "Error",
+    params: 'phase: "query" | "commit", timeoutMs: number, elapsedMs: number',
+  },
+  { name: "GassmaNestedTransactionError", extends: "Error", params: "" },
 ];
 
 export { errorClassDefinitions };


### PR DESCRIPTION
## 概要

core の $transaction(akahoshi1421/gassma#168、Phase 2)への cli 追随です。生成 GassmaClient に **型(d.ts)とランタイム(JS)の両面**で `$transaction` を露出します。

## 生成 d.ts

- `$transaction<T>(fn: (tx: Gassma{S}TransactionClient<O>) => T, options?: Gassma.GassmaTransactionOptions): T` を client interface に追加
- 生成 `TransactionClient` 型 = モデル群 + `$extends`($transaction なし。core の GassmaTransactionClient の写像)
- `Gassma.GassmaTransactionOptions`({ maxWait?; timeout? })と**トランザクションエラー3種**を namespace ミラーに追加(core と同一シグネチャ)
- 生成 `$extends` の戻り型は**元から $transaction を持たない構成**で、core の ExtendedGassmaClient 化に既に整合(変更不要と実査)

## 生成 JS — 委譲1行だが「呼び出し形」が本質

生成ラッパーは core client の own プロパティを Object.assign でコピーする構造のため、prototype の `$transaction` は写りません。追加したのは `this.$transaction = (fn, options) => client.$transaction(fn, options)` の1行ですが、**メソッド呼び出し形であることが要件**です — core はコンストラクタ initArgs を「インスタンスをキーにした WeakMap」から引くため、この形でないと tx 再構築時にオプションが失われます(ランタイムテストでピン)。

## 実査による設計修正(指示との差分)

当初指示にあった「@@map モデル用の wrapTx(tx client の再マッピング層)」は**不要と判断**しました。core(dev=ed12307)を実査した結果、`$transaction` は保存済み initArgs で**通常のコンストラクタ経路を完全再実行**するため、tx client は最初から「モデル名キー(@@map 適用済み)+globalOmit/defaults/strict 全適用済み」で生成型の約束と一致します。再マッピングを足すと二重適用になるため素通し委譲が正解。test-d で `tx.Member`(@@map モデル)が通り、シート名キーが型エラーになること・omit したフィールドが tx 内でも消えていることをピン済み。

## テスト

1086 → **1092(+6 単体)** + 新規 transaction.test-d.ts(両 fixture): 戻り値伝播 / tx 内モデル同型 / @@map / ネスト禁止 / **options 厳密(rollback・isolationLevel・配列形が型エラー)** / tx 内 $extends / 拡張 client に $transaction 無し / omit 引き継ぎ / エラー3種のコンストラクタ型。逆検証: 実装を stash して test-d が落ちることを実測。test:types 型エラー0 / typecheck / lint / format / build 全 green。

## 発見事項(スコープ外・要判断)

生成 namespace のエラーミラーに **pre-existing のドリフト**があります: core にあるが cli 生成に無い4クラス(GassmaFindFirstTakeError / GassmaUndefinedValueError / GassmaSkipInArrayError / GassmaMissingArgumentError)、逆に core が #163 で削除済みの GassmaTargetSheetNotFoundError が cli 側に残存。別途整理を推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX