### PR TITLE
feat: scaffold AGENTS.md in gassma bootstrap

### DIFF
--- a/packages/cli/src/__test__/bootstrap/bootstrapCommand.test.ts
+++ b/packages/cli/src/__test__/bootstrap/bootstrapCommand.test.ts
@@ -90,6 +90,12 @@ describe("bootstrap", () => {
         "utf-8",
       ),
     );
+    expect(fs.readFileSync(path.join(tmpDir, "AGENTS.md"), "utf-8")).toBe(
+      fs.readFileSync(
+        path.resolve(__dirname, "../../../templates/AGENTS.md.template"),
+        "utf-8",
+      ),
+    );
     expect(fs.existsSync(path.join(tmpDir, "src", "index.ts"))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, "dist", "appsscript.json"))).toBe(
       true,
@@ -218,6 +224,7 @@ describe("bootstrap", () => {
     expect(planNote?.message).toContain("create directory gassma-project");
     expect(planNote?.message).toContain("clasp create-script");
     expect(planNote?.message).toContain("write gassma-project/package.json");
+    expect(planNote?.message).toContain("write gassma-project/AGENTS.md");
     expect(planNote?.message).toContain("gassma init");
     expect(
       prompter.infos.every((message) => message.startsWith("[dry-run] ")),

--- a/packages/cli/src/__test__/bootstrap/env/loadBootstrapTemplates.test.ts
+++ b/packages/cli/src/__test__/bootstrap/env/loadBootstrapTemplates.test.ts
@@ -6,6 +6,7 @@ describe("loadBootstrapTemplates", () => {
     const templates = loadBootstrapTemplates();
 
     expect(templates.gitignore).toContain(".clasp.json");
+    expect(templates.agentsMd).toContain("# GAS project (Clasp + GASsma)");
     expect(templates.tsconfig).toContain("google-apps-script");
     expect(templates.packageJson).toContain('"gassma"');
     expect(templates.esbuild.export).toContain("gasEsbuildPlugin");

--- a/packages/cli/src/__test__/bootstrap/flow/writeSteps.test.ts
+++ b/packages/cli/src/__test__/bootstrap/flow/writeSteps.test.ts
@@ -30,6 +30,42 @@ describe("projectFilesStep", () => {
     expect(files.has(path.join(CWD, "esbuild.mjs"))).toBe(true);
     expect(files.has(path.join(CWD, "tsconfig.json"))).toBe(true);
     expect(files.has(path.join(CWD, ".gitignore"))).toBe(true);
+    expect(files.has(path.join(CWD, "AGENTS.md"))).toBe(true);
+  });
+
+  it("should write an AGENTS.md that matches the generated scripts", async () => {
+    const { files, store } = createMemoryStore({});
+    const deps = createTestDeps({ store });
+
+    await projectFilesStep.run(baseContext(), deps);
+
+    const content = files.get(path.join(CWD, "AGENTS.md")) ?? "";
+    const pkg = JSON.parse(files.get(path.join(CWD, "package.json")) ?? "{}");
+    expect(content).toContain("# GAS project (Clasp + GASsma)");
+    expect(content).toContain("npx gassma generate");
+    expect(content).toContain("npm run build");
+    expect(content).toContain("npm run deploy");
+    expect(pkg.scripts.build).toBeDefined();
+    expect(pkg.scripts.deploy).toBeDefined();
+    expect(content).toContain("gassma/schema.prisma");
+    expect(content).toContain("src/generated/");
+    expect(content).toContain(".clasp.json");
+    expect(content).toContain("dist/appsscript.json");
+    expect(content).toContain(
+      "https://akahoshi1421.github.io/gassma-reference/llms.txt",
+    );
+  });
+
+  it("should not overwrite an existing AGENTS.md", async () => {
+    const agentsPath = path.join(CWD, "AGENTS.md");
+    const { files, store } = createMemoryStore({ [agentsPath]: "my notes" });
+    const prompter = createFakePrompter();
+    const deps = createTestDeps({ store, prompter });
+
+    await projectFilesStep.run(baseContext(), deps);
+
+    expect(files.get(agentsPath)).toBe("my notes");
+    expect(prompter.infos.join(" ")).toContain("AGENTS.md");
   });
 
   it("should sanitize the directory name for the package name", async () => {

--- a/packages/cli/src/bootstrap/env/loadBootstrapTemplates.ts
+++ b/packages/cli/src/bootstrap/env/loadBootstrapTemplates.ts
@@ -3,6 +3,7 @@ import type { FunctionStyle } from "../functionStyle";
 
 type BootstrapTemplates = {
   gitignore: string;
+  agentsMd: string;
   tsconfig: string;
   packageJson: string;
   esbuild: Record<FunctionStyle, string>;
@@ -13,6 +14,7 @@ const loadBootstrapTemplates = (
   startDir: string = __dirname,
 ): BootstrapTemplates => ({
   gitignore: readTemplate(".gitignore.template", startDir),
+  agentsMd: readTemplate("AGENTS.md.template", startDir),
   tsconfig: readTemplate("tsconfig.json.template", startDir),
   packageJson: readTemplate("package.json.template", startDir),
   esbuild: {

--- a/packages/cli/src/bootstrap/flow/steps/writeSteps.ts
+++ b/packages/cli/src/bootstrap/flow/steps/writeSteps.ts
@@ -85,6 +85,12 @@ const projectFilesStep: BootstrapStep = {
       "tsconfig.json",
     );
     writeGitignore(context, deps);
+    writeIfMissing(
+      deps,
+      path.join(context.cwd, "AGENTS.md"),
+      deps.templates.agentsMd,
+      "AGENTS.md",
+    );
     return Promise.resolve(context);
   },
 };

--- a/packages/cli/templates/AGENTS.md.template
+++ b/packages/cli/templates/AGENTS.md.template
@@ -1,0 +1,26 @@
+# GAS project (Clasp + GASsma)
+
+A local development environment for Google Apps Script, powered by Clasp and GASsma.
+
+## Commands
+
+- `npx gassma generate` — generates the types and the client from gassma/schema.prisma
+- `npm run build` — bundles src/ into dist/ with esbuild
+- `npm run deploy` — build + clasp push (deploys to GAS)
+
+## Development flow
+
+1. To change the schema, edit `gassma/schema.prisma` and re-run `npx gassma generate`
+2. Write code in `src/`. **Never edit `src/generated/` by hand — it is generated output**
+3. Deploy to GAS with `npm run deploy`. Code is executed in the GAS editor
+
+## Constraints
+
+- The runtime is GAS. `SpreadsheetApp` and the other GAS globals do not work locally (running or testing the code locally is not possible)
+- `.clasp.json` / `.clasprc.json` contain credentials. Never commit them (already gitignored)
+- `dist/appsscript.json` is effectively source code — it contains the library dependencies. Do not delete or regenerate it
+
+## About GASsma
+
+GASsma is a GAS library + CLI that lets you work with spreadsheets the way Prisma works with databases. CRUD, aggregation, relations, and transactions are handled with almost the same syntax as Prisma.
+**Before touching anything related to the API, consult https://akahoshi1421.github.io/gassma-reference/llms.txt** (it is a link index — follow the links and read the pages you need).


### PR DESCRIPTION
## 概要

`gassma bootstrap` の生成ファイル群に **AGENTS.md(英語)** を追加します(ユーザー発案・内容承認済み)。生成プロジェクトに入ったコーディングエージェントが最初に必要とする行動情報 — コマンド3つ(`gassma generate` / `npm run build` / `npm run deploy`)・開発フロー(**`src/generated/` は手で編集しない**の明示警告つき)・環境制約(GAS 専用ランタイム・認証ファイルのコミット禁止・`dist/appsscript.json` は実質ソース)— を簡潔にまとめ、API 詳細は reference の llms.txt へ誘導します。

## 実装

- `templates/AGENTS.md.template` の**無置換 verbatim コピー**(パッチ機構は package.json 専用の既存設計を維持。タイトルは汎用 `# GAS project (Clasp + GASsma)`)
- 既存の `writeIfMissing` 経路に載せたため**冪等スキップ・--dry-run 計画化は自動適用**
- **記載事実は全部テンプレート実物と突き合わせ検証済み**(scripts 実名・generator output `./src/generated/gassma`・.gitignore の実内容・manifest の扱い)— 修正が必要な承認稿の誤りはゼロ

## テスト

1121 → **1123**(+2、既存4テストへのアサーション追加込み)。Red 実測(6 fail)→ Green、実装 stash の逆検証で 6 fail 再現。`npm pack --dry-run` で **AGENTS.md.template が tarball に載ること実証**(files allowlist の templates 経由)。test:types / typecheck / lint / format / build 全 green。

## マージ後(別 PR)

reference の bootstrap ページ(ja/en)の「生成されるもの」テーブルと冪等性の節に AGENTS.md を追記します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtxX