### PR TITLE
fix: name implicit junction sheets after the relation name

### DIFF
--- a/packages/cli/src/__test__/generate/read/extractRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractRelations.test.ts
@@ -332,6 +332,206 @@ model Tag {
     });
   });
 
+  it("should name the through sheet after a name argument relation", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[] @relation(name: "PostTags")
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[] @relation(name: "PostTags")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Post.tags.through).toEqual({
+      sheet: "_PostTags",
+      field: "postId",
+      reference: "tagId",
+    });
+    expect(result.Tag.posts.through).toEqual({
+      sheet: "_PostTags",
+      field: "tagId",
+      reference: "postId",
+    });
+  });
+
+  it("should pair self-referencing sides declared with a name argument relation", () => {
+    const schema = `
+model User {
+  id         Int    @id
+  follows    User[] @relation(name: "Follows")
+  followedBy User[] @relation(name: "Follows")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.User.follows.through).toEqual({
+      sheet: "_Follows",
+      field: "userBId",
+      reference: "userAId",
+    });
+    expect(result.User.followedBy.through).toEqual({
+      sheet: "_Follows",
+      field: "userAId",
+      reference: "userBId",
+    });
+  });
+
+  it("should split two name argument relations on the same pair into distinct sheets", () => {
+    const schema = `
+model User {
+  id         Int    @id
+  follows    User[] @relation(name: "Follows")
+  followedBy User[] @relation(name: "Follows")
+  blocks     User[] @relation(name: "Blocks")
+  blockedBy  User[] @relation(name: "Blocks")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.User.follows.through).toEqual({
+      sheet: "_Follows",
+      field: "userBId",
+      reference: "userAId",
+    });
+    expect(result.User.followedBy.through).toEqual({
+      sheet: "_Follows",
+      field: "userAId",
+      reference: "userBId",
+    });
+    expect(result.User.blocks.through).toEqual({
+      sheet: "_Blocks",
+      field: "userBId",
+      reference: "userAId",
+    });
+    expect(result.User.blockedBy.through).toEqual({
+      sheet: "_Blocks",
+      field: "userAId",
+      reference: "userBId",
+    });
+  });
+
+  it("should split two name argument relations between two models into distinct sheets", () => {
+    const schema = `
+model Post {
+  id       Int   @id
+  tags     Tag[] @relation(name: "PostTags")
+  featured Tag[] @relation(name: "FeaturedTags")
+}
+
+model Tag {
+  id         Int    @id
+  posts      Post[] @relation(name: "PostTags")
+  featuredIn Post[] @relation(name: "FeaturedTags")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Post.tags.through).toEqual({
+      sheet: "_PostTags",
+      field: "postId",
+      reference: "tagId",
+    });
+    expect(result.Post.featured.through).toEqual({
+      sheet: "_FeaturedTags",
+      field: "postId",
+      reference: "tagId",
+    });
+    expect(result.Tag.posts.through).toEqual({
+      sheet: "_PostTags",
+      field: "tagId",
+      reference: "postId",
+    });
+    expect(result.Tag.featuredIn.through).toEqual({
+      sheet: "_FeaturedTags",
+      field: "tagId",
+      reference: "postId",
+    });
+  });
+
+  it("should read the relation name regardless of argument order", () => {
+    const schema = `
+model User {
+  id            Int    @id
+  writtenPosts  Post[] @relation(name: "WrittenPosts")
+  favoritePosts Post[] @relation(name: "FavoritePosts")
+}
+
+model Post {
+  id            Int   @id
+  author        User  @relation(fields: [authorId], references: [id], name: "WrittenPosts")
+  authorId      Int
+  favoritedBy   User? @relation(name: "FavoritePosts", fields: [favoritedById], references: [id])
+  favoritedById Int?
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.User.writtenPosts).toEqual({
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "authorId",
+    });
+    expect(result.User.favoritePosts).toEqual({
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "favoritedById",
+    });
+    expect(result.Post.author).toEqual({
+      type: "manyToOne",
+      to: "User",
+      field: "authorId",
+      reference: "id",
+    });
+    expect(result.Post.favoritedBy).toEqual({
+      type: "manyToOne",
+      to: "User",
+      field: "favoritedById",
+      reference: "id",
+    });
+  });
+
+  it("should keep shorthand and unnamed through sheets when mixed with name arguments", () => {
+    const schema = `
+model Post {
+  id       Int     @id
+  tags     Tag[]   @relation(name: "PostTags")
+  featured Tag[]   @relation("FeaturedTags")
+  labels   Label[]
+}
+
+model Tag {
+  id         Int    @id
+  posts      Post[] @relation(name: "PostTags")
+  featuredIn Post[] @relation("FeaturedTags")
+}
+
+model Label {
+  id    Int    @id
+  posts Post[]
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Post.tags.through?.sheet).toBe("_PostTags");
+    expect(result.Post.featured.through?.sheet).toBe("_FeaturedTags");
+    expect(result.Post.labels.through).toEqual({
+      sheet: "_LabelToPost",
+      field: "postId",
+      reference: "labelId",
+    });
+    expect(result.Label.posts.through).toEqual({
+      sheet: "_LabelToPost",
+      field: "labelId",
+      reference: "postId",
+    });
+  });
+
   it("should extract self-referencing oneToMany relation", () => {
     const schema = `
 model Category {

--- a/packages/cli/src/__test__/generate/read/extractRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractRelations.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ThroughSheetConflictError } from "../../../error/mainError";
 import { extractRelations } from "../../../generate/read/extractRelations";
 
 describe("extractRelations", () => {
@@ -530,6 +531,100 @@ model Label {
       field: "labelId",
       reference: "postId",
     });
+  });
+
+  it("should reject one through sheet shared by two different model pairs", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[] @relation("Links")
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[] @relation("Links")
+}
+
+model User {
+  id     Int     @id
+  groups Group[] @relation("Links")
+}
+
+model Group {
+  id    Int    @id
+  users User[] @relation("Links")
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(ThroughSheetConflictError);
+    expect(() => extractRelations(schema)).toThrow(/_Links/);
+    expect(() => extractRelations(schema)).toThrow(/Post <-> Tag/);
+    expect(() => extractRelations(schema)).toThrow(/Group <-> User/);
+  });
+
+  it("should reject a relation name colliding with an unnamed through sheet", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[]
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[]
+}
+
+model Article {
+  id   Int   @id
+  refs Ref[] @relation("PostToTag")
+}
+
+model Ref {
+  id       Int       @id
+  articles Article[] @relation("PostToTag")
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(ThroughSheetConflictError);
+    expect(() => extractRelations(schema)).toThrow(/_PostToTag/);
+    expect(() => extractRelations(schema)).toThrow(/Article <-> Ref/);
+  });
+
+  it("should accept both sides of one relation pointing at the same through sheet", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[] @relation("PostTags")
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[] @relation("PostTags")
+}
+`;
+    expect(() => extractRelations(schema)).not.toThrow();
+  });
+
+  it("should accept two self-referencing fields sharing one through sheet", () => {
+    const schema = `
+model Tag {
+  id        Int   @id
+  related   Tag[] @relation("TagRelations")
+  relatedBy Tag[] @relation("TagRelations")
+}
+`;
+    expect(() => extractRelations(schema)).not.toThrow();
+  });
+
+  it("should accept two named relations on the same model pair", () => {
+    const schema = `
+model User {
+  id         Int    @id
+  follows    User[] @relation("Follows")
+  followedBy User[] @relation("Follows")
+  blocks     User[] @relation("Blocks")
+  blockedBy  User[] @relation("Blocks")
+}
+`;
+    expect(() => extractRelations(schema)).not.toThrow();
   });
 
   it("should extract self-referencing oneToMany relation", () => {

--- a/packages/cli/src/__test__/generate/read/extractRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractRelations.test.ts
@@ -212,6 +212,126 @@ model Apple {
     });
   });
 
+  it("should name the through sheet after the named relation", () => {
+    const schema = `
+model User {
+  id         Int    @id
+  follows    User[] @relation("Follows")
+  followedBy User[] @relation("Follows")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.User.follows.through).toEqual({
+      sheet: "_Follows",
+      field: "userBId",
+      reference: "userAId",
+    });
+    expect(result.User.followedBy.through).toEqual({
+      sheet: "_Follows",
+      field: "userAId",
+      reference: "userBId",
+    });
+  });
+
+  it("should split two named relations on the same pair into distinct sheets", () => {
+    const schema = `
+model User {
+  id         Int    @id
+  follows    User[] @relation("Follows")
+  followedBy User[] @relation("Follows")
+  blocks     User[] @relation("Blocks")
+  blockedBy  User[] @relation("Blocks")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.User.follows.through).toEqual({
+      sheet: "_Follows",
+      field: "userBId",
+      reference: "userAId",
+    });
+    expect(result.User.followedBy.through).toEqual({
+      sheet: "_Follows",
+      field: "userAId",
+      reference: "userBId",
+    });
+    expect(result.User.blocks.through).toEqual({
+      sheet: "_Blocks",
+      field: "userBId",
+      reference: "userAId",
+    });
+    expect(result.User.blockedBy.through).toEqual({
+      sheet: "_Blocks",
+      field: "userAId",
+      reference: "userBId",
+    });
+  });
+
+  it("should keep model-name columns for a named non-self manyToMany", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[] @relation("PostTags")
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[] @relation("PostTags")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Post.tags.through).toEqual({
+      sheet: "_PostTags",
+      field: "postId",
+      reference: "tagId",
+    });
+    expect(result.Tag.posts.through).toEqual({
+      sheet: "_PostTags",
+      field: "tagId",
+      reference: "postId",
+    });
+  });
+
+  it("should split two named relations between two models into distinct sheets", () => {
+    const schema = `
+model Post {
+  id       Int   @id
+  tags     Tag[] @relation("PostTags")
+  featured Tag[] @relation("FeaturedTags")
+}
+
+model Tag {
+  id         Int    @id
+  posts      Post[] @relation("PostTags")
+  featuredIn Post[] @relation("FeaturedTags")
+}
+`;
+    const result = extractRelations(schema);
+
+    expect(result.Post.tags.through).toEqual({
+      sheet: "_PostTags",
+      field: "postId",
+      reference: "tagId",
+    });
+    expect(result.Post.featured.through).toEqual({
+      sheet: "_FeaturedTags",
+      field: "postId",
+      reference: "tagId",
+    });
+    expect(result.Tag.posts.through).toEqual({
+      sheet: "_PostTags",
+      field: "tagId",
+      reference: "postId",
+    });
+    expect(result.Tag.featuredIn.through).toEqual({
+      sheet: "_FeaturedTags",
+      field: "tagId",
+      reference: "postId",
+    });
+  });
+
   it("should extract self-referencing oneToMany relation", () => {
     const schema = `
 model Category {
@@ -254,7 +374,7 @@ model Tag {
       field: "id",
       reference: "id",
       through: {
-        sheet: "_TagToTag",
+        sheet: "_TagRelations",
         field: "tagAId",
         reference: "tagBId",
       },
@@ -265,7 +385,7 @@ model Tag {
       field: "id",
       reference: "id",
       through: {
-        sheet: "_TagToTag",
+        sheet: "_TagRelations",
         field: "tagBId",
         reference: "tagAId",
       },
@@ -283,12 +403,12 @@ model Tag {
     const result = extractRelations(schema);
 
     expect(result.Tag.related.through).toEqual({
-      sheet: "_TagToTag",
+      sheet: "_TagRelations",
       field: "tagAId",
       reference: "tagBId",
     });
     expect(result.Tag.relatedBy.through).toEqual({
-      sheet: "_TagToTag",
+      sheet: "_TagRelations",
       field: "tagBId",
       reference: "tagAId",
     });
@@ -308,12 +428,12 @@ model Node {
     const result = extractRelations(schema);
 
     expect(result.Node.linked.through).toEqual({
-      sheet: "_NodeToNode",
+      sheet: "_Links",
       field: "nodeAId",
       reference: "nodeBId",
     });
     expect(result.Node.linkedBy.through).toEqual({
-      sheet: "_NodeToNode",
+      sheet: "_Links",
       field: "nodeBId",
       reference: "nodeAId",
     });
@@ -339,12 +459,12 @@ model Node {
     const result = extractRelations(schema);
 
     expect(result.Node.linked.through).toEqual({
-      sheet: "_NodeToNode",
+      sheet: "_Links",
       field: "nodeAId",
       reference: "nodeBId",
     });
     expect(result.Node.linkedBy.through).toEqual({
-      sheet: "_NodeToNode",
+      sheet: "_Links",
       field: "nodeBId",
       reference: "nodeAId",
     });

--- a/packages/cli/src/__test__/migrate/buildMigrateModels.test.ts
+++ b/packages/cli/src/__test__/migrate/buildMigrateModels.test.ts
@@ -222,7 +222,43 @@ model Tag {
 `;
     expect(buildMigrateModels(schema)).toEqual([
       { name: "Tag", columns: ["id"] },
-      { name: "_TagToTag", columns: ["tagAId", "tagBId"] },
+      { name: "_TagRelations", columns: ["tagAId", "tagBId"] },
+    ]);
+  });
+
+  it("should append one through sheet per named relation on the same pair", () => {
+    const schema = `
+model User {
+  id         Int    @id
+  follows    User[] @relation("Follows")
+  followedBy User[] @relation("Follows")
+  blocks     User[] @relation("Blocks")
+  blockedBy  User[] @relation("Blocks")
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "User", columns: ["id"] },
+      { name: "_Follows", columns: ["userAId", "userBId"] },
+      { name: "_Blocks", columns: ["userAId", "userBId"] },
+    ]);
+  });
+
+  it("should keep model-name columns for a named through sheet between two models", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[] @relation("PostTags")
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[] @relation("PostTags")
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "Post", columns: ["id"] },
+      { name: "Tag", columns: ["id"] },
+      { name: "_PostTags", columns: ["postId", "tagId"] },
     ]);
   });
 

--- a/packages/cli/src/__test__/migrate/buildMigrateModels.test.ts
+++ b/packages/cli/src/__test__/migrate/buildMigrateModels.test.ts
@@ -262,6 +262,36 @@ model Tag {
     ]);
   });
 
+  it("should append through sheets for name argument, shorthand and unnamed relations", () => {
+    const schema = `
+model Post {
+  id       Int     @id
+  tags     Tag[]   @relation(name: "PostTags")
+  featured Tag[]   @relation("FeaturedTags")
+  labels   Label[]
+}
+
+model Tag {
+  id         Int    @id
+  posts      Post[] @relation(name: "PostTags")
+  featuredIn Post[] @relation("FeaturedTags")
+}
+
+model Label {
+  id    Int    @id
+  posts Post[]
+}
+`;
+    expect(buildMigrateModels(schema)).toEqual([
+      { name: "Post", columns: ["id"] },
+      { name: "Tag", columns: ["id"] },
+      { name: "Label", columns: ["id"] },
+      { name: "_PostTags", columns: ["postId", "tagId"] },
+      { name: "_FeaturedTags", columns: ["postId", "tagId"] },
+      { name: "_LabelToPost", columns: ["labelId", "postId"] },
+    ]);
+  });
+
   it("should not create a through sheet for a self-referencing one-to-many", () => {
     const schema = `
 model Category {

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GASSMA_LIBRARY } from "../../bootstrap/const/gassmaLibrary";
+import { ThroughSheetConflictError } from "../../error/mainError";
 import { migrate } from "../../migrate/migrateCommand";
 
 const schemaWithDatasource = `
@@ -162,6 +163,40 @@ model Tag {
     expect(content).toContain(
       '{ name: "_LabelToPost", columns: ["labelId", "postId"] }',
     );
+  });
+
+  it("should fail when one through sheet is shared by two different model pairs", () => {
+    writeSchema(`
+datasource db {
+  provider = "gassma"
+  url      = "https://docs.google.com/spreadsheets/d/abc123/edit"
+}
+
+model Post {
+  id   Int   @id
+  tags Tag[] @relation("Links")
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[] @relation("Links")
+}
+
+model User {
+  id     Int     @id
+  groups Group[] @relation("Links")
+}
+
+model Group {
+  id    Int    @id
+  users User[] @relation("Links")
+}
+`);
+
+    expect(() => migrate({ output: "./out" }, fixedDeps)).toThrow(
+      ThroughSheetConflictError,
+    );
+    expect(() => migrate({ output: "./out" }, fixedDeps)).toThrow(/_Links/);
   });
 
   it("should write one through sheet per named relation while keeping unnamed names", () => {

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -157,7 +157,50 @@ model Tag {
       "utf-8",
     );
     expect(content).toContain(
-      '{ name: "_TagToTag", columns: ["tagAId", "tagBId"] }',
+      '{ name: "_TagRelations", columns: ["tagAId", "tagBId"] }',
+    );
+    expect(content).toContain(
+      '{ name: "_LabelToPost", columns: ["labelId", "postId"] }',
+    );
+  });
+
+  it("should write one through sheet per named relation while keeping unnamed names", () => {
+    writeSchema(`
+datasource db {
+  provider = "gassma"
+  url      = "https://docs.google.com/spreadsheets/d/abc123/edit"
+}
+
+model Post {
+  id     Int     @id
+  labels Label[]
+}
+
+model Label {
+  id    Int    @id
+  posts Post[]
+}
+
+model User {
+  id         Int    @id
+  follows    User[] @relation("Follows")
+  followedBy User[] @relation("Follows")
+  blocks     User[] @relation("Blocks")
+  blockedBy  User[] @relation("Blocks")
+}
+`);
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toContain(
+      '{ name: "_Follows", columns: ["userAId", "userBId"] }',
+    );
+    expect(content).toContain(
+      '{ name: "_Blocks", columns: ["userAId", "userBId"] }',
     );
     expect(content).toContain(
       '{ name: "_LabelToPost", columns: ["labelId", "postId"] }',

--- a/packages/cli/src/error/mainError.ts
+++ b/packages/cli/src/error/mainError.ts
@@ -58,6 +58,16 @@ class MigrateOutputDirError extends Error {
   }
 }
 
+class ThroughSheetConflictError extends Error {
+  constructor(sheetName: string, firstPair: string, secondPair: string) {
+    super(
+      `GASsmaThroughSheetConflictError: the through sheet "${sheetName}" would be shared by two different model pairs: ${firstPair} and ${secondPair}.\n` +
+        "An implicit many-to-many relation needs a through sheet of its own, so the two pairs would overwrite each other.\n" +
+        'Please give one of them a different relation name, e.g. @relation("OtherName") on both sides.',
+    );
+  }
+}
+
 export {
   ArgumentError,
   NoModelsError,
@@ -66,4 +76,5 @@ export {
   GassmaConfigEnvError,
   GassmaConfigLoadError,
   MigrateOutputDirError,
+  ThroughSheetConflictError,
 };

--- a/packages/cli/src/generate/read/assertUniqueThroughSheets.ts
+++ b/packages/cli/src/generate/read/assertUniqueThroughSheets.ts
@@ -1,0 +1,25 @@
+import { ThroughSheetConflictError } from "../../error/mainError";
+import type { RelationsConfig } from "./extractRelations";
+
+const toPairLabel = (from: string, to: string): string =>
+  [from, to].sort().join(" <-> ");
+
+const assertUniqueThroughSheets = (relations: RelationsConfig): void => {
+  const pairBySheet = new Map<string, string>();
+
+  Object.keys(relations).forEach((modelName) => {
+    Object.values(relations[modelName]).forEach((definition) => {
+      const through = definition.through;
+      if (through === undefined) return;
+
+      const pair = toPairLabel(modelName, definition.to);
+      const known = pairBySheet.get(through.sheet);
+      if (known !== undefined && known !== pair)
+        throw new ThroughSheetConflictError(through.sheet, known, pair);
+
+      pairBySheet.set(through.sheet, pair);
+    });
+  });
+};
+
+export { assertUniqueThroughSheets };

--- a/packages/cli/src/generate/read/detectImplicitManyToMany.ts
+++ b/packages/cli/src/generate/read/detectImplicitManyToMany.ts
@@ -44,6 +44,18 @@ const buildThroughColumns = (
     : { field: `${base}BId`, reference: `${base}AId` };
 };
 
+const buildThroughSheet = (
+  modelA: ModelDeclaration,
+  member: FieldDeclaration,
+  targetName: string,
+): string => {
+  const relationName = getRelationName(member);
+  if (relationName) return `_${relationName}`;
+
+  const sorted = [modelA.name.value, targetName].sort();
+  return `_${sorted[0]}To${sorted[1]}`;
+};
+
 const detectImplicitManyToMany = (
   models: ModelDeclaration[],
   result: RelationsConfig,
@@ -76,9 +88,6 @@ const detectImplicitManyToMany = (
       });
       if (!inverseField || inverseField.kind !== "field") return;
 
-      const sorted = [modelA.name.value, targetName].sort();
-      const throughSheet = `_${sorted[0]}To${sorted[1]}`;
-
       if (!result[modelA.name.value]) result[modelA.name.value] = {};
       result[modelA.name.value][member.name.value] = {
         type: "manyToMany",
@@ -86,7 +95,7 @@ const detectImplicitManyToMany = (
         field: "id",
         reference: "id",
         through: {
-          sheet: throughSheet,
+          sheet: buildThroughSheet(modelA, member, targetName),
           ...buildThroughColumns(modelA, member, targetName),
         },
       };

--- a/packages/cli/src/generate/read/extractRelations.ts
+++ b/packages/cli/src/generate/read/extractRelations.ts
@@ -3,6 +3,7 @@ import {
   findFirstAttribute,
 } from "@loancrate/prisma-schema-parser";
 import type { ModelDeclaration } from "@loancrate/prisma-schema-parser";
+import { assertUniqueThroughSheets } from "./assertUniqueThroughSheets";
 import { detectImplicitManyToMany } from "./detectImplicitManyToMany";
 import {
   getRelationName,
@@ -124,6 +125,7 @@ const extractRelations = (schemaText: string): RelationsConfig => {
   const result = buildRelationsConfig(fieldsideRelations, models);
 
   detectImplicitManyToMany(models, result);
+  assertUniqueThroughSheets(result);
 
   return result;
 };

--- a/packages/cli/src/generate/read/relationHelpers.ts
+++ b/packages/cli/src/generate/read/relationHelpers.ts
@@ -23,12 +23,11 @@ type FieldsideRelation = {
 const getRelationName = (field: FieldDeclaration): string | null => {
   const attr = findFirstAttribute(field.attributes, "relation");
   if (!attr) return null;
-  const firstArg = attr.args?.[0];
-  if (!firstArg) return null;
-  if ("kind" in firstArg && firstArg.kind !== "namedArgument") {
-    if (firstArg.kind === "literal" && typeof firstArg.value === "string")
-      return firstArg.value;
-  }
+  const arg = findArgument(attr.args, "name", 0);
+  if (!arg) return null;
+  const expr = arg.expression;
+  if (expr.kind === "literal" && typeof expr.value === "string")
+    return expr.value;
   return null;
 };
 


### PR DESCRIPTION
## 概要

暗黙多対多の**中間シート名がリレーション名を無視**していたため、同じモデルペア間に複数の多対多があると1枚のシートに潰れて**2つの関係のデータが混ざる**問題を修正します。Prisma の実挙動に合わせました。

| ケース | 中間シート名 |
|---|---|
| **無名**リレーション | `_PostToTag`(モデル名をアルファベット順・**変更なし**) |
| **命名**リレーション `@relation("Follows")` | **`_Follows`**(新) |

prisma 7.4.1 で実測して合わせています(命名 → `_Follows`/`_Blocks`、無名 → `_PostToTag`)。**列名の規則は一切変えていません**(通常 `postId`/`tagId`、自己参照 `userAId`/`userBId`)。

## 修正前に起きていたこと

```prisma
model User {
  follows    User[] @relation("Follows")
  followedBy User[] @relation("Follows")
  blocks     User[] @relation("Blocks")
  blockedBy  User[] @relation("Blocks")
}
```

`_UserToUser` が1枚だけ生成され、`follows` と `blocks` の through 設定が**完全に同一**になっていました。つまりシートの1行を見ても「フォローなのかブロックなのか判別できない」状態です。

修正後は `_Follows` と `_Blocks` の2枚に分かれ、それぞれ正しく逆向きに共有されます:

```js
follows:    { sheet: "_Follows", field: "userBId", reference: "userAId" }
followedBy: { sheet: "_Follows", field: "userAId", reference: "userBId" }
blocks:     { sheet: "_Blocks",  field: "userBId", reference: "userAId" }
blockedBy:  { sheet: "_Blocks",  field: "userAId", reference: "userBId" }
```

## ⚠️ BREAKING CHANGE — 既存シートのリネームが必要な場合があります

**影響を受けるのは `@relation("...")` で名前を付けた暗黙多対多を使っている場合だけ**です。無名リレーションのユーザーは影響ゼロです。

| schema | 旧シート名 | 新シート名 |
|---|---|---|
| `@relation("PostTags")`(通常ペア) | `_PostToTag` | `_PostTags` |
| `@relation("Follows")`(自己参照) | `_UserToUser` | `_Follows` |
| 無名 | `_ArticleToLabel` | `_ArticleToLabel`(**変更なし**) |

**特に自己参照の暗黙多対多は全件が対象**です。Prisma は無名の自己参照多対多を invalid にする(`Ambiguous self relation detected`)ため、**実在する自己参照多対多は必ず命名済み**だからです。

### 移行手順

`migrate` は既存シートを削除しないため、**データが消えることはありません**が、放置すると:

- 旧シート(`_UserToUser`)は `is not in the schema. It is left untouched.` の警告とともに残る
- 新シート(`_Follows`)が**空で新規作成**され、リレーションが空に見える

**スプレッドシート上で旧シートを新しい名前にリネームしてください**(列名は変わらないのでデータはそのまま使えます)。

## 同時に修正した2点

### 1. `@relation(name: "X")` 形式が認識されていなかった

`getRelationName` が名前付き引数形式を明示的に弾いていました。Prisma では `@relation("X")` と `@relation(name: "X")` は**完全に等価**で、`prisma format` も `gassma format` も短縮形に正規化しないため、実際に書かれ得る形式です。

この修正は中間シート名だけでなく、**1対多のペアリングも直しています**。名前が読めないと `findInverseField` が破綻し、同じモデルへの1対多が2本あると片方が生成すらされていませんでした:

```js
// 修正前: favoriteNotes が消失し、writtenPosts の参照先まで汚染されていた
"User": { "writtenPosts": { "reference": "favoritedById" } }
// 修正後
"User": { "writtenPosts":  { "reference": "authorId" },
          "favoriteNotes": { "reference": "favoritedById" } }
```

### 2. 中間シート名の衝突をエラーにする(本家より厳しい仕様)

異なるモデルペアが同じ中間シート名に解決される場合、`ThroughSheetConflictError` を投げます:

```
GASsmaThroughSheetConflictError: the through sheet "_Links" would be shared by two different model pairs: Post <-> Tag and Group <-> User.
An implicit many-to-many relation needs a through sheet of its own, so the two pairs would overwrite each other.
Please give one of them a different relation name, e.g. @relation("OtherName") on both sides.
```

**Prisma 本家は同じ状況をエラーにしません**(実測: `validate` は valid、`migrate` は `_Links` を1枚だけ作り片方のペアを黙って捨てる)。あえて厳しくした理由は、**Prisma には FK 制約があり実行時に落ちて気づけるのに対し、gassma には制約がなく静かにデータが混ざる**ためです。加えて、本 PR の命名変更によって「以前は2枚に分かれて動いていたスキーマが1枚に潰れる」回帰も防げます。

同じリレーションを両側から見た場合・自己参照の2フィールド・同一ペアに2組(`_Follows`/`_Blocks`)は**誤検出しない**ことを回帰テストで固定しています。

## テスト

t-wada 流 TDD(各サイクルで Red を実測確認)。**全体1237件パス**、format / lint / typecheck / test:types / build すべて clean。

独立した検証エージェントによる敵対的レビューを実施し、**base を別 worktree に展開して生成物をバイト単位で比較**しました。enum・`@@map`・`@map`・1:1・1:n・onDelete/onUpdate・無名多対多3組を含む網羅スキーマで `generate` と `migrate` の全生成物が **base と完全一致**(`diff -r` / `cmp` / `md5`)。ミューテーションテスト4種でも Red を確認しています。

## 既知の制限(このPRのスコープ外)

- **リレーション名に GAS のシート名として使えない文字**(`[ ] * ? : / \`、先頭末尾のシングルクォート)が含まれると、そのままシート名になり実機の `insertSheet` で失敗します。Prisma もテーブル名に verbatim で使うため同じ挙動です
- **片側だけ命名・両側で名前が食い違う**スキーマは Prisma が `validate` で弾く不正スキーマですが、`gassma validate` は構文検査のみのため素通しします(既存の穴)
- 中間シートの列名は Prisma の `A`/`B` ではなく `postId`/`tagId` 形式のままです(既存ユーザーのシートを壊さないため意図的に維持)

## 補足

リファレンスサイトの「型ファイルの動的生成」ページが中間シート名を「`_PostToTag`(アルファベット順)」としか説明していないため、命名リレーション時の記述追加が必要です(別リポジトリ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja