### PR TITLE
docs: refresh npm README (en/ja) to match current CLI features

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -10,6 +10,8 @@ Without GASsma-cli, you need to manually write GASsma-specific configurations su
 
 ## Usage
 
+> Starting a new project? `npx gassma bootstrap` sets up a local GAS development environment (clasp + esbuild + TypeScript + GASsma) in one command. See [bootstrap](#bootstrap) below. The following steps are for adding GASsma to an existing project.
+
 1. Install GASsma-cli
 
 ```sh
@@ -22,7 +24,7 @@ npm i gassma
 npx gassma init
 ```
 
-It will generate `schema.prisma` and `gassma.config.ts` after executing the above command.
+It will generate `gassma/schema.prisma` and `gassma.config.ts` after executing the above command.
 
 3. Write database definition and config
 
@@ -31,14 +33,14 @@ Example...
 ```prisma
 generator client {
   provider = "prisma-client-js"
-  output   = "./generated/gassma"
+  output   = "./src/generated/gassma"
 }
 
 model User {
-  id    Int     @id @default(autoincrement())
-  name  String
-  email String?
-  age   Int
+  id      Int      @id @default(autoincrement())
+  name    String
+  email   String?
+  age     Int
   profile Profile?
 }
 
@@ -46,7 +48,7 @@ model Profile {
   id      Int     @id @default(autoincrement())
   bio     String?
   website String?
-  userId  Int     @id
+  userId  Int     @unique
   user    User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }
 ```
@@ -70,14 +72,16 @@ export default defineConfig({
 npx gassma generate
 ```
 
-`schemaClient.js` and `schemaClient.d.ts` will be generated.
+`schemaClient.js` and `schemaClient.d.ts` will be generated in the `output` directory of the generator block.
+
+The file name is derived from the schema file name (`schema.prisma` -> `schemaClient.*`). You can also split the schema into multiple `.prisma` files in the same directory; they are merged automatically, and the file name is then derived from the directory name (`gassma/` -> `gassmaClient.*`).
 
 5. Development
 
 You can develop with GASsma just like Prisma by importing the generated client file (`schemaClient.js`), which includes database relations and other definitions.
 
 ```ts
-import { GassmaClient } from "../generated/gassma2/schemaClient";
+import { GassmaClient } from "./generated/gassma/schemaClient";
 
 const gassma = new GassmaClient();
 
@@ -96,7 +100,7 @@ function myFunction() {
 
 ### init
 
-Generate schema file and `gassma.config.ts` file.
+Generate `gassma/schema.prisma` and a `gassma.config.ts` file.
 
 #### options
 
@@ -107,49 +111,50 @@ Generate schema file and `gassma.config.ts` file.
 
 ### generate
 
-Generate type definition files and a client JS file with relation settings, autoincrement, default values, and more from .prisma files.
+Generate type definition files and a client JS file with relation settings, autoincrement, default values, and more from `.prisma` files.
 
 #### options
 
 |name|description|
 |--|--|
 |`--schema <path>`|Path to a specific .prisma file to generate|
+|`--config <path>`|Custom path to your GASsma config file|
 |`--watch`|Watch for changes and regenerate automatically|
 
 ### format
 
-Format .prisma files.
+Format `.prisma` files.
 
 #### options
 
 |name|description|
 |--|--|
 |`--schema <path>`|Path to a specific .prisma file to format|
+|`--config <path>`|Custom path to your GASsma config file|
 |`--check`|Check if files are formatted without modifying them|
 
 ### validate
 
-Validate .prisma files.
+Validate `.prisma` files.
 
 #### options
 
 |name|description|
 |--|--|
 |`--schema <path>`|Path to a specific .prisma file to validate|
+|`--config <path>`|Custom path to your GASsma config file|
 
 ### bootstrap
 
-Interactively set up a local GAS development environment (clasp + esbuild + TypeScript + GASsma). It creates an Apps Script project via `clasp create-script`, registers the GASsma library in `dist/appsscript.json`, generates `package.json`, `esbuild.mjs`, `tsconfig.json`, `.gitignore` and a sample `src/index.ts`, runs `gassma init`, and installs dependencies.
+Interactively set up a local GAS development environment (clasp + esbuild + TypeScript + GASsma). It creates an Apps Script project via clasp, registers the GASsma library, generates project files (`package.json`, `esbuild.mjs`, `tsconfig.json`, `.gitignore`, a sample `src/index.ts`), runs `gassma init`, and installs dependencies.
 
 ```sh
 npx gassma bootstrap my-app   # create my-app/ and set up inside it
-npx gassma bootstrap          # ask for a directory first (default: gassma-project)
+npx gassma bootstrap          # ask for a directory first
 npx gassma bootstrap .        # set up in the current directory
 ```
 
-If the target directory does not exist, it is created. If it exists and is not empty, bootstrap asks for confirmation before continuing (`--yes` continues automatically), so re-running the same command resumes an interrupted setup.
-
-Requires [clasp](https://github.com/google/clasp): `npm install -g @google/clasp`, then `clasp login`.
+Requires [clasp](https://github.com/google/clasp): `npm install -g @google/clasp`, then `clasp login`. See the [bootstrap reference](https://akahoshi1421.github.io/gassma-reference/en/docs/reference/bootstrap) for details.
 
 #### arguments
 
@@ -164,6 +169,43 @@ Requires [clasp](https://github.com/google/clasp): `npm install -g @google/clasp
 |`--yes`|Answer all prompts with their default values|
 |`--skip-install`|Skip dependency installation|
 |`--dry-run`|Show planned actions without writing files or running commands|
+
+### studio
+
+Open the datasource spreadsheet in your default browser.
+
+#### options
+
+|name|description|
+|--|--|
+|`--config <path>`|Custom path to your GASsma config file|
+
+### debug
+
+Print information helpful for debugging and bug reports (runtime, config, schema, clasp, and more).
+
+#### options
+
+|name|description|
+|--|--|
+|`--schema <path>`|Path to a specific .prisma file to inspect|
+|`--config <path>`|Custom path to your GASsma config file|
+
+### version
+
+Display the current version of GASsma CLI.
+
+#### options
+
+|name|description|
+|--|--|
+|`--json`|Output version information as JSON|
+
+## Config file
+
+The config file is searched in the current directory in the order `gassma.config.{js,ts,mjs,cjs,mts,cts}`, then `.config/gassma.{js,ts,mjs,cjs,mts,cts}`. `--config <path>` overrides the search. The `env("NAME")` helper from `gassma/config` reads environment variables in the config file.
+
+The schema also supports `previewFeatures = ["strictUndefinedChecks"]` in the generator block. See the [strictUndefinedChecks reference](https://akahoshi1421.github.io/gassma-reference/en/docs/reference/config/strict-undefined-checks) for details.
 
 ## Detail reference
 

--- a/packages/cli/docs/README.ja.md
+++ b/packages/cli/docs/README.ja.md
@@ -10,6 +10,8 @@ GASsma-cli を使わない場合、リレーションやデフォルト値など
 
 ## 使い方
 
+> 新規プロジェクトなら `npx gassma bootstrap` 一発で、GAS のローカル開発環境（clasp + esbuild + TypeScript + GASsma）をまとめてセットアップできます。詳細は下の [bootstrap](#bootstrap) を参照してください。以下の手順は既存プロジェクトに GASsma を追加する場合のものです。
+
 1. GASsma-cli をインストール
 
 ```sh
@@ -22,7 +24,7 @@ npm i gassma
 npx gassma init
 ```
 
-上記コマンドを実行すると、`schema.prisma` と `gassma.config.ts` が生成されます。
+上記コマンドを実行すると、`gassma/schema.prisma` と `gassma.config.ts` が生成されます。
 
 3. データベース定義と設定を記述
 
@@ -31,14 +33,14 @@ npx gassma init
 ```prisma
 generator client {
   provider = "prisma-client-js"
-  output   = "./generated/gassma"
+  output   = "./src/generated/gassma"
 }
 
 model User {
-  id    Int     @id @default(autoincrement())
-  name  String
-  email String?
-  age   Int
+  id      Int      @id @default(autoincrement())
+  name    String
+  email   String?
+  age     Int
   profile Profile?
 }
 
@@ -46,7 +48,7 @@ model Profile {
   id      Int     @id @default(autoincrement())
   bio     String?
   website String?
-  userId  Int     @id
+  userId  Int     @unique
   user    User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }
 ```
@@ -70,14 +72,16 @@ export default defineConfig({
 npx gassma generate
 ```
 
-`schemaClient.js` と `schemaClient.d.ts` が生成されます。
+generator ブロックの `output` ディレクトリに `schemaClient.js` と `schemaClient.d.ts` が生成されます。
+
+ファイル名はスキーマファイル名から決まります（`schema.prisma` -> `schemaClient.*`）。スキーマは同じディレクトリ内の複数の `.prisma` ファイルに分割することもでき、自動でマージされます。その場合のファイル名はディレクトリ名から決まります（`gassma/` -> `gassmaClient.*`）。
 
 5. 開発
 
 生成されたクライアントファイル（`schemaClient.js`）をインポートすることで、データベースのリレーションやその他の定義が組み込まれた状態で、Prisma と同じように GASsma で開発できます。
 
 ```ts
-import { GassmaClient } from "../generated/gassma2/schemaClient";
+import { GassmaClient } from "./generated/gassma/schemaClient";
 
 const gassma = new GassmaClient();
 
@@ -96,7 +100,7 @@ function myFunction() {
 
 ### init
 
-スキーマファイルと `gassma.config.ts` ファイルを生成します。
+`gassma/schema.prisma` と `gassma.config.ts` ファイルを生成します。
 
 #### オプション
 
@@ -114,6 +118,7 @@ function myFunction() {
 |名前|説明|
 |--|--|
 |`--schema <path>`|生成対象の `.prisma` ファイルのパス|
+|`--config <path>`|GASsma config ファイルのカスタムパス|
 |`--watch`|変更を監視して自動的に再生成|
 
 ### format
@@ -125,6 +130,7 @@ function myFunction() {
 |名前|説明|
 |--|--|
 |`--schema <path>`|フォーマット対象の `.prisma` ファイルのパス|
+|`--config <path>`|GASsma config ファイルのカスタムパス|
 |`--check`|ファイルを変更せずにフォーマット済みかチェック|
 
 ### validate
@@ -136,6 +142,70 @@ function myFunction() {
 |名前|説明|
 |--|--|
 |`--schema <path>`|バリデーション対象の `.prisma` ファイルのパス|
+|`--config <path>`|GASsma config ファイルのカスタムパス|
+
+### bootstrap
+
+GAS のローカル開発環境（clasp + esbuild + TypeScript + GASsma）を対話形式でセットアップします。clasp で Apps Script プロジェクトを作成し、GASsma ライブラリを登録し、プロジェクトファイル（`package.json`・`esbuild.mjs`・`tsconfig.json`・`.gitignore`・サンプルの `src/index.ts`）を生成して `gassma init` を実行し、依存関係をインストールします。
+
+```sh
+npx gassma bootstrap my-app   # my-app/ を作成してその中にセットアップ
+npx gassma bootstrap          # 最初にディレクトリを質問
+npx gassma bootstrap .        # カレントディレクトリにセットアップ
+```
+
+[clasp](https://github.com/google/clasp) が必要です: `npm install -g @google/clasp` の後、`clasp login` してください。詳細は [bootstrap リファレンス](https://akahoshi1421.github.io/gassma-reference/docs/reference/bootstrap)を参照してください。
+
+#### 引数
+
+|名前|説明|
+|--|--|
+|`[directory]`|セットアップ先のディレクトリ（カレントディレクトリなら `.`）。省略すると対話で質問|
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--yes`|すべての質問にデフォルト値で回答|
+|`--skip-install`|依存関係のインストールをスキップ|
+|`--dry-run`|ファイルの書き込みやコマンド実行をせずに実行予定の内容を表示|
+
+### studio
+
+データソースのスプレッドシートをデフォルトブラウザで開きます。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--config <path>`|GASsma config ファイルのカスタムパス|
+
+### debug
+
+デバッグやバグ報告に役立つ情報（ランタイム・config・スキーマ・clasp など）を表示します。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--schema <path>`|調査対象の `.prisma` ファイルのパス|
+|`--config <path>`|GASsma config ファイルのカスタムパス|
+
+### version
+
+GASsma CLI の現在のバージョンを表示します。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--json`|バージョン情報を JSON で出力|
+
+## config ファイル
+
+config ファイルはカレントディレクトリから `gassma.config.{js,ts,mjs,cjs,mts,cts}`、次に `.config/gassma.{js,ts,mjs,cjs,mts,cts}` の順で探索されます。`--config <path>` で探索を上書きできます。`gassma/config` の `env("NAME")` ヘルパーで config ファイル内から環境変数を読み取れます。
+
+スキーマの generator ブロックでは `previewFeatures = ["strictUndefinedChecks"]` もサポートしています。詳細は [strictUndefinedChecks リファレンス](https://akahoshi1421.github.io/gassma-reference/docs/reference/config/strict-undefined-checks)を参照してください。
 
 ## 詳細リファレンス
 


### PR DESCRIPTION
## 概要

npm publish 時にパッケージページへそのまま載る README(en + docs/README.ja.md、pack の files allowlist 掲載パス)を現行機能に刷新します(ユーザー指摘: 情報が古い)。

## 修正点

1. **コマンドリファレンス補完**: 全8コマンド(init / generate / format / validate / **bootstrap / studio / debug / version**)を両言語に。各1〜2行+オプション表の簡潔さは維持し、詳細はリファレンスサイトへ誘導
2. **`--config` と config 探索規則**の節を新設(探索順・`env()` ヘルパー1行)
3. **不正サンプルスキーマの修正**: Profile の `@id` 二重 → `userId Int @unique`。**修正後スキーマを実 CLI の `gassma validate` にかけて valid を確認済み**
4. **生成物・パスの整合**: init 生成物は `gassma/schema.prisma`、サンプル output は init テンプレート実物の `./src/generated/gassma`、import 例の `gassma2` 誤記修正
5. **生成ファイル名規則を明記**: 単一ファイル→ファイル名由来(`schema.prisma` → `schemaClient.*`)/ 複数 `.prisma` →ディレクトリ名由来(`gassma/` → `gassmaClient.*`)— `deriveSchemaName` 実装どおり。既存記述の `schemaClient.js` は init 既定(単一ファイル)では**実は正しかった**と判明
6. **bootstrap 導線**: 冒頭に「新規プロジェクトは `npx gassma bootstrap` 一発」(実オプション `--yes`/`--skip-install`/`--dry-run`・`[directory]` 引数を実装と突き合わせ)
7. previewFeatures(strictUndefinedChecks)を1行+リンクで言及
8. **ja/en 完全一致化**(ja は bootstrap 含む4コマンド欠落だった)

## リンク検証

README 内の reference リンク3種(`/reference/type-generation`・`/reference/bootstrap`・`/reference/config/strict-undefined-checks`)は、reference リポジトリ main の frontmatter slug と照合済み(実在ページのみ使用)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX