### PR TITLE
feat: add create-vite style directory argument to gassma bootstrap

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -139,9 +139,23 @@ Validate .prisma files.
 
 ### bootstrap
 
-Interactively set up a local GAS development environment (clasp + esbuild + TypeScript + GASsma) in the current directory. It creates an Apps Script project via `clasp create-script`, registers the GASsma library in `dist/appsscript.json`, generates `package.json`, `esbuild.mjs`, `tsconfig.json`, `.gitignore` and a sample `src/index.ts`, runs `gassma init`, and installs dependencies.
+Interactively set up a local GAS development environment (clasp + esbuild + TypeScript + GASsma). It creates an Apps Script project via `clasp create-script`, registers the GASsma library in `dist/appsscript.json`, generates `package.json`, `esbuild.mjs`, `tsconfig.json`, `.gitignore` and a sample `src/index.ts`, runs `gassma init`, and installs dependencies.
+
+```sh
+npx gassma bootstrap my-app   # create my-app/ and set up inside it
+npx gassma bootstrap          # ask for a directory first (default: gassma-project)
+npx gassma bootstrap .        # set up in the current directory
+```
+
+If the target directory does not exist, it is created. If it exists and is not empty, bootstrap asks for confirmation before continuing (`--yes` continues automatically), so re-running the same command resumes an interrupted setup.
 
 Requires [clasp](https://github.com/google/clasp): `npm install -g @google/clasp`, then `clasp login`.
+
+#### arguments
+
+|name|description|
+|--|--|
+|`[directory]`|Directory to set up the project in (`.` for the current directory). Omitting it prompts for one|
 
 #### options
 

--- a/packages/cli/src/__test__/bootstrap/bootstrapCommand.test.ts
+++ b/packages/cli/src/__test__/bootstrap/bootstrapCommand.test.ts
@@ -76,7 +76,7 @@ describe("bootstrap", () => {
     const prompter = createFakePrompter();
 
     await bootstrap(
-      { yes: true },
+      { yes: true, directory: "." },
       { exec, prompter, isTty: true, userAgent: "npm/10.0.0 node/v20.0.0" },
     );
 
@@ -113,7 +113,7 @@ describe("bootstrap", () => {
     const prompter = createFakePrompter();
 
     await bootstrap(
-      { yes: true, skipInstall: true },
+      { yes: true, skipInstall: true, directory: "." },
       { exec, prompter, isTty: true },
     );
 
@@ -138,7 +138,7 @@ describe("bootstrap", () => {
     const prompter = createFakePrompter();
 
     await bootstrap(
-      { yes: true, skipInstall: true },
+      { yes: true, skipInstall: true, directory: "." },
       {
         exec,
         prompter,
@@ -165,7 +165,7 @@ describe("bootstrap", () => {
     const prompter = createFakePrompter();
 
     await bootstrap(
-      { yes: true, skipInstall: true },
+      { yes: true, skipInstall: true, directory: "." },
       {
         exec,
         prompter,
@@ -189,7 +189,7 @@ describe("bootstrap", () => {
     const prompter = createFakePrompter();
 
     await bootstrap(
-      { yes: true, skipInstall: true },
+      { yes: true, skipInstall: true, directory: "." },
       { exec, prompter, isTty: true },
     );
 
@@ -215,8 +215,9 @@ describe("bootstrap", () => {
       note.title.includes("dry run"),
     );
     expect(planNote).toBeDefined();
+    expect(planNote?.message).toContain("create directory gassma-project");
     expect(planNote?.message).toContain("clasp create-script");
-    expect(planNote?.message).toContain("package.json");
+    expect(planNote?.message).toContain("write gassma-project/package.json");
     expect(planNote?.message).toContain("gassma init");
     expect(
       prompter.infos.every((message) => message.startsWith("[dry-run] ")),
@@ -247,7 +248,10 @@ describe("bootstrap", () => {
     });
     const prompter = createFakePrompter();
 
-    await bootstrap({ yes: true }, { exec, prompter, isTty: true });
+    await bootstrap(
+      { yes: true, directory: "." },
+      { exec, prompter, isTty: true },
+    );
 
     expect(prompter.warns.join(" ")).toContain("clasp create-script failed");
     expect(process.exitCode).toBe(1);
@@ -260,7 +264,7 @@ describe("bootstrap", () => {
     const prompter = createFakePrompter();
 
     await bootstrap(
-      { yes: true, skipInstall: true },
+      { yes: true, skipInstall: true, directory: "." },
       { exec, prompter, isTty: true },
     );
 
@@ -270,5 +274,114 @@ describe("bootstrap", () => {
     expect(commands.some((c) => c.includes("create-script"))).toBe(false);
     expect(prompter.infos.join(" ")).toContain("Skipping clasp create-script");
     expect(fs.existsSync(path.join(tmpDir, "package.json"))).toBe(true);
+  });
+
+  it("should create the given directory and bootstrap inside it", async () => {
+    const { calls, exec } = createClaspExec();
+    const prompter = createFakePrompter();
+
+    await bootstrap(
+      { yes: true, skipInstall: true, directory: "my-app" },
+      { exec, prompter, isTty: true },
+    );
+
+    const appDir = path.join(tmpDir, "my-app");
+    expect(process.exitCode).toBeUndefined();
+    expect(fs.realpathSync(process.cwd())).toBe(fs.realpathSync(appDir));
+    expect(fs.existsSync(path.join(appDir, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(appDir, "gassma", "schema.prisma"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(tmpDir, "package.json"))).toBe(false);
+
+    const createCall = calls.find((call) => call.args[0] === "create-script");
+    expect(createCall?.args).toContain("my-app");
+    expect(fs.realpathSync(createCall?.options?.cwd ?? "")).toBe(
+      fs.realpathSync(appDir),
+    );
+  });
+
+  it("should bootstrap into gassma-project when the directory is omitted with --yes", async () => {
+    const { exec } = createClaspExec();
+    const prompter = createFakePrompter();
+
+    await bootstrap(
+      { yes: true, skipInstall: true },
+      { exec, prompter, isTty: true },
+    );
+
+    expect(
+      fs.existsSync(path.join(tmpDir, "gassma-project", "package.json")),
+    ).toBe(true);
+  });
+
+  it("should stop when the target directory is not empty and the user declines", async () => {
+    fs.mkdirSync(path.join(tmpDir, "my-app"));
+    fs.writeFileSync(path.join(tmpDir, "my-app", "keep.txt"), "x");
+    const { calls, exec } = createClaspExec();
+    const prompter = createFakePrompter();
+
+    await bootstrap({ directory: "my-app" }, { exec, prompter, isTty: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(prompter.warns.join(" ")).toContain("cancelled");
+    expect(fs.existsSync(path.join(tmpDir, "my-app", "package.json"))).toBe(
+      false,
+    );
+    expect(calls.some((call) => call.args[0] === "create-script")).toBe(false);
+  });
+
+  it("should continue when the user accepts a non-empty directory", async () => {
+    fs.mkdirSync(path.join(tmpDir, "my-app"));
+    fs.writeFileSync(path.join(tmpDir, "my-app", "keep.txt"), "x");
+    const { exec } = createClaspExec();
+    const prompter = createFakePrompter({
+      confirm: { 'Directory "my-app" is not empty. Continue?': true },
+    });
+
+    await bootstrap(
+      { skipInstall: true, directory: "my-app" },
+      { exec, prompter, isTty: true },
+    );
+
+    expect(process.exitCode).toBeUndefined();
+    expect(fs.existsSync(path.join(tmpDir, "my-app", "package.json"))).toBe(
+      true,
+    );
+  });
+
+  it("should resume idempotently in a bootstrapped directory with --yes", async () => {
+    fs.mkdirSync(path.join(tmpDir, "my-app"));
+    fs.writeFileSync(path.join(tmpDir, "my-app", ".clasp.json"), "{}");
+    const { calls, exec } = createClaspExec();
+    const prompter = createFakePrompter();
+
+    await bootstrap(
+      { yes: true, skipInstall: true, directory: "my-app" },
+      { exec, prompter, isTty: true },
+    );
+
+    expect(process.exitCode).toBeUndefined();
+    expect(calls.some((call) => call.args[0] === "create-script")).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "my-app", "package.json"))).toBe(
+      true,
+    );
+  });
+
+  it("should not create the directory with --dry-run", async () => {
+    const { exec } = createClaspExec();
+    const prompter = createFakePrompter();
+
+    await bootstrap(
+      { yes: true, dryRun: true, directory: "my-app" },
+      { exec, prompter, isTty: true },
+    );
+
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+    const planNote = prompter.notes.find((note) =>
+      note.title.includes("dry run"),
+    );
+    expect(planNote?.message).toContain("create directory my-app");
+    expect(planNote?.message).toContain("write my-app/package.json");
   });
 });

--- a/packages/cli/src/__test__/bootstrap/env/targetDirectory.test.ts
+++ b/packages/cli/src/__test__/bootstrap/env/targetDirectory.test.ts
@@ -1,0 +1,101 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createDirectoryOps,
+  inspectDirectory,
+  resolveTargetDirectory,
+} from "../../../bootstrap/env/targetDirectory";
+
+describe("resolveTargetDirectory", () => {
+  it("should resolve a relative name against the cwd", () => {
+    expect(resolveTargetDirectory("/home/user", "my-app")).toBe(
+      path.resolve("/home/user", "my-app"),
+    );
+  });
+
+  it("should resolve '.' to the cwd itself", () => {
+    expect(resolveTargetDirectory("/home/user", ".")).toBe(
+      path.resolve("/home/user"),
+    );
+  });
+
+  it("should keep an absolute path as is", () => {
+    expect(resolveTargetDirectory("/home/user", "/opt/app")).toBe(
+      path.resolve("/opt/app"),
+    );
+  });
+
+  it("should treat a blank input as the cwd", () => {
+    expect(resolveTargetDirectory("/home/user", "  ")).toBe(
+      path.resolve("/home/user"),
+    );
+  });
+});
+
+describe("inspectDirectory", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-target-dir-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should report a missing path", () => {
+    expect(inspectDirectory(path.join(tmpDir, "nope"))).toBe("missing");
+  });
+
+  it("should report an empty directory", () => {
+    expect(inspectDirectory(tmpDir)).toBe("empty");
+  });
+
+  it("should report a non-empty directory", () => {
+    fs.writeFileSync(path.join(tmpDir, "a.txt"), "a");
+    expect(inspectDirectory(tmpDir)).toBe("nonEmpty");
+  });
+
+  it("should report a directory containing only dotfiles as non-empty", () => {
+    fs.writeFileSync(path.join(tmpDir, ".env"), "");
+    expect(inspectDirectory(tmpDir)).toBe("nonEmpty");
+  });
+
+  it("should report a file path as a file", () => {
+    const filePath = path.join(tmpDir, "file.txt");
+    fs.writeFileSync(filePath, "x");
+    expect(inspectDirectory(filePath)).toBe("file");
+  });
+});
+
+describe("createDirectoryOps", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-target-ops-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should create nested directories with ensure", () => {
+    const target = path.join(tmpDir, "a", "b");
+
+    createDirectoryOps().ensure(target);
+
+    expect(fs.statSync(target).isDirectory()).toBe(true);
+  });
+
+  it("should change the process cwd with changeTo", () => {
+    const original = process.cwd();
+    try {
+      createDirectoryOps().changeTo(tmpDir);
+      expect(process.cwd()).toBe(fs.realpathSync(tmpDir));
+    } finally {
+      process.chdir(original);
+    }
+  });
+});

--- a/packages/cli/src/__test__/bootstrap/flow/directoryStep.test.ts
+++ b/packages/cli/src/__test__/bootstrap/flow/directoryStep.test.ts
@@ -1,0 +1,212 @@
+import path from "path";
+import { describe, expect, it } from "vitest";
+import type { DirectoryStatus } from "../../../bootstrap/env/targetDirectory";
+import { createInitialContext } from "../../../bootstrap/flow/context";
+import { BootstrapCancelledError } from "../../../bootstrap/flow/prompts";
+import { directoryStep } from "../../../bootstrap/flow/steps/directoryStep";
+import { createFakePrompter, createTestDeps } from "./testHelpers";
+
+const CWD = "/project";
+
+const baseContext = () =>
+  createInitialContext({ cwd: CWD, packageManager: "npm" });
+
+const createFakeDirectoryOps = (status: DirectoryStatus) => {
+  const ensured: string[] = [];
+  const changedTo: string[] = [];
+  return {
+    ensured,
+    changedTo,
+    ops: {
+      inspect: () => status,
+      ensure: (dirPath: string) => {
+        ensured.push(dirPath);
+      },
+      changeTo: (dirPath: string) => {
+        changedTo.push(dirPath);
+      },
+    },
+  };
+};
+
+describe("directoryStep", () => {
+  it("should use the directory argument without prompting", async () => {
+    const fake = createFakeDirectoryOps("missing");
+    const prompter = {
+      ...createFakePrompter(),
+      text: () => Promise.reject(new Error("must not prompt")),
+    };
+    const deps = createTestDeps({
+      prompter,
+      directoryArg: "my-app",
+      directories: fake.ops,
+    });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    const target = path.join(CWD, "my-app");
+    expect(ctx.cwd).toBe(target);
+    expect(ctx.title).toBe("my-app");
+    expect(fake.ensured).toEqual([target]);
+    expect(fake.changedTo).toEqual([target]);
+  });
+
+  it("should ask for a directory with the gassma-project default", async () => {
+    const fake = createFakeDirectoryOps("missing");
+    const deps = createTestDeps({ directories: fake.ops });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    expect(ctx.cwd).toBe(path.join(CWD, "gassma-project"));
+    expect(ctx.title).toBe("gassma-project");
+  });
+
+  it("should use the answered directory name", async () => {
+    const fake = createFakeDirectoryOps("missing");
+    const prompter = createFakePrompter({
+      text: { "Project directory?": "answered-app" },
+    });
+    const deps = createTestDeps({ prompter, directories: fake.ops });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    expect(ctx.cwd).toBe(path.join(CWD, "answered-app"));
+  });
+
+  it("should keep the cwd for '.' without creating a directory", async () => {
+    const fake = createFakeDirectoryOps("empty");
+    const deps = createTestDeps({
+      directoryArg: ".",
+      directories: fake.ops,
+    });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    expect(ctx.cwd).toBe(path.resolve(CWD));
+    expect(ctx.title).toBe("project");
+    expect(fake.ensured).toEqual([]);
+    expect(fake.changedTo).toEqual([path.resolve(CWD)]);
+  });
+
+  it("should cancel when the user declines a non-empty directory", async () => {
+    const fake = createFakeDirectoryOps("nonEmpty");
+    const deps = createTestDeps({
+      directoryArg: "my-app",
+      directories: fake.ops,
+    });
+
+    await expect(directoryStep.run(baseContext(), deps)).rejects.toThrow(
+      BootstrapCancelledError,
+    );
+    expect(fake.changedTo).toEqual([]);
+  });
+
+  it("should continue when the user accepts a non-empty directory", async () => {
+    const fake = createFakeDirectoryOps("nonEmpty");
+    const prompter = createFakePrompter({
+      confirm: { 'Directory "my-app" is not empty. Continue?': true },
+    });
+    const deps = createTestDeps({
+      prompter,
+      directoryArg: "my-app",
+      directories: fake.ops,
+    });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    expect(ctx.cwd).toBe(path.join(CWD, "my-app"));
+    expect(fake.ensured).toEqual([]);
+    expect(fake.changedTo).toEqual([path.join(CWD, "my-app")]);
+  });
+
+  it("should continue in a non-empty directory with --yes", async () => {
+    const fake = createFakeDirectoryOps("nonEmpty");
+    const deps = createTestDeps({
+      assumeYes: true,
+      directoryArg: "my-app",
+      directories: fake.ops,
+    });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    expect(ctx.cwd).toBe(path.join(CWD, "my-app"));
+  });
+
+  it("should fail when the target is an existing file", async () => {
+    const fake = createFakeDirectoryOps("file");
+    const deps = createTestDeps({
+      directoryArg: "my-app",
+      directories: fake.ops,
+    });
+
+    await expect(directoryStep.run(baseContext(), deps)).rejects.toThrow(
+      '"my-app" already exists and is not a directory.',
+    );
+  });
+
+  it("should only plan the directory creation in dry-run mode", async () => {
+    const fake = createFakeDirectoryOps("missing");
+    const deps = createTestDeps({
+      dryRun: true,
+      directoryArg: "my-app",
+      directories: fake.ops,
+    });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    expect(deps.plannedActions).toEqual(["create directory my-app"]);
+    expect(fake.ensured).toEqual([]);
+    expect(fake.changedTo).toEqual([]);
+    expect(ctx.cwd).toBe(path.join(CWD, "my-app"));
+  });
+
+  it("should not plan a directory creation for an existing directory in dry-run mode", async () => {
+    const fake = createFakeDirectoryOps("empty");
+    const deps = createTestDeps({
+      dryRun: true,
+      directoryArg: ".",
+      directories: fake.ops,
+    });
+
+    await directoryStep.run(baseContext(), deps);
+
+    expect(deps.plannedActions).toEqual([]);
+    expect(fake.changedTo).toEqual([]);
+  });
+
+  it("should detect the package manager from the parent for a missing directory", async () => {
+    const fake = createFakeDirectoryOps("missing");
+    const detectedFrom: string[] = [];
+    const deps = createTestDeps({
+      directoryArg: "my-app",
+      directories: fake.ops,
+      detectPackageManager: (cwd) => {
+        detectedFrom.push(cwd);
+        return Promise.resolve("pnpm");
+      },
+    });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    expect(detectedFrom).toEqual([CWD]);
+    expect(ctx.packageManager).toBe("pnpm");
+  });
+
+  it("should detect the package manager from an existing target directory", async () => {
+    const fake = createFakeDirectoryOps("empty");
+    const detectedFrom: string[] = [];
+    const deps = createTestDeps({
+      directoryArg: "my-app",
+      directories: fake.ops,
+      detectPackageManager: (cwd) => {
+        detectedFrom.push(cwd);
+        return Promise.resolve("yarn");
+      },
+    });
+
+    const ctx = await directoryStep.run(baseContext(), deps);
+
+    expect(detectedFrom).toEqual([path.join(CWD, "my-app")]);
+    expect(ctx.packageManager).toBe("yarn");
+  });
+});

--- a/packages/cli/src/__test__/bootstrap/flow/testHelpers.ts
+++ b/packages/cli/src/__test__/bootstrap/flow/testHelpers.ts
@@ -113,6 +113,13 @@ const createTestDeps = (
     plannedActions: planned,
     dryRun: false,
     skipInstall: false,
+    assumeYes: false,
+    directories: {
+      inspect: () => "empty",
+      ensure: () => undefined,
+      changeTo: () => undefined,
+    },
+    detectPackageManager: () => Promise.resolve("npm"),
     gassmaVersion: "1.1.0",
     templates: loadBootstrapTemplates(),
     ...overrides,

--- a/packages/cli/src/__test__/command/bootstrapFlag.test.ts
+++ b/packages/cli/src/__test__/command/bootstrapFlag.test.ts
@@ -46,9 +46,27 @@ describe("gassma bootstrap (e2e)", () => {
         { cwd: tmpDir, stdio: "pipe" },
       ).toString();
 
+      expect(output).toContain("create directory gassma-project");
       expect(output).toContain("clasp create-script");
-      expect(output).toContain("write package.json");
+      expect(output).toContain("write gassma-project/package.json");
       expect(output).toContain("gassma init");
+      expect(output).toContain("Dry run complete");
+      expect(fs.readdirSync(tmpDir)).toEqual([]);
+    },
+  );
+
+  it(
+    "should plan the given directory for --dry-run --yes with a directory argument",
+    { timeout: 120_000 },
+    () => {
+      const output = execFileSync(
+        process.execPath,
+        [tsxCli, commandTs, "bootstrap", "my-app", "--dry-run", "--yes"],
+        { cwd: tmpDir, stdio: "pipe" },
+      ).toString();
+
+      expect(output).toContain("create directory my-app");
+      expect(output).toContain("write my-app/package.json");
       expect(output).toContain("Dry run complete");
       expect(fs.readdirSync(tmpDir)).toEqual([]);
     },

--- a/packages/cli/src/bootstrap/bootstrapCommand.ts
+++ b/packages/cli/src/bootstrap/bootstrapCommand.ts
@@ -7,6 +7,7 @@ import { createDefaultFetchText } from "./env/fetchLatestLibraryVersion";
 import type { FetchTextFn } from "./env/fetchLatestLibraryVersion";
 import { createFsFileStore } from "./env/fileStore";
 import { loadBootstrapTemplates } from "./env/readTemplate";
+import { createDirectoryOps } from "./env/targetDirectory";
 import { buildBootstrapSteps } from "./flow/buildSteps";
 import { createInitialContext, runSteps } from "./flow/context";
 import type { BootstrapDeps } from "./flow/context";
@@ -20,6 +21,7 @@ import {
 import type { Prompter } from "./flow/prompts";
 
 type BootstrapOptions = {
+  directory?: string;
   yes?: boolean;
   skipInstall?: boolean;
   dryRun?: boolean;
@@ -97,16 +99,15 @@ const bootstrap = async (
     plannedActions: env.plannedActions,
     dryRun,
     skipInstall: options.skipInstall === true,
+    assumeYes: yes,
+    directoryArg: options.directory,
+    directories: createDirectoryOps(),
+    detectPackageManager: (directory) =>
+      detectPackageManager({ cwd: directory, userAgent: overrides.userAgent }),
     gassmaVersion: getVersion(),
     templates: loadBootstrapTemplates(),
   };
-  const initialContext = createInitialContext({
-    cwd,
-    packageManager: await detectPackageManager({
-      cwd,
-      userAgent: overrides.userAgent,
-    }),
-  });
+  const initialContext = createInitialContext({ cwd, packageManager: "npm" });
 
   prompter.intro("gassma bootstrap");
   try {

--- a/packages/cli/src/bootstrap/env/targetDirectory.ts
+++ b/packages/cli/src/bootstrap/env/targetDirectory.ts
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+
+type DirectoryStatus = "missing" | "file" | "empty" | "nonEmpty";
+
+type DirectoryOps = {
+  inspect: (dirPath: string) => DirectoryStatus;
+  ensure: (dirPath: string) => void;
+  changeTo: (dirPath: string) => void;
+};
+
+const resolveTargetDirectory = (cwd: string, input: string): string => {
+  const trimmed = input.trim();
+  return path.resolve(cwd, trimmed === "" ? "." : trimmed);
+};
+
+const inspectDirectory = (dirPath: string): DirectoryStatus => {
+  if (!fs.existsSync(dirPath)) return "missing";
+  if (!fs.statSync(dirPath).isDirectory()) return "file";
+  return fs.readdirSync(dirPath).length === 0 ? "empty" : "nonEmpty";
+};
+
+const createDirectoryOps = (): DirectoryOps => ({
+  inspect: inspectDirectory,
+  ensure: (dirPath) => {
+    fs.mkdirSync(dirPath, { recursive: true });
+  },
+  changeTo: (dirPath) => {
+    process.chdir(dirPath);
+  },
+});
+
+export { createDirectoryOps, inspectDirectory, resolveTargetDirectory };
+export type { DirectoryOps, DirectoryStatus };

--- a/packages/cli/src/bootstrap/flow/buildSteps.ts
+++ b/packages/cli/src/bootstrap/flow/buildSteps.ts
@@ -7,6 +7,7 @@ import {
   titleStep,
 } from "./steps/askSteps";
 import { claspCreateStep, manifestStep } from "./steps/claspSteps";
+import { directoryStep } from "./steps/directoryStep";
 import { installRunStep, nextStepsStep } from "./steps/finishSteps";
 import {
   initStep,
@@ -16,6 +17,7 @@ import {
 
 // Future questions (e.g. linter selection) are added by inserting a step here.
 const buildBootstrapSteps = (): BootstrapStep[] => [
+  directoryStep,
   titleStep,
   sheetsStep,
   claspCreateStep,

--- a/packages/cli/src/bootstrap/flow/context.ts
+++ b/packages/cli/src/bootstrap/flow/context.ts
@@ -4,6 +4,7 @@ import type { ExecFn } from "../env/execCommand";
 import type { FetchTextFn } from "../env/fetchLatestLibraryVersion";
 import type { FileStore } from "../env/fileStore";
 import type { BootstrapTemplates } from "../env/readTemplate";
+import type { DirectoryOps } from "../env/targetDirectory";
 import type { FunctionStyle } from "../functionStyle";
 import type { Prompter } from "./prompts";
 
@@ -28,6 +29,10 @@ type BootstrapDeps = {
   plannedActions: readonly string[];
   dryRun: boolean;
   skipInstall: boolean;
+  assumeYes: boolean;
+  directoryArg?: string;
+  directories: DirectoryOps;
+  detectPackageManager: (cwd: string) => Promise<PackageManager>;
   gassmaVersion: string;
   templates: BootstrapTemplates;
 };

--- a/packages/cli/src/bootstrap/flow/steps/directoryStep.ts
+++ b/packages/cli/src/bootstrap/flow/steps/directoryStep.ts
@@ -1,0 +1,63 @@
+import path from "path";
+import { resolveTargetDirectory } from "../../env/targetDirectory";
+import type { BootstrapContext, BootstrapDeps } from "../context";
+import type { BootstrapStep } from "../context";
+import { BootstrapCancelledError } from "../prompts";
+
+const DEFAULT_DIRECTORY = "gassma-project";
+
+const confirmNonEmpty = async (
+  input: string,
+  deps: BootstrapDeps,
+): Promise<void> => {
+  const proceed = await deps.prompter.confirm(
+    `Directory "${input}" is not empty. Continue?`,
+    deps.assumeYes,
+  );
+  if (!proceed) throw new BootstrapCancelledError();
+};
+
+const enterDirectory = (
+  context: BootstrapContext,
+  deps: BootstrapDeps,
+  target: string,
+  missing: boolean,
+): void => {
+  if (deps.dryRun) {
+    if (!missing) return;
+    const relative = path.relative(context.cwd, target);
+    deps.plan(`create directory ${relative === "" ? target : relative}`);
+    return;
+  }
+  if (missing) deps.directories.ensure(target);
+  deps.directories.changeTo(target);
+};
+
+const directoryStep: BootstrapStep = {
+  id: "directory",
+  run: async (context, deps) => {
+    const input =
+      deps.directoryArg ??
+      (await deps.prompter.text("Project directory?", DEFAULT_DIRECTORY));
+    const target = resolveTargetDirectory(context.cwd, input);
+    const status = deps.directories.inspect(target);
+
+    if (status === "file") {
+      throw new Error(`"${input}" already exists and is not a directory.`);
+    }
+    if (status === "nonEmpty") await confirmNonEmpty(input, deps);
+
+    enterDirectory(context, deps, target, status === "missing");
+
+    return {
+      ...context,
+      cwd: target,
+      title: path.basename(target) || context.title,
+      packageManager: await deps.detectPackageManager(
+        status === "missing" ? context.cwd : target,
+      ),
+    };
+  },
+};
+
+export { directoryStep };

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -72,14 +72,19 @@ program
   .description(
     "Set up a local GAS development environment (clasp + esbuild + TypeScript + GASsma)",
   )
+  .argument(
+    "[directory]",
+    'Directory to set up the project in ("." for the current directory)',
+  )
   .option("--yes", "Answer all prompts with their default values")
   .option("--skip-install", "Skip dependency installation")
   .option(
     "--dry-run",
     "Show planned actions without writing files or running commands",
   )
-  .action(async (options) => {
+  .action(async (directory, options) => {
     await bootstrap({
+      directory,
       yes: options.yes,
       skipInstall: options.skipInstall,
       dryRun: options.dryRun,


### PR DESCRIPTION
## 概要

`gassma bootstrap` に **create-vite 型のディレクトリ引数**を追加しました。従来は「ディレクトリを自前で作って中で実行」のみでしたが、ツール側がディレクトリ作成から面倒を見ます。

```
npx gassma bootstrap my-app   # my-app/ を作成して中に構築
npx gassma bootstrap          # 引数省略 → 最初に "Project directory?" を質問(default: gassma-project)
npx gassma bootstrap .        # カレントに構築(従来の in-place はこれで表現。create-vite と同じ規約)
```

## 設計の経緯

- bootstrap は元々**新規プロジェクト専用**なので「ディレクトリを作るところまでが仕事」が自然
- 当初 in-place 維持の論拠だった「冪等な再実行」は、実際には**中断からの再開**のみが実ユースケースであり、それはディレクトリ引数モデルでも「非空 dir → 続行確認 → 既存 .clasp.json で clasp create スキップ」で完全に保たれる(E2E で再開経路を実証済み)

## 挙動の詳細

- 存在しない dir は作成、**存在して非空なら続行確認**(default No、`--yes` で自動続行 = 中断再開の経路)。同名ファイルが存在する場合は明確なエラー
- **Project title の既定値 = 対象ディレクトリ名**
- PM 検出は対象ディレクトリ基準(未作成時は親基準)
- `--dry-run` は **mkdir すらしない**(plan に `create directory my-app` + `write my-app/...` を表示)
- ディレクトリ質問は BootstrapStep のリスト先頭への1ステップ挿入で実現(設計時に用意した拡張点をそのまま使用)
- **`--yes` の挙動変更**: 引数なしの `--yes` は従来「カレントに構築」→ 新「`./gassma-project` を作成して構築」(「--yes は全質問に default で答える」の一貫性。未 publish のため互換性問題なし)

## 検証

- **1026テスト**(+30)green、typecheck / lint / format / build clean(git worktree 内で実装・検証)
- 偽 clasp シム E2E 4種: 新規 dir 作成 / 同コマンド再実行での冪等再開 / `.` で従来同等の生成物 / dry-run の書き込み・mkdir ゼロ
- マージ後の dev(並行の transaction client #130 と合成)でも **1122テスト全 green** を再確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja