### PR TITLE
feat: add gassma migrate command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -144,6 +144,19 @@ Validate `.prisma` files.
 |`--schema <path>`|Path to a specific .prisma file to validate|
 |`--config <path>`|Custom path to your GASsma config file|
 
+### migrate
+
+Generate a GAS function that syncs spreadsheet sheets with your schema. It writes the runnable stub `gassma-migration.js` into the output directory and a migration trail at `migrations/<timestamp>[_name]/migration.js` next to your schema. `clasp push` is not run automatically: push the stub yourself, then run the `gassmaMigrate` function once in the Apps Script editor.
+
+#### options
+
+|name|description|
+|--|--|
+|`--name <name>`|Name for the new migration|
+|`--output <dir>`|Directory to write gassma-migration.js (defaults to rootDir in .clasp.json)|
+|`--schema <path>`|Path to a specific .prisma file to migrate from|
+|`--config <path>`|Custom path to your GASsma config file|
+
 ### bootstrap
 
 Interactively set up a local GAS development environment (clasp + esbuild + TypeScript + GASsma). It creates an Apps Script project via clasp, registers the GASsma library, generates project files (`package.json`, `esbuild.mjs`, `tsconfig.json`, `.gitignore`, a sample `src/index.ts`), runs `gassma init`, and installs dependencies.

--- a/packages/cli/docs/README.ja.md
+++ b/packages/cli/docs/README.ja.md
@@ -144,6 +144,19 @@ function myFunction() {
 |`--schema <path>`|バリデーション対象の `.prisma` ファイルのパス|
 |`--config <path>`|GASsma config ファイルのカスタムパス|
 
+### migrate
+
+スキーマに合わせてスプレッドシートのシートを同期する GAS 関数を生成します。実行用スタブ `gassma-migration.js` を出力ディレクトリに、証跡 `migrations/<timestamp>[_name]/migration.js` をスキーマと同じディレクトリに生成します。`clasp push` は自動実行されません。スタブを push した後、Apps Script エディタで `gassmaMigrate` 関数を 1 回実行してください。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--name <name>`|マイグレーションの名前|
+|`--output <dir>`|gassma-migration.js の出力先ディレクトリ（デフォルトは .clasp.json の rootDir）|
+|`--schema <path>`|マイグレーション対象の `.prisma` ファイルのパス|
+|`--config <path>`|GASsma config ファイルのカスタムパス|
+
 ### bootstrap
 
 GAS のローカル開発環境（clasp + esbuild + TypeScript + GASsma）を対話形式でセットアップします。clasp で Apps Script プロジェクトを作成し、GASsma ライブラリを登録し、プロジェクトファイル（`package.json`・`esbuild.mjs`・`tsconfig.json`・`.gitignore`・サンプルの `src/index.ts`）を生成して `gassma init` を実行し、依存関係をインストールします。

--- a/packages/cli/src/__test__/command/migrateFlag.test.ts
+++ b/packages/cli/src/__test__/command/migrateFlag.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const projectRoot = path.resolve(__dirname, "../../..");
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+const commandTs = path.join(projectRoot, "src", "command.ts");
+
+describe("gassma migrate (e2e)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "gassma-migrate-e2e-")),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it(
+    "should list the migrate command in the help output",
+    { timeout: 120_000 },
+    () => {
+      const output = execFileSync(
+        process.execPath,
+        [tsxCli, commandTs, "--help"],
+        { cwd: tmpDir, stdio: "pipe" },
+      ).toString();
+
+      expect(output).toContain("migrate");
+    },
+  );
+
+  it(
+    "should generate the migration files end to end",
+    { timeout: 120_000 },
+    () => {
+      fs.mkdirSync(path.join(tmpDir, "gassma"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma", "schema.prisma"),
+        "model User {\n  id   Int    @id\n  name String\n}\n",
+      );
+
+      const output = execFileSync(
+        process.execPath,
+        [tsxCli, commandTs, "migrate", "--output", "./dist", "--name", "init"],
+        { cwd: tmpDir, stdio: "pipe" },
+      ).toString();
+
+      expect(output).toContain("gassma-migration.js");
+      const stub = fs.readFileSync(
+        path.join(tmpDir, "dist", "gassma-migration.js"),
+        "utf-8",
+      );
+      expect(stub).toContain("function gassmaMigrate()");
+
+      const migrations = fs.readdirSync(
+        path.join(tmpDir, "gassma", "migrations"),
+      );
+      expect(migrations).toHaveLength(1);
+      expect(migrations[0]).toMatch(/^\d{14}_init$/);
+    },
+  );
+});

--- a/packages/cli/src/__test__/migrate/buildMigrateModels.test.ts
+++ b/packages/cli/src/__test__/migrate/buildMigrateModels.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { buildMigrateModels } from "../../migrate/buildMigrateModels";
+
+describe("buildMigrateModels", () => {
+  it("should list scalar columns in declaration order", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  name  String
+  email String
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "User", columns: ["id", "name", "email"] },
+    ]);
+  });
+
+  it("should strip the optional suffix from optional fields", () => {
+    const schema = `
+model User {
+  id  Int  @id
+  age Int?
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "User", columns: ["id", "age"] },
+    ]);
+  });
+
+  it("should keep every model in declaration order", () => {
+    const schema = `
+model Post {
+  id Int @id
+}
+
+model User {
+  id Int @id
+}
+`;
+    const models = buildMigrateModels(schema);
+    expect(models.map((model) => model.name)).toEqual(["Post", "User"]);
+  });
+
+  it("should use @map physical column names", () => {
+    const schema = `
+model User {
+  id       Int    @id
+  fullName String @map("full_name")
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "User", columns: ["id", "full_name"] },
+    ]);
+  });
+
+  it("should use the @@map physical sheet name", () => {
+    const schema = `
+model User {
+  id Int @id
+
+  @@map("users")
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "users", columns: ["id"] },
+    ]);
+  });
+
+  it("should keep @ignore fields at their declared position", () => {
+    const schema = `
+model User {
+  id       Int    @id
+  internal String @ignore
+  email    String
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "User", columns: ["id", "internal", "email"] },
+    ]);
+  });
+
+  it("should include @@ignore models with their columns", () => {
+    const schema = `
+model User {
+  id Int @id
+}
+
+model AuditLog {
+  id      Int    @id
+  message String
+
+  @@ignore
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "User", columns: ["id"] },
+      { name: "AuditLog", columns: ["id", "message"] },
+    ]);
+  });
+
+  it("should apply @map inside @@ignore models", () => {
+    const schema = `
+model AuditLog {
+  id      Int    @id
+  message String @map("log_message")
+
+  @@ignore
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "AuditLog", columns: ["id", "log_message"] },
+    ]);
+  });
+
+  it("should include enum columns", () => {
+    const schema = `
+enum Role {
+  USER
+  ADMIN
+}
+
+model User {
+  id   Int  @id
+  role Role @default(USER)
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "User", columns: ["id", "role"] },
+    ]);
+  });
+
+  it("should exclude relation object fields but keep FK scalar columns", () => {
+    const schema = `
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int
+}
+
+model User {
+  id    Int    @id
+  posts Post[]
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "Post", columns: ["id", "authorId"] },
+      { name: "User", columns: ["id"] },
+    ]);
+  });
+
+  it("should append one through sheet for an implicit many-to-many", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[]
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[]
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "Post", columns: ["id"] },
+      { name: "Tag", columns: ["id"] },
+      { name: "_PostToTag", columns: ["postId", "tagId"] },
+    ]);
+  });
+
+  it("should order through sheet columns by model name even when declared inversely", () => {
+    const schema = `
+model Tag {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id   Int   @id
+  tags Tag[]
+}
+`;
+    const models = buildMigrateModels(schema);
+    expect(models).toContainEqual({
+      name: "_PostToTag",
+      columns: ["postId", "tagId"],
+    });
+    expect(models.filter((model) => model.name === "_PostToTag")).toHaveLength(
+      1,
+    );
+  });
+
+  it("should not let @@map affect the through sheet name", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[]
+
+  @@map("記事")
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[]
+}
+`;
+    const models = buildMigrateModels(schema);
+    expect(models.map((model) => model.name)).toEqual([
+      "記事",
+      "Tag",
+      "_PostToTag",
+    ]);
+    expect(models[2].columns).toEqual(["postId", "tagId"]);
+  });
+
+  it("should not create a through sheet for one-to-many relations", () => {
+    const schema = `
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int
+}
+
+model User {
+  id    Int    @id
+  posts Post[]
+}
+`;
+    const models = buildMigrateModels(schema);
+    expect(models.map((model) => model.name)).toEqual(["Post", "User"]);
+  });
+
+  it("should return an empty array for a schema without models", () => {
+    const schema = `
+datasource db {
+  provider = "gassma"
+  url      = "https://docs.google.com/spreadsheets/d/abc123/edit"
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([]);
+  });
+});

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -152,6 +152,40 @@ describe("migrate", () => {
     ]);
   });
 
+  it("should keep a name with path separators inside a single flat directory", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out", name: "evil/sub" }, fixedDeps);
+
+    expect(fs.readdirSync(path.join("gassma", "migrations"))).toEqual([
+      "20260729040506_evil_sub",
+    ]);
+
+    const laterDeps = {
+      now: () => new Date(Date.UTC(2026, 6, 30, 0, 0, 0)),
+    };
+    migrate({ output: "./out" }, laterDeps);
+
+    expect(fs.readdirSync(path.join("gassma", "migrations"))).toEqual([
+      "20260729040506_evil_sub",
+    ]);
+  });
+
+  it("should keep a traversal name inside the migrations directory", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out", name: "../../../outside-trail" }, fixedDeps);
+
+    expect(fs.readdirSync(path.join("gassma", "migrations"))).toEqual([
+      "20260729040506_outside_trail",
+    ]);
+    expect(fs.readdirSync("gassma").sort()).toEqual([
+      "migrations",
+      "schema.prisma",
+    ]);
+    expect(fs.existsSync("outside-trail")).toBe(false);
+  });
+
   it("should not record a second migration when nothing changed", () => {
     writeSchema(schemaWithDatasource);
     migrate({ output: "./out" }, fixedDeps);

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -203,6 +203,23 @@ describe("migrate", () => {
     );
   });
 
+  it("should not claim a migration was generated when already in sync", () => {
+    writeSchema(schemaWithDatasource);
+    migrate({ output: "./out" }, fixedDeps);
+    vi.mocked(console.log).mockClear();
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const logged = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).not.toContain("Migration generated");
+    expect(logged).toContain("Refreshed gassma-migration.js");
+    expect(logged).toContain("clasp push");
+    expect(logged).toContain("gassmaMigrate");
+  });
+
   it("should rewrite gassma-migration.js even when already in sync", () => {
     writeSchema(schemaWithDatasource);
     migrate({ output: "./out" }, fixedDeps);

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -1,0 +1,239 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GASSMA_LIBRARY } from "../../bootstrap/const/gassmaLibrary";
+import { migrate } from "../../migrate/migrateCommand";
+
+const schemaWithDatasource = `
+datasource db {
+  provider = "gassma"
+  url      = "https://docs.google.com/spreadsheets/d/abc123/edit"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+
+const schemaWithoutDatasource = `
+model User {
+  id   Int    @id
+  name String
+}
+`;
+
+const fixedDeps = {
+  now: () => new Date(Date.UTC(2026, 6, 29, 4, 5, 6)),
+};
+
+const writeSchema = (schema: string): void => {
+  fs.mkdirSync("gassma", { recursive: true });
+  fs.writeFileSync(path.join("gassma", "schema.prisma"), schema);
+};
+
+describe("migrate", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "gassma-migrate-cmd-")),
+    );
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should write gassma-migration.js into the --output directory", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toBe(`function gassmaMigrate() {
+  Gassma.migrateSheets({
+    spreadsheetId: "abc123",
+    models: [
+      { name: "User", columns: ["id", "name"] }
+    ]
+  });
+}
+`);
+  });
+
+  it("should resolve the output directory from rootDir in .clasp.json", () => {
+    writeSchema(schemaWithDatasource);
+    fs.writeFileSync(".clasp.json", JSON.stringify({ rootDir: "./dist" }));
+
+    migrate(undefined, fixedDeps);
+
+    expect(fs.existsSync(path.join("dist", "gassma-migration.js"))).toBe(true);
+  });
+
+  it("should throw when no output directory can be resolved", () => {
+    writeSchema(schemaWithDatasource);
+
+    expect(() => migrate(undefined, fixedDeps)).toThrow("--output");
+  });
+
+  it("should omit spreadsheetId when no datasource url is available", () => {
+    writeSchema(schemaWithoutDatasource);
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).not.toContain("spreadsheetId");
+  });
+
+  it("should use the userSymbol from appsscript.json in the output directory", () => {
+    writeSchema(schemaWithDatasource);
+    fs.mkdirSync("out", { recursive: true });
+    fs.writeFileSync(
+      path.join("out", "appsscript.json"),
+      JSON.stringify({
+        dependencies: {
+          libraries: [
+            {
+              userSymbol: "MyGassma",
+              libraryId: GASSMA_LIBRARY.scriptId,
+              version: "10",
+            },
+          ],
+        },
+      }),
+    );
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toContain("MyGassma.migrateSheets(");
+  });
+
+  it("should record the migration next to the schema with the timestamped name", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out", name: "init" }, fixedDeps);
+
+    const trailPath = path.join(
+      "gassma",
+      "migrations",
+      "20260729040506_init",
+      "migration.js",
+    );
+    expect(fs.readFileSync(trailPath, "utf-8")).toBe(
+      fs.readFileSync(path.join("out", "gassma-migration.js"), "utf-8"),
+    );
+  });
+
+  it("should name the migration directory with the timestamp only when --name is omitted", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    expect(fs.readdirSync(path.join("gassma", "migrations"))).toEqual([
+      "20260729040506",
+    ]);
+  });
+
+  it("should not record a second migration when nothing changed", () => {
+    writeSchema(schemaWithDatasource);
+    migrate({ output: "./out" }, fixedDeps);
+
+    const laterDeps = {
+      now: () => new Date(Date.UTC(2026, 6, 30, 0, 0, 0)),
+    };
+    migrate({ output: "./out" }, laterDeps);
+
+    expect(fs.readdirSync(path.join("gassma", "migrations"))).toEqual([
+      "20260729040506",
+    ]);
+    expect(console.log).toHaveBeenCalledWith(
+      "Already in sync, no schema change or pending migration was found.",
+    );
+  });
+
+  it("should rewrite gassma-migration.js even when already in sync", () => {
+    writeSchema(schemaWithDatasource);
+    migrate({ output: "./out" }, fixedDeps);
+    fs.rmSync(path.join("out", "gassma-migration.js"));
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    expect(fs.existsSync(path.join("out", "gassma-migration.js"))).toBe(true);
+  });
+
+  it("should record a new migration when the schema changed", () => {
+    writeSchema(schemaWithDatasource);
+    migrate({ output: "./out" }, fixedDeps);
+
+    writeSchema(`${schemaWithDatasource}
+model Post {
+  id Int @id
+}
+`);
+    const laterDeps = {
+      now: () => new Date(Date.UTC(2026, 6, 30, 0, 0, 0)),
+    };
+    migrate({ output: "./out" }, laterDeps);
+
+    expect(fs.readdirSync(path.join("gassma", "migrations")).sort()).toEqual([
+      "20260729040506",
+      "20260730000000",
+    ]);
+  });
+
+  it("should throw when the schema has no models", () => {
+    fs.mkdirSync("gassma", { recursive: true });
+    fs.writeFileSync(
+      path.join("gassma", "schema.prisma"),
+      'datasource db {\n  provider = "gassma"\n  url = ""\n}\n',
+    );
+
+    expect(() => migrate({ output: "./out" }, fixedDeps)).toThrow(
+      "GASsmaNoModelsError",
+    );
+  });
+
+  it("should read the schema from the --schema option", () => {
+    fs.mkdirSync("custom", { recursive: true });
+    fs.writeFileSync(path.join("custom", "app.prisma"), schemaWithDatasource);
+
+    migrate({ output: "./out", schema: "custom/app.prisma" }, fixedDeps);
+
+    expect(
+      fs.existsSync(
+        path.join("custom", "migrations", "20260729040506", "migration.js"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should print next steps after generating", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const logged = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).toContain("clasp push");
+    expect(logged).toContain("gassmaMigrate");
+  });
+});

--- a/packages/cli/src/__test__/migrate/migrationDirName.test.ts
+++ b/packages/cli/src/__test__/migrate/migrationDirName.test.ts
@@ -90,5 +90,27 @@ describe("buildMigrationDirName", () => {
         "20260729040506_v2_rollout",
       );
     });
+
+    it("should decamelize like Prisma does", () => {
+      expect(buildMigrationDirName(date, "addUserTable")).toBe(
+        "20260729040506_add_user_table",
+      );
+    });
+
+    it("should split acronym runs like Prisma does", () => {
+      expect(buildMigrationDirName(date, "addAPIKeyV2 andHTTPStuff")).toBe(
+        "20260729040506_add_api_key_v2_and_http_stuff",
+      );
+    });
+
+    it("should keep an acronym-only name as a single word", () => {
+      expect(buildMigrationDirName(date, "API")).toBe("20260729040506_api");
+    });
+
+    it("should split before an uppercase letter after a digit", () => {
+      expect(buildMigrationDirName(date, "v2Rollout")).toBe(
+        "20260729040506_v2_rollout",
+      );
+    });
   });
 });

--- a/packages/cli/src/__test__/migrate/migrationDirName.test.ts
+++ b/packages/cli/src/__test__/migrate/migrationDirName.test.ts
@@ -19,8 +19,8 @@ describe("buildMigrationDirName", () => {
 
   it("should append the name with an underscore", () => {
     const date = new Date(Date.UTC(2026, 6, 29, 4, 5, 6));
-    expect(buildMigrationDirName(date, "add-user")).toBe(
-      "20260729040506_add-user",
+    expect(buildMigrationDirName(date, "add_user")).toBe(
+      "20260729040506_add_user",
     );
   });
 
@@ -32,5 +32,63 @@ describe("buildMigrationDirName", () => {
   it("should treat an empty name as omitted", () => {
     const date = new Date(Date.UTC(2026, 6, 29, 4, 5, 6));
     expect(buildMigrationDirName(date, "")).toBe("20260729040506");
+  });
+
+  describe("name sanitization", () => {
+    const date = new Date(Date.UTC(2026, 6, 29, 4, 5, 6));
+
+    it("should replace path separators like Prisma does", () => {
+      expect(buildMigrationDirName(date, "evil/sub ★ mixed")).toBe(
+        "20260729040506_evil_sub_mixed",
+      );
+    });
+
+    it("should replace backslashes", () => {
+      expect(buildMigrationDirName(date, "evil\\sub")).toBe(
+        "20260729040506_evil_sub",
+      );
+    });
+
+    it("should neutralize parent directory references", () => {
+      expect(buildMigrationDirName(date, "../../../outside-trail")).toBe(
+        "20260729040506_outside_trail",
+      );
+    });
+
+    it("should lowercase and collapse spaces and symbols like Prisma does", () => {
+      expect(buildMigrationDirName(date, "Add User ★Table--")).toBe(
+        "20260729040506_add_user_table",
+      );
+    });
+
+    it("should collapse hyphens into underscores", () => {
+      expect(buildMigrationDirName(date, "add-user")).toBe(
+        "20260729040506_add_user",
+      );
+    });
+
+    it("should strip leading and trailing symbols", () => {
+      expect(buildMigrationDirName(date, "--add--")).toBe("20260729040506_add");
+    });
+
+    it("should replace multibyte characters between words", () => {
+      expect(buildMigrationDirName(date, "addユーザーtable")).toBe(
+        "20260729040506_add_table",
+      );
+    });
+
+    it("should treat a symbols-only name as omitted", () => {
+      expect(buildMigrationDirName(date, "★--/")).toBe("20260729040506");
+    });
+
+    it("should treat a multibyte-only name as omitted", () => {
+      expect(buildMigrationDirName(date, "日本語")).toBe("20260729040506");
+    });
+
+    it("should keep digits", () => {
+      expect(buildMigrationDirName(date, "v2 Rollout")).toBe(
+        "20260729040506_v2_rollout",
+      );
+    });
   });
 });

--- a/packages/cli/src/__test__/migrate/migrationDirName.test.ts
+++ b/packages/cli/src/__test__/migrate/migrationDirName.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildMigrationDirName } from "../../migrate/migrationDirName";
+
+describe("buildMigrationDirName", () => {
+  it("should format the date as UTC yyyymmddhhmmss", () => {
+    const date = new Date(Date.UTC(2026, 6, 29, 4, 5, 6));
+    expect(buildMigrationDirName(date)).toBe("20260729040506");
+  });
+
+  it("should zero-pad every component", () => {
+    const date = new Date(Date.UTC(2026, 0, 2, 3, 4, 5));
+    expect(buildMigrationDirName(date)).toBe("20260102030405");
+  });
+
+  it("should use UTC regardless of the local timezone offset", () => {
+    const date = new Date("2026-07-29T09:00:00+09:00");
+    expect(buildMigrationDirName(date)).toBe("20260729000000");
+  });
+
+  it("should append the name with an underscore", () => {
+    const date = new Date(Date.UTC(2026, 6, 29, 4, 5, 6));
+    expect(buildMigrationDirName(date, "add-user")).toBe(
+      "20260729040506_add-user",
+    );
+  });
+
+  it("should not add a trailing underscore without a name", () => {
+    const date = new Date(Date.UTC(2026, 6, 29, 4, 5, 6));
+    expect(buildMigrationDirName(date).endsWith("_")).toBe(false);
+  });
+
+  it("should treat an empty name as omitted", () => {
+    const date = new Date(Date.UTC(2026, 6, 29, 4, 5, 6));
+    expect(buildMigrationDirName(date, "")).toBe("20260729040506");
+  });
+});

--- a/packages/cli/src/__test__/migrate/migrationTrail.test.ts
+++ b/packages/cli/src/__test__/migrate/migrationTrail.test.ts
@@ -1,0 +1,75 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  findLatestMigrationContent,
+  writeMigrationTrail,
+} from "../../migrate/migrationTrail";
+
+describe("migrationTrail", () => {
+  let tmpDir: string;
+  let migrationsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-migrate-trail-"));
+    migrationsDir = path.join(tmpDir, "migrations");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("findLatestMigrationContent", () => {
+    it("should return undefined when the migrations directory is missing", () => {
+      expect(findLatestMigrationContent(migrationsDir)).toBeUndefined();
+    });
+
+    it("should return undefined when the migrations directory is empty", () => {
+      fs.mkdirSync(migrationsDir, { recursive: true });
+      expect(findLatestMigrationContent(migrationsDir)).toBeUndefined();
+    });
+
+    it("should read migration.js from the latest timestamp directory", () => {
+      writeMigrationTrail(migrationsDir, "20260101000000", "old");
+      writeMigrationTrail(migrationsDir, "20260729040506_add-user", "new");
+      expect(findLatestMigrationContent(migrationsDir)).toBe("new");
+    });
+
+    it("should ignore directories that are not migrations", () => {
+      writeMigrationTrail(migrationsDir, "20260101000000", "old");
+      fs.mkdirSync(path.join(migrationsDir, "notes"), { recursive: true });
+      fs.mkdirSync(path.join(migrationsDir, "99999999999999999"), {
+        recursive: true,
+      });
+      expect(findLatestMigrationContent(migrationsDir)).toBe("old");
+    });
+
+    it("should ignore plain files in the migrations directory", () => {
+      writeMigrationTrail(migrationsDir, "20260101000000", "old");
+      fs.writeFileSync(path.join(migrationsDir, "99999999999999"), "file");
+      expect(findLatestMigrationContent(migrationsDir)).toBe("old");
+    });
+
+    it("should return undefined when the latest directory lacks migration.js", () => {
+      fs.mkdirSync(path.join(migrationsDir, "20260729040506"), {
+        recursive: true,
+      });
+      expect(findLatestMigrationContent(migrationsDir)).toBeUndefined();
+    });
+  });
+
+  describe("writeMigrationTrail", () => {
+    it("should create the directory and write migration.js", () => {
+      const written = writeMigrationTrail(
+        migrationsDir,
+        "20260729040506_add-user",
+        "content",
+      );
+      expect(written).toBe(
+        path.join(migrationsDir, "20260729040506_add-user", "migration.js"),
+      );
+      expect(fs.readFileSync(written, "utf-8")).toBe("content");
+    });
+  });
+});

--- a/packages/cli/src/__test__/migrate/patchMigrationScript.test.ts
+++ b/packages/cli/src/__test__/migrate/patchMigrationScript.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { patchMigrationScript } from "../../migrate/patchMigrationScript";
+import { readTemplate } from "../../util/readTemplate";
+
+const template = readTemplate("gassma-migration.js.template");
+
+const baseOptions = {
+  userSymbol: "Gassma",
+  definition: {
+    models: [{ name: "User", columns: ["id", "name"] }],
+  },
+} satisfies Parameters<typeof patchMigrationScript>[1];
+
+describe("patchMigrationScript", () => {
+  it("should keep the gassmaMigrate top-level function name", () => {
+    const result = patchMigrationScript(template, baseOptions);
+    expect(result).toContain("function gassmaMigrate()");
+  });
+
+  it("should call migrateSheets on the default Gassma symbol", () => {
+    const result = patchMigrationScript(template, baseOptions);
+    expect(result).toContain("Gassma.migrateSheets(");
+  });
+
+  it("should call migrateSheets on a custom user symbol", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      userSymbol: "MyGassma",
+    });
+    expect(result).toContain("MyGassma.migrateSheets(");
+    expect(result).not.toMatch(/(?<!My)Gassma\.migrateSheets/);
+  });
+
+  it("should render each model with its name and columns", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      definition: {
+        models: [
+          { name: "User", columns: ["id", "name"] },
+          { name: "_PostToTag", columns: ["postId", "tagId"] },
+        ],
+      },
+    });
+    expect(result).toContain('{ name: "User", columns: ["id", "name"] }');
+    expect(result).toContain(
+      '{ name: "_PostToTag", columns: ["postId", "tagId"] }',
+    );
+  });
+
+  it("should include spreadsheetId when given", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      definition: { ...baseOptions.definition, spreadsheetId: "abc123" },
+    });
+    expect(result).toContain('spreadsheetId: "abc123",');
+  });
+
+  it("should omit spreadsheetId when not given", () => {
+    const result = patchMigrationScript(template, baseOptions);
+    expect(result).not.toContain("spreadsheetId");
+  });
+
+  it("should escape double quotes in sheet and column names", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      definition: {
+        models: [{ name: 'Sheet"1', columns: ['col"a'] }],
+      },
+    });
+    expect(result).toContain('"Sheet\\"1"');
+    expect(result).toContain('"col\\"a"');
+  });
+
+  it("should produce syntactically valid JavaScript", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      definition: {
+        spreadsheetId: "abc123",
+        models: [
+          { name: "User", columns: ["id", "name"] },
+          { name: "_PostToTag", columns: ["postId", "tagId"] },
+        ],
+      },
+    });
+    expect(() => new Function(result)).not.toThrow();
+  });
+
+  it("should end with a newline", () => {
+    const result = patchMigrationScript(template, baseOptions);
+    expect(result.endsWith("\n")).toBe(true);
+  });
+
+  it("should render the full expected script", () => {
+    const result = patchMigrationScript(template, {
+      userSymbol: "Gassma",
+      definition: {
+        spreadsheetId: "abc123",
+        models: [
+          { name: "User", columns: ["id", "name"] },
+          { name: "Post", columns: ["id", "authorId"] },
+        ],
+      },
+    });
+    expect(result).toBe(`function gassmaMigrate() {
+  Gassma.migrateSheets({
+    spreadsheetId: "abc123",
+    models: [
+      { name: "User", columns: ["id", "name"] },
+      { name: "Post", columns: ["id", "authorId"] }
+    ]
+  });
+}
+`);
+  });
+});

--- a/packages/cli/src/__test__/migrate/resolveOutputDir.test.ts
+++ b/packages/cli/src/__test__/migrate/resolveOutputDir.test.ts
@@ -1,0 +1,50 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveOutputDir } from "../../migrate/resolveOutputDir";
+
+describe("resolveOutputDir", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-migrate-out-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should prefer the --output option over .clasp.json", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".clasp.json"),
+      JSON.stringify({ rootDir: "./dist" }),
+    );
+    expect(resolveOutputDir("./custom", tmpDir)).toBe("./custom");
+  });
+
+  it("should fall back to rootDir in .clasp.json", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".clasp.json"),
+      JSON.stringify({ scriptId: "abc", rootDir: "./dist" }),
+    );
+    expect(resolveOutputDir(undefined, tmpDir)).toBe("./dist");
+  });
+
+  it("should throw a clear error when neither is available", () => {
+    expect(() => resolveOutputDir(undefined, tmpDir)).toThrow("--output");
+  });
+
+  it("should throw when .clasp.json has no rootDir", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".clasp.json"),
+      JSON.stringify({ scriptId: "abc" }),
+    );
+    expect(() => resolveOutputDir(undefined, tmpDir)).toThrow("--output");
+  });
+
+  it("should throw when .clasp.json cannot be parsed", () => {
+    fs.writeFileSync(path.join(tmpDir, ".clasp.json"), "{ broken");
+    expect(() => resolveOutputDir(undefined, tmpDir)).toThrow("--output");
+  });
+});

--- a/packages/cli/src/__test__/migrate/resolveUserSymbol.test.ts
+++ b/packages/cli/src/__test__/migrate/resolveUserSymbol.test.ts
@@ -1,0 +1,71 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GASSMA_LIBRARY } from "../../bootstrap/const/gassmaLibrary";
+import { resolveUserSymbol } from "../../migrate/resolveUserSymbol";
+
+const writeManifest = (dir: string, manifest: unknown): void => {
+  fs.writeFileSync(path.join(dir, "appsscript.json"), JSON.stringify(manifest));
+};
+
+describe("resolveUserSymbol", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-migrate-sym-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should default to Gassma when appsscript.json is missing", () => {
+    expect(resolveUserSymbol(tmpDir)).toBe("Gassma");
+  });
+
+  it("should read the userSymbol of the gassma library entry", () => {
+    writeManifest(tmpDir, {
+      dependencies: {
+        libraries: [
+          {
+            userSymbol: "MyGassma",
+            libraryId: GASSMA_LIBRARY.scriptId,
+            version: "1",
+          },
+        ],
+      },
+    });
+    expect(resolveUserSymbol(tmpDir)).toBe("MyGassma");
+  });
+
+  it("should ignore other libraries", () => {
+    writeManifest(tmpDir, {
+      dependencies: {
+        libraries: [
+          { userSymbol: "Other", libraryId: "other-id", version: "1" },
+        ],
+      },
+    });
+    expect(resolveUserSymbol(tmpDir)).toBe("Gassma");
+  });
+
+  it("should default when the manifest cannot be parsed", () => {
+    fs.writeFileSync(path.join(tmpDir, "appsscript.json"), "{ broken");
+    expect(resolveUserSymbol(tmpDir)).toBe("Gassma");
+  });
+
+  it("should default when the entry has no string userSymbol", () => {
+    writeManifest(tmpDir, {
+      dependencies: {
+        libraries: [{ libraryId: GASSMA_LIBRARY.scriptId, version: "1" }],
+      },
+    });
+    expect(resolveUserSymbol(tmpDir)).toBe("Gassma");
+  });
+
+  it("should default when the manifest has no libraries", () => {
+    writeManifest(tmpDir, { timeZone: "Asia/Tokyo" });
+    expect(resolveUserSymbol(tmpDir)).toBe("Gassma");
+  });
+});

--- a/packages/cli/src/__test__/migrate/stripIgnoreAttributes.test.ts
+++ b/packages/cli/src/__test__/migrate/stripIgnoreAttributes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { stripIgnoreAttributes } from "../../migrate/stripIgnoreAttributes";
+
+describe("stripIgnoreAttributes", () => {
+  it("should remove @ignore field attributes", () => {
+    const schema = `
+model User {
+  id       Int    @id
+  internal String @ignore
+}
+`;
+    const result = stripIgnoreAttributes(schema);
+    expect(result).not.toContain("@ignore");
+    expect(result).toContain("internal String");
+  });
+
+  it("should remove @@ignore block attributes without leaving a stray @", () => {
+    const schema = `
+model AuditLog {
+  id Int @id
+
+  @@ignore
+}
+`;
+    const result = stripIgnoreAttributes(schema);
+    expect(result).not.toContain("ignore");
+    expect(result).not.toMatch(/^\s*@\s*$/m);
+  });
+
+  it("should keep other attributes untouched", () => {
+    const schema = `
+model User {
+  id   Int    @id @default(autoincrement())
+  name String @map("user_name") @ignore
+
+  @@map("users")
+}
+`;
+    const result = stripIgnoreAttributes(schema);
+    expect(result).toContain("@id");
+    expect(result).toContain("@default(autoincrement())");
+    expect(result).toContain('@map("user_name")');
+    expect(result).toContain('@@map("users")');
+  });
+
+  it("should not touch fields whose name contains ignore", () => {
+    const schema = `
+model Flag {
+  id          Int     @id
+  ignoreCount Int
+  ignored     Boolean
+}
+`;
+    const result = stripIgnoreAttributes(schema);
+    expect(result).toContain("ignoreCount");
+    expect(result).toContain("ignored");
+  });
+});

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -6,6 +6,7 @@ import { format } from "./format/formatCommand";
 import { generate } from "./generate/generate";
 import { watchGenerate } from "./generate/watchGenerate";
 import { init } from "./init/initCommand";
+import { migrate } from "./migrate/migrateCommand";
 import { studioCommand } from "./studio/studioCommand";
 import { validate } from "./validate/validateCommand";
 import { getVersion } from "./version/getVersion";
@@ -57,6 +58,27 @@ program
       console.error("Some files are not formatted.");
       process.exit(1);
     }
+  });
+
+program
+  .command("migrate")
+  .description(
+    "Generate a GAS function that syncs spreadsheet sheets with your schema",
+  )
+  .option("--name <name>", "Name for the new migration")
+  .option(
+    "--output <dir>",
+    "Directory to write gassma-migration.js (defaults to rootDir in .clasp.json)",
+  )
+  .option("--schema <path>", "Path to a specific .prisma file to migrate from")
+  .option("--config <path>", "Custom path to your GASsma config file")
+  .action((options) => {
+    migrate({
+      name: options.name,
+      output: options.output,
+      schema: options.schema,
+      config: options.config,
+    });
   });
 
 program

--- a/packages/cli/src/error/mainError.ts
+++ b/packages/cli/src/error/mainError.ts
@@ -48,6 +48,16 @@ class GassmaConfigLoadError extends Error {
   }
 }
 
+class MigrateOutputDirError extends Error {
+  constructor() {
+    super(
+      "GASsmaMigrateOutputDirError: could not determine where to write gassma-migration.js.\n" +
+        "Pass --output <dir> (e.g. npx gassma migrate --output ./dist), " +
+        'or run in a project whose .clasp.json has "rootDir".',
+    );
+  }
+}
+
 export {
   ArgumentError,
   NoModelsError,
@@ -55,4 +65,5 @@ export {
   ConfigFileNotFoundError,
   GassmaConfigEnvError,
   GassmaConfigLoadError,
+  MigrateOutputDirError,
 };

--- a/packages/cli/src/migrate/buildMigrateModels.ts
+++ b/packages/cli/src/migrate/buildMigrateModels.ts
@@ -1,0 +1,61 @@
+import { extractMap } from "../generate/read/extractMap";
+import { extractMapSheets } from "../generate/read/extractMapSheets";
+import { extractRelations } from "../generate/read/extractRelations";
+import { prismaReader } from "../generate/read/prismaReader";
+import { stripIgnoreAttributes } from "./stripIgnoreAttributes";
+
+type MigrateModelDefinition = {
+  name: string;
+  columns: string[];
+};
+
+const stripOptionalSuffix = (field: string): string =>
+  field.endsWith("?") ? field.slice(0, -1) : field;
+
+const toLowercaseFirst = (value: string): string =>
+  value.charAt(0).toLowerCase() + value.slice(1);
+
+const buildSheetModels = (schemaText: string): MigrateModelDefinition[] => {
+  const parsed = prismaReader(stripIgnoreAttributes(schemaText));
+  const map = extractMap(schemaText);
+  const mapSheets = extractMapSheets(schemaText);
+
+  return Object.keys(parsed).map((modelName) => ({
+    name: mapSheets[modelName] ?? modelName,
+    columns: Object.keys(parsed[modelName]).map((field) => {
+      const codeName = stripOptionalSuffix(field);
+      return map[modelName]?.[codeName] ?? codeName;
+    }),
+  }));
+};
+
+const buildThroughModels = (schemaText: string): MigrateModelDefinition[] => {
+  const relations = extractRelations(schemaText);
+  const seenSheets = new Set<string>();
+  const models: MigrateModelDefinition[] = [];
+
+  Object.keys(relations).forEach((modelName) => {
+    Object.values(relations[modelName]).forEach((definition) => {
+      if (definition.type !== "manyToMany") return;
+      if (definition.through === undefined) return;
+      if (seenSheets.has(definition.through.sheet)) return;
+      seenSheets.add(definition.through.sheet);
+
+      const sorted = [modelName, definition.to].sort();
+      models.push({
+        name: definition.through.sheet,
+        columns: sorted.map((name) => `${toLowercaseFirst(name)}Id`),
+      });
+    });
+  });
+
+  return models;
+};
+
+const buildMigrateModels = (schemaText: string): MigrateModelDefinition[] => [
+  ...buildSheetModels(schemaText),
+  ...buildThroughModels(schemaText),
+];
+
+export { buildMigrateModels };
+export type { MigrateModelDefinition };

--- a/packages/cli/src/migrate/migrateCommand.ts
+++ b/packages/cli/src/migrate/migrateCommand.ts
@@ -1,0 +1,135 @@
+import fs from "fs";
+import path from "path";
+import { extractSpreadsheetId } from "../config/extractSpreadsheetId";
+import { filterOutputFiles } from "../config/filterOutputFiles";
+import { loadConfig } from "../config/loadConfig";
+import { logLoadedConfig } from "../config/logLoadedConfig";
+import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
+import { NoModelsError } from "../error/mainError";
+import { findBaseDir } from "../generate/generate";
+import { mergeSchemaFiles } from "../generate/mergeSchemaFiles";
+import { extractDatasourceUrl } from "../generate/read/extractDatasourceUrl";
+import { readTemplate } from "../util/readTemplate";
+import { buildMigrateModels } from "./buildMigrateModels";
+import { buildMigrationDirName } from "./migrationDirName";
+import {
+  findLatestMigrationContent,
+  writeMigrationTrail,
+} from "./migrationTrail";
+import { patchMigrationScript } from "./patchMigrationScript";
+import type { MigrateSheetsDefinition } from "./patchMigrationScript";
+import { resolveOutputDir } from "./resolveOutputDir";
+import { resolveUserSymbol } from "./resolveUserSymbol";
+
+type MigrateOptions = {
+  name?: string;
+  output?: string;
+  schema?: string;
+  config?: string;
+};
+
+type MigrateDeps = {
+  now: () => Date;
+};
+
+const defaultDeps: MigrateDeps = { now: () => new Date() };
+
+const STUB_FILE_NAME = "gassma-migration.js";
+
+const resolveSpreadsheetId = (
+  schemaText: string,
+  configUrl: string | undefined,
+): string | undefined => {
+  const fromConfig = extractSpreadsheetId(configUrl);
+  const fromSchema = extractDatasourceUrl(schemaText);
+  const resolved = extractSpreadsheetId(fromSchema ?? fromConfig);
+  return resolved === undefined || resolved === "" ? undefined : resolved;
+};
+
+const buildDefinition = (
+  schemaText: string,
+  configUrl: string | undefined,
+  schemaLocation: string,
+): MigrateSheetsDefinition => {
+  const models = buildMigrateModels(schemaText);
+  if (models.length === 0) throw new NoModelsError(schemaLocation);
+
+  const spreadsheetId = resolveSpreadsheetId(schemaText, configUrl);
+  return {
+    ...(spreadsheetId === undefined ? {} : { spreadsheetId }),
+    models,
+  };
+};
+
+const writeMigrationStub = (outputDir: string, content: string): string => {
+  fs.mkdirSync(outputDir, { recursive: true });
+  const stubPath = path.join(outputDir, STUB_FILE_NAME);
+  fs.writeFileSync(stubPath, content, "utf-8");
+  console.log(`📄 Wrote ${stubPath}`);
+  return stubPath;
+};
+
+const recordMigration = (
+  baseDir: string,
+  content: string,
+  name: string | undefined,
+  deps: MigrateDeps,
+): void => {
+  const migrationsDir = path.join(baseDir, "migrations");
+  if (findLatestMigrationContent(migrationsDir) === content) {
+    console.log(
+      "Already in sync, no schema change or pending migration was found.",
+    );
+    return;
+  }
+
+  const dirName = buildMigrationDirName(deps.now(), name);
+  const trailPath = writeMigrationTrail(migrationsDir, dirName, content);
+  console.log(`📄 Created ${trailPath}`);
+};
+
+const printNextSteps = (stubPath: string): void => {
+  console.log("\n✅ Migration generated\n");
+  console.log("Next steps:");
+  console.log(`  1. Run "clasp push" (or "npm run push") to upload ${STUB_FILE_NAME}
+  2. In the Apps Script editor, run the "gassmaMigrate" function once`);
+  console.log(
+    '\nNote: push with "clasp push" directly. A full clean build (e.g. "npm run deploy")' +
+      ` may wipe the output directory and delete ${stubPath} before it is pushed.`,
+  );
+};
+
+function migrate(options?: MigrateOptions, deps: MigrateDeps = defaultDeps) {
+  const allFiles = resolveSchemaFiles({
+    schema: options?.schema,
+    config: options?.config,
+  });
+  const baseDir = findBaseDir(allFiles.map((f) => f.filePath));
+  const files = filterOutputFiles(allFiles, baseDir);
+  const loaded = loadConfig(options?.config);
+  logLoadedConfig(loaded?.filePath);
+
+  const schemaText = mergeSchemaFiles(files.map((f) => f.filePath));
+  const schemaLocation = path.resolve(
+    files.length === 1 ? files[0].filePath : baseDir,
+  );
+  const definition = buildDefinition(
+    schemaText,
+    loaded?.config.datasource?.url,
+    schemaLocation,
+  );
+
+  const outputDir = resolveOutputDir(options?.output, process.cwd());
+  const userSymbol = resolveUserSymbol(outputDir);
+  const content = patchMigrationScript(
+    readTemplate("gassma-migration.js.template"),
+    { userSymbol, definition },
+  );
+
+  const stubPath = writeMigrationStub(outputDir, content);
+  recordMigration(baseDir, content, options?.name, deps);
+  printNextSteps(stubPath);
+}
+
+export { migrate };
+export type { MigrateDeps, MigrateOptions };

--- a/packages/cli/src/migrate/migrateCommand.ts
+++ b/packages/cli/src/migrate/migrateCommand.ts
@@ -74,22 +74,26 @@ const recordMigration = (
   content: string,
   name: string | undefined,
   deps: MigrateDeps,
-): void => {
+): boolean => {
   const migrationsDir = path.join(baseDir, "migrations");
   if (findLatestMigrationContent(migrationsDir) === content) {
     console.log(
       "Already in sync, no schema change or pending migration was found.",
     );
-    return;
+    return false;
   }
 
   const dirName = buildMigrationDirName(deps.now(), name);
   const trailPath = writeMigrationTrail(migrationsDir, dirName, content);
   console.log(`📄 Created ${trailPath}`);
+  return true;
 };
 
-const printNextSteps = (stubPath: string): void => {
-  console.log("\n✅ Migration generated\n");
+const printNextSteps = (stubPath: string, recorded: boolean): void => {
+  const headline = recorded
+    ? "✅ Migration generated"
+    : `✅ Refreshed ${STUB_FILE_NAME} (no new migration recorded)`;
+  console.log(`\n${headline}\n`);
   console.log("Next steps:");
   console.log(`  1. Run "clasp push" (or "npm run push") to upload ${STUB_FILE_NAME}
   2. In the Apps Script editor, run the "gassmaMigrate" function once`);
@@ -127,8 +131,8 @@ function migrate(options?: MigrateOptions, deps: MigrateDeps = defaultDeps) {
   );
 
   const stubPath = writeMigrationStub(outputDir, content);
-  recordMigration(baseDir, content, options?.name, deps);
-  printNextSteps(stubPath);
+  const recorded = recordMigration(baseDir, content, options?.name, deps);
+  printNextSteps(stubPath, recorded);
 }
 
 export { migrate };

--- a/packages/cli/src/migrate/migrationDirName.ts
+++ b/packages/cli/src/migrate/migrationDirName.ts
@@ -10,10 +10,17 @@ const formatMigrationTimestamp = (date: Date): string =>
     pad2(date.getUTCSeconds()),
   ].join("");
 
+const sanitizeMigrationName = (name: string): string =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
 const buildMigrationDirName = (date: Date, name?: string): string => {
   const timestamp = formatMigrationTimestamp(date);
-  if (name === undefined || name === "") return timestamp;
-  return `${timestamp}_${name}`;
+  const sanitized = sanitizeMigrationName(name ?? "");
+  if (sanitized === "") return timestamp;
+  return `${timestamp}_${sanitized}`;
 };
 
 export { buildMigrationDirName };

--- a/packages/cli/src/migrate/migrationDirName.ts
+++ b/packages/cli/src/migrate/migrationDirName.ts
@@ -1,0 +1,19 @@
+const pad2 = (value: number): string => String(value).padStart(2, "0");
+
+const formatMigrationTimestamp = (date: Date): string =>
+  [
+    String(date.getUTCFullYear()),
+    pad2(date.getUTCMonth() + 1),
+    pad2(date.getUTCDate()),
+    pad2(date.getUTCHours()),
+    pad2(date.getUTCMinutes()),
+    pad2(date.getUTCSeconds()),
+  ].join("");
+
+const buildMigrationDirName = (date: Date, name?: string): string => {
+  const timestamp = formatMigrationTimestamp(date);
+  if (name === undefined || name === "") return timestamp;
+  return `${timestamp}_${name}`;
+};
+
+export { buildMigrationDirName };

--- a/packages/cli/src/migrate/migrationDirName.ts
+++ b/packages/cli/src/migrate/migrationDirName.ts
@@ -10,8 +10,13 @@ const formatMigrationTimestamp = (date: Date): string =>
     pad2(date.getUTCSeconds()),
   ].join("");
 
-const sanitizeMigrationName = (name: string): string =>
+const decamelize = (name: string): string =>
   name
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2");
+
+const sanitizeMigrationName = (name: string): string =>
+  decamelize(name)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");

--- a/packages/cli/src/migrate/migrationTrail.ts
+++ b/packages/cli/src/migrate/migrationTrail.ts
@@ -1,0 +1,44 @@
+import fs from "fs";
+import path from "path";
+
+const MIGRATION_DIR_PATTERN = /^\d{14}(_.*)?$/;
+
+const listMigrationDirNames = (migrationsDir: string): string[] => {
+  if (!fs.existsSync(migrationsDir)) return [];
+
+  return fs
+    .readdirSync(migrationsDir, { withFileTypes: true })
+    .filter(
+      (entry) => entry.isDirectory() && MIGRATION_DIR_PATTERN.test(entry.name),
+    )
+    .map((entry) => entry.name)
+    .sort();
+};
+
+const findLatestMigrationContent = (
+  migrationsDir: string,
+): string | undefined => {
+  const dirNames = listMigrationDirNames(migrationsDir);
+  if (dirNames.length === 0) return undefined;
+
+  const latest = dirNames[dirNames.length - 1];
+  const migrationPath = path.join(migrationsDir, latest, "migration.js");
+  if (!fs.existsSync(migrationPath)) return undefined;
+
+  return fs.readFileSync(migrationPath, "utf-8");
+};
+
+const writeMigrationTrail = (
+  migrationsDir: string,
+  dirName: string,
+  content: string,
+): string => {
+  const trailDir = path.join(migrationsDir, dirName);
+  fs.mkdirSync(trailDir, { recursive: true });
+
+  const migrationPath = path.join(trailDir, "migration.js");
+  fs.writeFileSync(migrationPath, content, "utf-8");
+  return migrationPath;
+};
+
+export { findLatestMigrationContent, writeMigrationTrail };

--- a/packages/cli/src/migrate/patchMigrationScript.ts
+++ b/packages/cli/src/migrate/patchMigrationScript.ts
@@ -1,0 +1,53 @@
+import type { MigrateModelDefinition } from "./buildMigrateModels";
+
+type MigrateSheetsDefinition = {
+  spreadsheetId?: string;
+  models: MigrateModelDefinition[];
+};
+
+type PatchMigrationScriptOptions = {
+  userSymbol: string;
+  definition: MigrateSheetsDefinition;
+};
+
+const quote = (value: string): string => JSON.stringify(value);
+
+const renderModel = (model: MigrateModelDefinition): string => {
+  const columns = model.columns.map(quote).join(", ");
+  return `{ name: ${quote(model.name)}, columns: [${columns}] }`;
+};
+
+const renderDefinition = (definition: MigrateSheetsDefinition): string => {
+  const spreadsheetIdLines =
+    definition.spreadsheetId === undefined
+      ? []
+      : [`    spreadsheetId: ${quote(definition.spreadsheetId)},`];
+  const lastIndex = definition.models.length - 1;
+  const modelLines = definition.models.map(
+    (model, index) =>
+      `      ${renderModel(model)}${index === lastIndex ? "" : ","}`,
+  );
+
+  return [
+    "{",
+    ...spreadsheetIdLines,
+    "    models: [",
+    ...modelLines,
+    "    ]",
+    "  }",
+  ].join("\n");
+};
+
+const patchMigrationScript = (
+  template: string,
+  options: PatchMigrationScriptOptions,
+): string =>
+  template
+    .replace(
+      "Gassma.migrateSheets",
+      () => `${options.userSymbol}.migrateSheets`,
+    )
+    .replace("({})", () => `(${renderDefinition(options.definition)})`);
+
+export { patchMigrationScript };
+export type { MigrateSheetsDefinition, PatchMigrationScriptOptions };

--- a/packages/cli/src/migrate/resolveOutputDir.ts
+++ b/packages/cli/src/migrate/resolveOutputDir.ts
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+import { isRecord } from "../bootstrap/util/isRecord";
+import { MigrateOutputDirError } from "../error/mainError";
+
+const readClaspRootDir = (cwd: string): string | undefined => {
+  const claspJsonPath = path.join(cwd, ".clasp.json");
+  if (!fs.existsSync(claspJsonPath)) return undefined;
+
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(claspJsonPath, "utf-8"));
+    if (!isRecord(parsed)) return undefined;
+    return typeof parsed.rootDir === "string" ? parsed.rootDir : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const resolveOutputDir = (output: string | undefined, cwd: string): string => {
+  if (output !== undefined) return output;
+
+  const rootDir = readClaspRootDir(cwd);
+  if (rootDir !== undefined) return rootDir;
+
+  throw new MigrateOutputDirError();
+};
+
+export { resolveOutputDir };

--- a/packages/cli/src/migrate/resolveUserSymbol.ts
+++ b/packages/cli/src/migrate/resolveUserSymbol.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+import { GASSMA_LIBRARY } from "../bootstrap/const/gassmaLibrary";
+import { isRecord } from "../bootstrap/util/isRecord";
+
+const readLibraries = (manifest: Record<string, unknown>): unknown[] => {
+  const dependencies = manifest.dependencies;
+  if (!isRecord(dependencies)) return [];
+  return Array.isArray(dependencies.libraries) ? dependencies.libraries : [];
+};
+
+const findGassmaUserSymbol = (manifest: unknown): string | undefined => {
+  if (!isRecord(manifest)) return undefined;
+
+  const entry = readLibraries(manifest)
+    .filter(isRecord)
+    .find((library) => library.libraryId === GASSMA_LIBRARY.scriptId);
+  if (entry === undefined) return undefined;
+
+  return typeof entry.userSymbol === "string" ? entry.userSymbol : undefined;
+};
+
+const resolveUserSymbol = (outputDir: string): string => {
+  const manifestPath = path.join(outputDir, "appsscript.json");
+  if (!fs.existsSync(manifestPath)) return GASSMA_LIBRARY.userSymbol;
+
+  try {
+    const manifest: unknown = JSON.parse(
+      fs.readFileSync(manifestPath, "utf-8"),
+    );
+    return findGassmaUserSymbol(manifest) ?? GASSMA_LIBRARY.userSymbol;
+  } catch {
+    return GASSMA_LIBRARY.userSymbol;
+  }
+};
+
+export { resolveUserSymbol };

--- a/packages/cli/src/migrate/stripIgnoreAttributes.ts
+++ b/packages/cli/src/migrate/stripIgnoreAttributes.ts
@@ -1,0 +1,6 @@
+// prismaReader drops @ignore fields and @@ignore models, but Prisma keeps
+// them in the database schema, so migrate parses an ignore-free copy.
+const stripIgnoreAttributes = (schemaText: string): string =>
+  schemaText.replace(/@@ignore\b/g, "").replace(/@ignore\b/g, "");
+
+export { stripIgnoreAttributes };

--- a/packages/cli/templates/gassma-migration.js.template
+++ b/packages/cli/templates/gassma-migration.js.template
@@ -1,0 +1,3 @@
+function gassmaMigrate() {
+  Gassma.migrateSheets({});
+}


### PR DESCRIPTION
## 概要

新コマンド **`npx gassma migrate`** を追加します。schema.prisma を元に、**スプレッドシートへシート(テーブル)と列を自動生成する GAS 関数を生成**します。

本体側の受け口 `Gassma.migrateSheets` は gassma 本体 PR #171 でマージ済みです。

```
npx gassma migrate [--name <name>] [--output <dir>] [--schema <path>] [--config <path>]
```

生成される実行用スタブの実物(スモークテスト結果):

```js
function gassmaMigrate() {
  MyGassma.migrateSheets({
    spreadsheetId: "1AbCdEfG_hIjK-lMn",
    models: [
      { name: "User", columns: ["id", "full_name", "role", "age", "secret"] },
      { name: "記事", columns: ["id", "記事タイトル", "author_id"] },
      { name: "audit_logs", columns: ["id", "log_message", "level"] },
      { name: "_PostToTag", columns: ["postId", "tagId"] }
    ]
  });
}
```

## 設計

### なぜ生の JS をビルド出力先に置くのか

TypeScript の `export` で書くと、GAS でトップレベル関数として露出させる仕組み(esbuild プラグイン等)に依存してしまいます。**コンパイル済みの生 JS を直接置けばこの問題が消え**、独自ビルド構成のプロジェクトでも動きます。

出力先は **`--output` > `.clasp.json` の `rootDir` > エラー**の順で解決します(`dist` 決め打ちにはしません。`build/` 等を使っている構成にも追従するため)。ライブラリのシンボル名は出力先の `appsscript.json` から gassma ライブラリ(scriptId 一致)の `userSymbol` を読み、無ければ `Gassma` にフォールバックします。

### `clasp push` は自動実行しません

書きかけの本体コードまで巻き込んで GAS に上げてしまうためです。代わりに Next steps で `clasp push` → エディタで `gassmaMigrate` を1回実行、を案内します(clean 付きのフルビルドではなく `clasp push` を直接叩く注意も表示)。

### 証跡(migrations ディレクトリ)

schema.prisma の隣に `migrations/<UTC yyyymmddhhmmss>[_name]/migration.js` を出力します(Prisma が `prisma/migrations/` に置くのと同じ「schema の隣」規則)。中身は実行用スタブと同一で、**git にコミットしてスキーマ進化の記録を残す**用途です。

**これは順序付き適用エンジンではありません**(down migration も deploy もない、純粋な記録)。実際の同期は毎回ライブのシート状態と突き合わせる冪等な差分適用です。

- **直近の証跡と同内容なら新しいディレクトリを作りません** — `Already in sync, no schema change or pending migration was found.`(Prisma と同じ文言)
- **実行用スタブは同内容でも毎回書きます**(ビルドで消えても再実行で復元できるように)

## 変換ルール

- **物理名解決**: シート名 = `mapSheets[model] ?? model` / 列名 = `map[model][field] ?? field`。`@map` / `@@map` を正しく反映します(本体 `migrateSheets` は物理名を verbatim で書くだけなので、解決は CLI の責務)
- **`@ignore` フィールド・`@@ignore` モデルも作成対象に含めます**。Prisma のセマンティクスは「クライアントから除外されるだけで DB には存在する」であり、prisma 7.4.1 で実測確認しました(`@ignore` 列は `ALTER TABLE ADD COLUMN`、`@@ignore` モデルは `CREATE TABLE` が生成される)
- **暗黙多対多の中間シートも作成対象**(`_PostToTag`、列は gassma 独自規約の `postId`/`tagId`)
- optional フィールドの `?` サフィックスを列名から除去
- 列順・モデル順は schema の宣言順を維持

パーサはすべて `generate` が使っている既存実装を再利用しており、新しいパーサは書いていません。

## `--name` のサニタイズ

Prisma と同じ規則です(prisma 7.4.1 で実測して合わせました):

| 入力 | 生成されるディレクトリ |
|---|---|
| `Add User ★Table--` | `<ts>_add_user_table` |
| `addUserTable` | `<ts>_add_user_table` |
| `addAPIKeyV2 andHTTPStuff` | `<ts>_add_api_key_v2_and_http_stuff` |

decamelize → 小文字化 → 英数字以外の連続を `_` 1つに → 前後の `_` を除去。サニタイズ後が空なら timestamp のみになります。

これは**レビューで見つかった実害のある問題への対処**でもあります。サニタイズ前は `--name "evil/sub"` がディレクトリをネストさせて直近証跡の検出を永久に失敗させ(**実行のたびに証跡が増え続ける**)、`--name "../../../outside"` で `migrations/` の外にファイルを書けていました。現在はどちらも `migrations/` 直下のフラットな1階層に収まることを実測確認済みです。

## テスト

t-wada 流 TDD で実装。**87ケース追加、全体 1208件パス**(typecheck / lint / format / build / test:types すべて clean)。

変換ロジック・テンプレートのパッチ・ディレクトリ名生成・出力先解決・userSymbol 解決・証跡の読み書きはすべて純粋関数として切り出し、単体テストで固めています。`tsx` 経由の e2e もあります。

独立した検証エージェントによる敵対的レビューを実施し、以下を実測で確認しました:

- **JS インジェクション耐性** — `@map("\"]});process.exit(1);//")` のような値を注入しても安全に文字列化(`JSON.stringify` ベース + `String.replace` の置換に関数形式を使用)。生成物は全て `node --check` 通過
- **`@ignore` 除去の正規表現の安全性** — 文字列リテラル内の `@ignore`、コメント内、`@@ignoreSomething`(未知属性)、`@map("@ignore")` を試して出力不変
- 日本語のシート名・列名が正しく処理される
- `npm pack --dry-run` で新テンプレートの同梱を確認
- 変異テスト3種すべてで Red を確認(テストが実装追従でないことの担保)

## 既知の制限(このPRのスコープ外)

- **自己参照の暗黙多対多**で中間シートの列が重複します(`_TagToTag` の列が `["tagId","tagId"]`)。根本は既存 `detectImplicitManyToMany` の限界で、migrate が顕在化させたものです
- 同一 UTC 秒内にスキーマを変更して2回実行すると証跡が上書きされます

## 補足

`gassma-migration.js` は `templates/` 配下のテンプレートから生成しており、「CLI が生成する全ファイルのソースを templates/ に統一する」規約(#132)を維持しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja