### PR TITLE
fix: disambiguate junction columns for self-relation implicit many-to-many

### DIFF
--- a/packages/cli/src/__test__/generate/read/extractRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractRelations.test.ts
@@ -238,6 +238,99 @@ model Category {
     });
   });
 
+  it("should assign A/B columns to a self-referencing implicit manyToMany", () => {
+    const schema = `
+model Tag {
+  id        Int   @id
+  related   Tag[] @relation("TagRelations")
+  relatedBy Tag[] @relation("TagRelations")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Tag.related).toEqual({
+      type: "manyToMany",
+      to: "Tag",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "_TagToTag",
+        field: "tagAId",
+        reference: "tagBId",
+      },
+    });
+    expect(result.Tag.relatedBy).toEqual({
+      type: "manyToMany",
+      to: "Tag",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "_TagToTag",
+        field: "tagBId",
+        reference: "tagAId",
+      },
+    });
+  });
+
+  it("should keep self-referencing A/B sides stable across declaration order", () => {
+    const schema = `
+model Tag {
+  id        Int   @id
+  relatedBy Tag[] @relation("TagRelations")
+  related   Tag[] @relation("TagRelations")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Tag.related.through).toEqual({
+      sheet: "_TagToTag",
+      field: "tagAId",
+      reference: "tagBId",
+    });
+    expect(result.Tag.relatedBy.through).toEqual({
+      sheet: "_TagToTag",
+      field: "tagBId",
+      reference: "tagAId",
+    });
+  });
+
+  it("should use A/B columns when only one self-referencing list field exists", () => {
+    const schema = `
+model Tag {
+  id      Int   @id
+  related Tag[]
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Tag.related.through).toEqual({
+      sheet: "_TagToTag",
+      field: "tagAId",
+      reference: "tagBId",
+    });
+  });
+
+  it("should not create a through sheet for a self-referencing oneToMany", () => {
+    const schema = `
+model Category {
+  id       Int        @id
+  parentId Int?
+  parent   Category?  @relation(fields: [parentId], references: [id])
+  children Category[]
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Category.children).toEqual({
+      type: "oneToMany",
+      to: "Category",
+      field: "id",
+      reference: "parentId",
+    });
+    const types = Object.values(result.Category).map((rel) => rel.type);
+    expect(types).not.toContain("manyToMany");
+  });
+
   it("should extract manyToMany relation with through table", () => {
     const schema = `
 model Post {

--- a/packages/cli/src/__test__/generate/read/extractRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractRelations.test.ts
@@ -294,6 +294,62 @@ model Tag {
     });
   });
 
+  it("should pair self-referencing manyToMany fields by relation name", () => {
+    const schema = `
+model Node {
+  id       Int    @id
+  parentId Int?
+  parent   Node?  @relation("Tree", fields: [parentId], references: [id])
+  children Node[] @relation("Tree")
+  linked   Node[] @relation("Links")
+  linkedBy Node[] @relation("Links")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Node.linked.through).toEqual({
+      sheet: "_NodeToNode",
+      field: "nodeAId",
+      reference: "nodeBId",
+    });
+    expect(result.Node.linkedBy.through).toEqual({
+      sheet: "_NodeToNode",
+      field: "nodeBId",
+      reference: "nodeAId",
+    });
+    expect(result.Node.children).toEqual({
+      type: "oneToMany",
+      to: "Node",
+      field: "id",
+      reference: "parentId",
+    });
+  });
+
+  it("should keep A/B sides stable regardless of unrelated field positions", () => {
+    const schema = `
+model Node {
+  id       Int    @id
+  linked   Node[] @relation("Links")
+  linkedBy Node[] @relation("Links")
+  parentId Int?
+  parent   Node?  @relation("Tree", fields: [parentId], references: [id])
+  children Node[] @relation("Tree")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Node.linked.through).toEqual({
+      sheet: "_NodeToNode",
+      field: "nodeAId",
+      reference: "nodeBId",
+    });
+    expect(result.Node.linkedBy.through).toEqual({
+      sheet: "_NodeToNode",
+      field: "nodeBId",
+      reference: "nodeAId",
+    });
+  });
+
   it("should use A/B columns when only one self-referencing list field exists", () => {
     const schema = `
 model Tag {

--- a/packages/cli/src/__test__/migrate/buildMigrateModels.test.ts
+++ b/packages/cli/src/__test__/migrate/buildMigrateModels.test.ts
@@ -212,6 +212,34 @@ model Tag {
     expect(models[2].columns).toEqual(["postId", "tagId"]);
   });
 
+  it("should build distinct A/B columns for a self-referencing through sheet", () => {
+    const schema = `
+model Tag {
+  id        Int   @id
+  related   Tag[] @relation("TagRelations")
+  relatedBy Tag[] @relation("TagRelations")
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "Tag", columns: ["id"] },
+      { name: "_TagToTag", columns: ["tagAId", "tagBId"] },
+    ]);
+  });
+
+  it("should not create a through sheet for a self-referencing one-to-many", () => {
+    const schema = `
+model Category {
+  id       Int        @id
+  parentId Int?
+  parent   Category?  @relation(fields: [parentId], references: [id])
+  children Category[]
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "Category", columns: ["id", "parentId"] },
+    ]);
+  });
+
   it("should not create a through sheet for one-to-many relations", () => {
     const schema = `
 model Post {

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -126,6 +126,44 @@ describe("migrate", () => {
     expect(content).toContain("MyGassma.migrateSheets(");
   });
 
+  it("should write distinct columns for self-referencing and normal through sheets", () => {
+    writeSchema(`
+datasource db {
+  provider = "gassma"
+  url      = "https://docs.google.com/spreadsheets/d/abc123/edit"
+}
+
+model Post {
+  id     Int     @id
+  labels Label[]
+}
+
+model Label {
+  id    Int    @id
+  posts Post[]
+}
+
+model Tag {
+  id        Int   @id
+  related   Tag[] @relation("TagRelations")
+  relatedBy Tag[] @relation("TagRelations")
+}
+`);
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toContain(
+      '{ name: "_TagToTag", columns: ["tagAId", "tagBId"] }',
+    );
+    expect(content).toContain(
+      '{ name: "_LabelToPost", columns: ["labelId", "postId"] }',
+    );
+  });
+
   it("should record the migration next to the schema with the timestamped name", () => {
     writeSchema(schemaWithDatasource);
 

--- a/packages/cli/src/generate/read/detectImplicitManyToMany.ts
+++ b/packages/cli/src/generate/read/detectImplicitManyToMany.ts
@@ -1,10 +1,45 @@
 import { findFirstAttribute } from "@loancrate/prisma-schema-parser";
-import type { ModelDeclaration } from "@loancrate/prisma-schema-parser";
+import type {
+  FieldDeclaration,
+  ModelDeclaration,
+} from "@loancrate/prisma-schema-parser";
 import type { RelationsConfig } from "./extractRelations";
 import { getFieldReferences } from "./relationHelpers";
 
 const toLowercaseFirst = (s: string): string =>
   s.charAt(0).toLowerCase() + s.slice(1);
+
+const isSelfSideA = (
+  model: ModelDeclaration,
+  member: FieldDeclaration,
+): boolean => {
+  const partner = model.members.find((m): m is FieldDeclaration => {
+    if (m.kind !== "field") return false;
+    if (m === member) return false;
+    if (m.type.kind !== "list") return false;
+    const t = m.type.type;
+    return t.kind === "typeId" && t.name.value === model.name.value;
+  });
+  if (!partner) return true;
+  return member.name.value < partner.name.value;
+};
+
+const buildThroughColumns = (
+  modelA: ModelDeclaration,
+  member: FieldDeclaration,
+  targetName: string,
+): { field: string; reference: string } => {
+  if (modelA.name.value !== targetName)
+    return {
+      field: `${toLowercaseFirst(modelA.name.value)}Id`,
+      reference: `${toLowercaseFirst(targetName)}Id`,
+    };
+
+  const base = toLowercaseFirst(targetName);
+  return isSelfSideA(modelA, member)
+    ? { field: `${base}AId`, reference: `${base}BId` }
+    : { field: `${base}BId`, reference: `${base}AId` };
+};
 
 const detectImplicitManyToMany = (
   models: ModelDeclaration[],
@@ -49,8 +84,7 @@ const detectImplicitManyToMany = (
         reference: "id",
         through: {
           sheet: throughSheet,
-          field: `${toLowercaseFirst(modelA.name.value)}Id`,
-          reference: `${toLowercaseFirst(targetName)}Id`,
+          ...buildThroughColumns(modelA, member, targetName),
         },
       };
     });

--- a/packages/cli/src/generate/read/detectImplicitManyToMany.ts
+++ b/packages/cli/src/generate/read/detectImplicitManyToMany.ts
@@ -4,7 +4,7 @@ import type {
   ModelDeclaration,
 } from "@loancrate/prisma-schema-parser";
 import type { RelationsConfig } from "./extractRelations";
-import { getFieldReferences } from "./relationHelpers";
+import { getFieldReferences, getRelationName } from "./relationHelpers";
 
 const toLowercaseFirst = (s: string): string =>
   s.charAt(0).toLowerCase() + s.slice(1);
@@ -13,12 +13,15 @@ const isSelfSideA = (
   model: ModelDeclaration,
   member: FieldDeclaration,
 ): boolean => {
+  const relationName = getRelationName(member);
   const partner = model.members.find((m): m is FieldDeclaration => {
     if (m.kind !== "field") return false;
     if (m === member) return false;
     if (m.type.kind !== "list") return false;
     const t = m.type.type;
-    return t.kind === "typeId" && t.name.value === model.name.value;
+    if (t.kind !== "typeId") return false;
+    if (t.name.value !== model.name.value) return false;
+    return getRelationName(m) === relationName;
   });
   if (!partner) return true;
   return member.name.value < partner.name.value;

--- a/packages/cli/src/migrate/buildMigrateModels.ts
+++ b/packages/cli/src/migrate/buildMigrateModels.ts
@@ -29,6 +29,15 @@ const buildSheetModels = (schemaText: string): MigrateModelDefinition[] => {
   }));
 };
 
+const buildThroughColumns = (
+  modelName: string,
+  to: string,
+  through: { field: string; reference: string },
+): string[] => {
+  if (modelName === to) return [through.field, through.reference].sort();
+  return [modelName, to].sort().map((name) => `${toLowercaseFirst(name)}Id`);
+};
+
 const buildThroughModels = (schemaText: string): MigrateModelDefinition[] => {
   const relations = extractRelations(schemaText);
   const seenSheets = new Set<string>();
@@ -41,10 +50,13 @@ const buildThroughModels = (schemaText: string): MigrateModelDefinition[] => {
       if (seenSheets.has(definition.through.sheet)) return;
       seenSheets.add(definition.through.sheet);
 
-      const sorted = [modelName, definition.to].sort();
       models.push({
         name: definition.through.sheet,
-        columns: sorted.map((name) => `${toLowercaseFirst(name)}Id`),
+        columns: buildThroughColumns(
+          modelName,
+          definition.to,
+          definition.through,
+        ),
       });
     });
   });


### PR DESCRIPTION
## 概要

自己参照の暗黙多対多で、**中間シートの2列が同じ名前になり区別できない**問題を修正します。

```prisma
model Tag {
  id        Int   @id
  related   Tag[] @relation("TagRelations")
  relatedBy Tag[] @relation("TagRelations")
}
```

| | 修正前 | 修正後 |
|---|---|---|
| 自己参照 `_TagToTag` | `["tagId", "tagId"]` ❌ | **`["tagAId", "tagBId"]`** ✅ |
| 通常 `_LabelToPost` | `["labelId", "postId"]` | `["labelId", "postId"]`(**変更なし**) |

## これは migrate だけの問題ではありませんでした

本体の実行時コードは `through.field` と `through.reference` を**別々の列名として**使います(`gassma/src/util/relation/resolvers/manyToMany.ts` などで行オブジェクトから引く)。両方が同名だと**起点と相手を区別できず、自己参照の多対多は実行時にも機能していません**でした。この修正で初めて機能する状態になります。

生成される relations も逆向きに共有されます:

```json
"related":   { "through": { "sheet": "_TagToTag", "field": "tagAId", "reference": "tagBId" } },
"relatedBy": { "through": { "sheet": "_TagToTag", "field": "tagBId", "reference": "tagAId" } }
```

## 修正箇所は2つ

1. **`generate/read/detectImplicitManyToMany.ts`** — 中間シートの列名を、自己参照のときだけ `${model}AId` / `${model}BId` に分ける。A/B の割り当ては**同じリレーション名を持つフィールド同士**を辞書順で比較して決定
2. **`migrate/buildMigrateModels.ts`** — `through.field`/`through.reference` を無視してモデル名から列名を再導出していた。**観測された `["tagId","tagId"]` の直接原因はこちら**

どちらも**自己参照のときだけ分岐**し、通常の多対多の経路は元のコードのままです。

## リレーション名でペアを決める理由

当初は「自分以外で最初の同一モデル型リストフィールド」を相方としていましたが、レビューで**現実的なスキーマで壊れる**ことが判明したため修正しました:

```prisma
model Node {
  parentId Int?
  parent   Node?  @relation("Tree", fields: [parentId], references: [id])
  children Node[] @relation("Tree")   // 自己ツリー(1対多)
  linked   Node[] @relation("Links")  // 自己リンク(多対多)
  linkedBy Node[] @relation("Links")
}
```

`linked`/`linkedBy` の相方が**両方 `children`** になり、結果として両方が同じ向きになっていました。さらに `children` の宣言位置を動かすと A/B が反転する = **無関係なフィールドの位置で意味が変わる**状態でした。再生成のたびにシートの意味が反転すればデータ破壊につながります。

相方の探索を**同じリレーション名のフィールドに限定**して解決しています(無名同士は一致とみなす = Prisma が複数リレーションを名前で曖昧性解消するのと同じ規則)。実測で、上記スキーマの `linked`/`linkedBy` が正しく逆向きになり、`children` を前後どちらに宣言しても結果が変わらないことを確認しました。

## テスト

t-wada 流 TDD。**8ケース追加、全体1217件パス**(format / lint / typecheck / test:types / build すべて clean)。

- 自己参照多対多で A/B が付き重複しない
- 2つのエントリで `field`/`reference` が逆向き
- **宣言順を入れ替えても A/B が変わらない**(純粋なペア / 自己ツリー同居の両方)
- **リレーション名でペアが決まる**(自己ツリーと自己リンクの同居)
- 通常の多対多が変わらない
- 自己参照1対多(親子ツリー)で中間シートが作られない(回帰ガード)
- migrate 経由の出力で重複が消えている

独立した検証エージェントによる敵対的レビューを実施し、**base を別 worktree に展開して生成物をバイト単位で比較**しました。命名多対多・`@@map`・`@map`・enum・明示FK・自己参照1対多を含む網羅スキーマに対する `generate` と `migrate` の全生成物が **base と完全一致**することを確認しています(通常の多対多を壊していないことの担保)。実装2ファイルを base に戻すと新テストが Red になることも確認済みです。

## gassma-test への影響

**ありません**。全 prisma ファイルを確認したところ、自己参照は `Category` の親子ツリー(1対多)のみ、暗黙多対多は `Post↔Tag` の通常ケースのみでした。`sheet/` の CSV も `src/consts` も変更不要です。

## 既知の限界(このPRのスコープ外)

同一モデルに**自己参照の多対多が2組以上**ある場合(`follows`/`followedBy` と `blocks`/`blockedBy` など)、中間シート名が両方 `_UserToUser` になって衝突します。Prisma は named 暗黙多対多のテーブルを `_Follows`/`_Blocks` とリレーション名で命名して回避しており、対応するならその方向です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja