### PR TITLE
feat: unlock the rollback transaction option in generated types (core #169 follow-up)

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -38,7 +38,7 @@ describe("getGassmaCommonTypes", () => {
     expect(result).toContain("type GassmaTransactionOptions = {");
     expect(result).toContain("maxWait?: number");
     expect(result).toContain("timeout?: number");
-    expect(result).not.toContain("rollback");
+    expect(result).toContain("rollback?: boolean");
     expect(result).not.toContain("isolationLevel");
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -18,6 +18,11 @@ describe("getGassmaErrorClasses", () => {
     expect(result).toContain(
       "class GassmaNestedTransactionError extends Error",
     );
+    expect(result).toContain(
+      "class GassmaTransactionRollbackError extends Error",
+    );
+    expect(result).toContain("constructor(backupSheetNames: string[])");
+    expect(result).toContain("readonly backupSheetNames: string[];");
   });
 
   it("should include GassmaSkipNegativeError", () => {

--- a/packages/cli/src/__test__/types/transaction/transaction.test-d.ts
+++ b/packages/cli/src/__test__/types/transaction/transaction.test-d.ts
@@ -49,14 +49,18 @@ declare const strictClient: StrictGassmaClient;
   });
 }
 
-// options は maxWait / timeout のみ
+// options は maxWait / timeout / rollback のみ
 {
   client.$transaction(() => 1, {});
   client.$transaction(() => 1, { maxWait: 1000 });
   client.$transaction(() => 1, { maxWait: 1000, timeout: 2000 });
-
-  // @ts-expect-error rollback オプションは存在しない
   client.$transaction(() => 1, { rollback: false });
+  client.$transaction(() => 1, { rollback: true });
+  client.$transaction(() => 1, {
+    maxWait: 1000,
+    timeout: 2000,
+    rollback: true,
+  });
 
   // @ts-expect-error isolationLevel オプションは存在しない
   client.$transaction(() => 1, { isolationLevel: "Serializable" });
@@ -120,4 +124,11 @@ declare const strictClient: StrictGassmaClient;
   >().toEqualTypeOf<
     [phase: "query" | "commit", timeoutMs: number, elapsedMs: number]
   >();
+  expectTypeOf<Gassma.GassmaTransactionRollbackError>().toExtend<Error>();
+  expectTypeOf<
+    ConstructorParameters<typeof Gassma.GassmaTransactionRollbackError>
+  >().toEqualTypeOf<[backupSheetNames: string[]]>();
+  expectTypeOf<
+    Gassma.GassmaTransactionRollbackError["backupSheetNames"]
+  >().toEqualTypeOf<string[]>();
 }

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -87,6 +87,7 @@ const getGassmaCommonTypes = (strict?: boolean) => {
   type GassmaTransactionOptions = {
     maxWait?: number;
     timeout?: number;
+    rollback?: boolean;
   };
 
   type ManyReturn = {

--- a/packages/cli/src/generate/typeGenerate/gassmaErrorClasses.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaErrorClasses.ts
@@ -5,8 +5,11 @@ const getGassmaErrorClasses = () => {
     const ctorLine = def.params
       ? `    constructor(${def.params});\n`
       : `    constructor();\n`;
+    const memberLines = (def.members ?? [])
+      .map((member) => `    ${member};\n`)
+      .join("");
 
-    return `${pre}  class ${def.name} extends ${def.extends} {\n${ctorLine}  }\n`;
+    return `${pre}  class ${def.name} extends ${def.extends} {\n${ctorLine}${memberLines}  }\n`;
   }, "");
 };
 

--- a/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -2,6 +2,7 @@ type ErrorClassDef = {
   name: string;
   extends: string;
   params: string;
+  members?: string[];
 };
 
 const errorClassDefinitions: ErrorClassDef[] = [
@@ -173,6 +174,12 @@ const errorClassDefinitions: ErrorClassDef[] = [
     params: 'phase: "query" | "commit", timeoutMs: number, elapsedMs: number',
   },
   { name: "GassmaNestedTransactionError", extends: "Error", params: "" },
+  {
+    name: "GassmaTransactionRollbackError",
+    extends: "Error",
+    params: "backupSheetNames: string[]",
+    members: ["readonly backupSheetNames: string[]"],
+  },
 ];
 
 export { errorClassDefinitions };


### PR DESCRIPTION
## 概要

core の rollback(akahoshi1421/gassma#169、$transaction Phase 3)への cli 追随です。

- `Gassma.GassmaTransactionOptions` に `rollback?: boolean`(core と同順: maxWait → timeout → rollback)
- エラーミラーのレンダラーに **members 宣言のサポート**を追加し、`GassmaTransactionRollbackError` を `readonly backupSheetNames: string[]` プロパティ付きで生成(core dev 1e9d6ab の宣言と両 fixture で逐語一致を確認)
- **#130 の「rollback は型エラー」ピンを正例3本に反転**(`{rollback: false}` / `{rollback: true}` / 全オプション同時)。isolationLevel・配列形の拒否ピンは維持

## テスト

1121 全 pass(既存 it へのアサーション追加のため件数不変)+ test-d に RollbackError の toExtend / ConstructorParameters / プロパティ型検証。Red 実測(単体2 fail + 型チェック8箇所)→ Green、実装 stash の逆検証も再現。test:types 型エラー0 / typecheck / lint / format / build 全 green。

これで **$transaction は core/cli とも仕様の完成形**です。マージ後は gassma-test 追随(rollback 実機検証+ambient 再同期+surface 51 実体)を経てリリース時セットへ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX