### PR TITLE
feat: offer a linter and formatter choice during bootstrap

### DIFF
--- a/packages/cli/src/__test__/bootstrap/bootstrapCommand.test.ts
+++ b/packages/cli/src/__test__/bootstrap/bootstrapCommand.test.ts
@@ -114,6 +114,92 @@ describe("bootstrap", () => {
     expect(commands.some((c) => c === "npm i")).toBe(true);
   });
 
+  it("should default to the oxlint setup with --yes", async () => {
+    const { exec } = createClaspExec();
+    const prompter = createFakePrompter();
+
+    await bootstrap(
+      { yes: true, skipInstall: true, directory: "." },
+      { exec, prompter, isTty: true },
+    );
+
+    expect(fs.readFileSync(path.join(tmpDir, ".oxlintrc.json"), "utf-8")).toBe(
+      fs.readFileSync(
+        path.resolve(__dirname, "../../../templates/.oxlintrc.json.template"),
+        "utf-8",
+      ),
+    );
+    expect(fs.existsSync(path.join(tmpDir, "eslint.config.mjs"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".prettierrc"))).toBe(false);
+
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "package.json"), "utf-8"),
+    );
+    expect(pkg.scripts.lint).toBe("oxlint");
+    expect(pkg.scripts["format:check"]).toBe("oxfmt --check");
+    expect(pkg.devDependencies.oxlint).toBeTypeOf("string");
+    expect(pkg.devDependencies.oxfmt).toBeTypeOf("string");
+  });
+
+  it("should write the eslint setup when it is selected", async () => {
+    const { exec } = createClaspExec();
+    const prompter = createFakePrompter({
+      select: { "Linter and formatter setup?": "eslint" },
+    });
+
+    await bootstrap(
+      { skipInstall: true, directory: "." },
+      { exec, prompter, isTty: true },
+    );
+
+    expect(fs.existsSync(path.join(tmpDir, "eslint.config.mjs"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".prettierrc"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".oxlintrc.json"))).toBe(false);
+
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "package.json"), "utf-8"),
+    );
+    expect(pkg.scripts.lint).toBe("eslint .");
+    expect(pkg.devDependencies.prettier).toBeTypeOf("string");
+  });
+
+  it("should write no linter files when none is selected", async () => {
+    const { exec } = createClaspExec();
+    const prompter = createFakePrompter({
+      select: { "Linter and formatter setup?": "none" },
+    });
+
+    await bootstrap(
+      { skipInstall: true, directory: "." },
+      { exec, prompter, isTty: true },
+    );
+
+    expect(fs.existsSync(path.join(tmpDir, ".oxlintrc.json"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "eslint.config.mjs"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".prettierrc"))).toBe(false);
+
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "package.json"), "utf-8"),
+    );
+    expect(pkg.scripts.lint).toBeUndefined();
+    expect(pkg.devDependencies.oxlint).toBeUndefined();
+  });
+
+  it("should keep an existing .oxlintrc.json untouched", async () => {
+    fs.writeFileSync(path.join(tmpDir, ".oxlintrc.json"), "my rules");
+    const { exec } = createClaspExec();
+    const prompter = createFakePrompter();
+
+    await bootstrap(
+      { yes: true, skipInstall: true, directory: "." },
+      { exec, prompter, isTty: true },
+    );
+
+    expect(fs.readFileSync(path.join(tmpDir, ".oxlintrc.json"), "utf-8")).toBe(
+      "my rules",
+    );
+  });
+
   it("should write the manifest with the fetched library version", async () => {
     const { exec } = createClaspExec();
     const prompter = createFakePrompter();
@@ -225,6 +311,7 @@ describe("bootstrap", () => {
     expect(planNote?.message).toContain("clasp create-script");
     expect(planNote?.message).toContain("write gassma-project/package.json");
     expect(planNote?.message).toContain("write gassma-project/AGENTS.md");
+    expect(planNote?.message).toContain("write gassma-project/.oxlintrc.json");
     expect(planNote?.message).toContain("gassma init");
     expect(
       prompter.infos.every((message) => message.startsWith("[dry-run] ")),

--- a/packages/cli/src/__test__/bootstrap/env/loadBootstrapTemplates.test.ts
+++ b/packages/cli/src/__test__/bootstrap/env/loadBootstrapTemplates.test.ts
@@ -14,4 +14,18 @@ describe("loadBootstrapTemplates", () => {
     expect(templates.sampleIndex.export).toContain("export const main");
     expect(templates.sampleIndex.global).toContain("global.main = main;");
   });
+
+  it("should load the linter templates", () => {
+    const templates = loadBootstrapTemplates();
+
+    expect(JSON.parse(templates.oxlintrc)).toEqual({
+      plugins: ["typescript"],
+      categories: { correctness: "error" },
+      ignorePatterns: ["dist/**", "src/generated/**"],
+    });
+    expect(templates.eslintConfig).toContain("typescript-eslint");
+    expect(templates.eslintConfig).toContain("eslint-config-prettier");
+    expect(templates.eslintConfig).toContain("src/generated/**");
+    expect(() => JSON.parse(templates.prettierrc)).not.toThrow();
+  });
 });

--- a/packages/cli/src/__test__/bootstrap/flow/askSteps.test.ts
+++ b/packages/cli/src/__test__/bootstrap/flow/askSteps.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createInitialContext } from "../../../bootstrap/flow/context";
 import {
   installPromptStep,
+  linterStep,
   sampleStep,
   sheetsStep,
   styleStep,
@@ -97,6 +98,53 @@ describe("styleStep", () => {
     const ctx = await styleStep.run(baseContext(), deps);
 
     expect(ctx.style).toBe("export");
+  });
+});
+
+describe("linterStep", () => {
+  it("should offer oxlint, eslint and none", async () => {
+    const prompter = createFakePrompter();
+    const deps = createTestDeps({ prompter });
+
+    await linterStep.run(baseContext(), deps);
+
+    expect(prompter.selects).toHaveLength(1);
+    expect(prompter.selects[0].message).toBe("Linter and formatter setup?");
+    expect(prompter.selects[0].choices).toEqual([
+      { value: "oxlint", label: "oxlint + oxfmt", hint: "recommended" },
+      { value: "eslint", label: "eslint + prettier" },
+      { value: "none", label: "none" },
+    ]);
+  });
+
+  it("should store the selected linter", async () => {
+    const prompter = createFakePrompter({
+      select: { "Linter and formatter setup?": "eslint" },
+    });
+    const deps = createTestDeps({ prompter });
+
+    const ctx = await linterStep.run(baseContext(), deps);
+
+    expect(ctx.linter).toBe("eslint");
+  });
+
+  it("should store the none choice", async () => {
+    const prompter = createFakePrompter({
+      select: { "Linter and formatter setup?": "none" },
+    });
+    const deps = createTestDeps({ prompter });
+
+    const ctx = await linterStep.run(baseContext(), deps);
+
+    expect(ctx.linter).toBe("none");
+  });
+
+  it("should default to oxlint", async () => {
+    const deps = createTestDeps();
+
+    const ctx = await linterStep.run(baseContext(), deps);
+
+    expect(ctx.linter).toBe("oxlint");
   });
 });
 

--- a/packages/cli/src/__test__/bootstrap/flow/buildSteps.test.ts
+++ b/packages/cli/src/__test__/bootstrap/flow/buildSteps.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildBootstrapSteps } from "../../../bootstrap/flow/buildSteps";
+
+const stepIds = () => buildBootstrapSteps().map((step) => step.id);
+
+describe("buildBootstrapSteps", () => {
+  it("should ask for the linter between the style and the sample", () => {
+    const ids = stepIds();
+
+    expect(ids.indexOf("linter")).toBe(ids.indexOf("style") + 1);
+    expect(ids.indexOf("sample")).toBe(ids.indexOf("linter") + 1);
+  });
+
+  it("should ask every question before writing project files", () => {
+    const ids = stepIds();
+
+    expect(ids.indexOf("linter")).toBeLessThan(ids.indexOf("projectFiles"));
+  });
+});

--- a/packages/cli/src/__test__/bootstrap/flow/testHelpers.ts
+++ b/packages/cli/src/__test__/bootstrap/flow/testHelpers.ts
@@ -14,11 +14,18 @@ type PromptAnswers = {
   select?: Record<string, string>;
 };
 
+type SelectCall = {
+  message: string;
+  choices: SelectChoice<string>[];
+  defaultValue: string;
+};
+
 type FakePrompter = Prompter & {
   notes: { title: string; message: string }[];
   infos: string[];
   warns: string[];
   outros: string[];
+  selects: SelectCall[];
 };
 
 const createFakePrompter = (answers: PromptAnswers = {}): FakePrompter => {
@@ -26,12 +33,14 @@ const createFakePrompter = (answers: PromptAnswers = {}): FakePrompter => {
   const infos: string[] = [];
   const warns: string[] = [];
   const outros: string[] = [];
+  const selects: SelectCall[] = [];
 
   return {
     notes,
     infos,
     warns,
     outros,
+    selects,
     intro: () => undefined,
     outro: (message) => {
       outros.push(message);
@@ -54,6 +63,7 @@ const createFakePrompter = (answers: PromptAnswers = {}): FakePrompter => {
       choices: SelectChoice<T>[],
       defaultValue: T,
     ) => {
+      selects.push({ message, choices, defaultValue });
       const wanted = answers.select?.[message];
       const matched = choices.find((choice) => choice.value === wanted);
       return Promise.resolve(
@@ -132,4 +142,4 @@ export {
   createScriptedExec,
   createTestDeps,
 };
-export type { ExecCall, FakePrompter, PromptAnswers };
+export type { ExecCall, FakePrompter, PromptAnswers, SelectCall };

--- a/packages/cli/src/__test__/bootstrap/flow/writeSteps.test.ts
+++ b/packages/cli/src/__test__/bootstrap/flow/writeSteps.test.ts
@@ -45,6 +45,8 @@ describe("projectFilesStep", () => {
     expect(content).toContain("npx gassma generate");
     expect(content).toContain("npm run build");
     expect(content).toContain("npm run deploy");
+    expect(content).toContain("npm run lint");
+    expect(content).toContain("npm run format");
     expect(pkg.scripts.build).toBeDefined();
     expect(pkg.scripts.deploy).toBeDefined();
     expect(content).toContain("gassma/schema.prisma");
@@ -183,6 +185,56 @@ describe("projectFilesStep", () => {
     expect(content.startsWith("node_modules/\n")).toBe(true);
     expect(content).toContain(".clasp.json");
     expect(content).toContain("!dist/appsscript.json");
+  });
+});
+
+describe("projectFilesStep linter files", () => {
+  const oxlintPath = path.join(CWD, ".oxlintrc.json");
+  const eslintPath = path.join(CWD, "eslint.config.mjs");
+  const prettierPath = path.join(CWD, ".prettierrc");
+
+  it("should write .oxlintrc.json for the oxlint choice", async () => {
+    const { files, store } = createMemoryStore({});
+    const deps = createTestDeps({ store });
+
+    await projectFilesStep.run({ ...baseContext(), linter: "oxlint" }, deps);
+
+    expect(files.get(oxlintPath)).toBe(deps.templates.oxlintrc);
+    expect(files.has(eslintPath)).toBe(false);
+    expect(files.has(prettierPath)).toBe(false);
+  });
+
+  it("should write eslint.config.mjs and .prettierrc for the eslint choice", async () => {
+    const { files, store } = createMemoryStore({});
+    const deps = createTestDeps({ store });
+
+    await projectFilesStep.run({ ...baseContext(), linter: "eslint" }, deps);
+
+    expect(files.get(eslintPath)).toBe(deps.templates.eslintConfig);
+    expect(files.get(prettierPath)).toBe(deps.templates.prettierrc);
+    expect(files.has(oxlintPath)).toBe(false);
+  });
+
+  it("should write no linter config for the none choice", async () => {
+    const { files, store } = createMemoryStore({});
+    const deps = createTestDeps({ store });
+
+    await projectFilesStep.run({ ...baseContext(), linter: "none" }, deps);
+
+    expect(files.has(oxlintPath)).toBe(false);
+    expect(files.has(eslintPath)).toBe(false);
+    expect(files.has(prettierPath)).toBe(false);
+  });
+
+  it("should not overwrite an existing linter config", async () => {
+    const { files, store } = createMemoryStore({ [oxlintPath]: "my rules" });
+    const prompter = createFakePrompter();
+    const deps = createTestDeps({ store, prompter });
+
+    await projectFilesStep.run({ ...baseContext(), linter: "oxlint" }, deps);
+
+    expect(files.get(oxlintPath)).toBe("my rules");
+    expect(prompter.infos.join(" ")).toContain(".oxlintrc.json");
   });
 });
 

--- a/packages/cli/src/__test__/bootstrap/generators/mergePackageJson.test.ts
+++ b/packages/cli/src/__test__/bootstrap/generators/mergePackageJson.test.ts
@@ -7,6 +7,7 @@ const desired = patchPackageJson(readTemplate("package.json.template"), {
   name: "my-app",
   gassmaVersion: "1.1.0",
   style: "export",
+  linter: "oxlint",
 });
 
 const parse = (text: string) => JSON.parse(text);

--- a/packages/cli/src/__test__/bootstrap/generators/patchPackageJson.test.ts
+++ b/packages/cli/src/__test__/bootstrap/generators/patchPackageJson.test.ts
@@ -11,6 +11,7 @@ const baseOptions = {
   name: "my-app",
   gassmaVersion: "1.1.0",
   style: "export",
+  linter: "none",
 } satisfies Parameters<typeof patchPackageJson>[1];
 
 describe("patchPackageJson", () => {
@@ -57,6 +58,94 @@ describe("patchPackageJson", () => {
       "esbuild-gas-plugin": "^0.10.0",
       typescript: "^6.0.3",
     });
+  });
+
+  it("should add the oxlint toolchain when oxlint is chosen", () => {
+    const pkg = patchPackageJson(template, {
+      ...baseOptions,
+      linter: "oxlint",
+    });
+
+    expect(pkg.devDependencies).toMatchObject({
+      oxlint: "^1.76.0",
+      oxfmt: "^0.61.0",
+    });
+    expect(pkg.scripts).toMatchObject({
+      lint: "oxlint",
+      "lint:fix": "oxlint --fix",
+      format: "oxfmt",
+      "format:check": "oxfmt --check",
+    });
+  });
+
+  it("should keep devDependencies sorted so that oxfmt --check passes", () => {
+    const pkg = patchPackageJson(template, {
+      ...baseOptions,
+      linter: "oxlint",
+    });
+
+    expect(JSON.stringify(pkg.devDependencies)).toBe(
+      JSON.stringify({
+        "@gassma/gas-esbuild-plugin": "^0.1.0",
+        "@types/google-apps-script": "^2.0.11",
+        esbuild: "^0.28.0",
+        oxfmt: "^0.61.0",
+        oxlint: "^1.76.0",
+        typescript: "^6.0.3",
+      }),
+    );
+  });
+
+  it("should not add oxlint-tsgolint for the oxlint choice", () => {
+    const pkg = patchPackageJson(template, {
+      ...baseOptions,
+      linter: "oxlint",
+    });
+
+    expect(pkg.devDependencies).not.toHaveProperty("oxlint-tsgolint");
+    expect(JSON.stringify(pkg.scripts)).not.toContain("--type-aware");
+  });
+
+  it("should add the eslint toolchain when eslint is chosen", () => {
+    const pkg = patchPackageJson(template, {
+      ...baseOptions,
+      linter: "eslint",
+    });
+
+    expect(pkg.devDependencies).toMatchObject({
+      eslint: "^10.8.0",
+      "typescript-eslint": "^8.65.0",
+      prettier: "^3.9.6",
+      "eslint-config-prettier": "^10.1.8",
+    });
+    expect(pkg.scripts).toMatchObject({
+      lint: "eslint .",
+      "lint:fix": "eslint . --fix",
+      format: "prettier --write .",
+      "format:check": "prettier --check .",
+    });
+  });
+
+  it("should keep the two toolchains apart", () => {
+    const oxlintPkg = patchPackageJson(template, {
+      ...baseOptions,
+      linter: "oxlint",
+    });
+    const eslintPkg = patchPackageJson(template, {
+      ...baseOptions,
+      linter: "eslint",
+    });
+
+    expect(oxlintPkg.devDependencies).not.toHaveProperty("eslint");
+    expect(eslintPkg.devDependencies).not.toHaveProperty("oxlint");
+  });
+
+  it("should add no scripts and no devDependencies for the none choice", () => {
+    const pkg = patchPackageJson(template, baseOptions);
+
+    expect(pkg.scripts).not.toHaveProperty("lint");
+    expect(pkg.devDependencies).not.toHaveProperty("oxlint");
+    expect(pkg.devDependencies).not.toHaveProperty("prettier");
   });
 
   it("should preserve the template key order", () => {

--- a/packages/cli/src/__test__/templates.test.ts
+++ b/packages/cli/src/__test__/templates.test.ts
@@ -13,16 +13,37 @@ const GITIGNORE = [
 
 const TSCONFIG = `{
   "compilerOptions": {
-    "lib": [
-      "esnext"
-    ],
-    "types": [
-      "google-apps-script"
-    ]
+    "lib": ["esnext"],
+    "types": ["google-apps-script"]
   },
-  "include": [
-    "./src"
-  ]
+  "include": ["./src"]
+}
+`;
+
+const OXLINTRC = `{
+  "plugins": ["typescript"],
+  "categories": { "correctness": "error" },
+  "ignorePatterns": ["dist/**", "src/generated/**"]
+}
+`;
+
+const ESLINT_CONFIG = `import { defineConfig, globalIgnores } from "eslint/config";
+import prettier from "eslint-config-prettier/flat";
+import tseslint from "typescript-eslint";
+
+export default defineConfig([
+  globalIgnores(["dist/**", "src/generated/**"]),
+  {
+    files: ["**/*.ts"],
+    extends: [tseslint.configs.recommended, prettier],
+  },
+]);
+`;
+
+const PRETTIERRC = `{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all"
 }
 `;
 
@@ -124,6 +145,18 @@ describe("bundled templates", () => {
 
   it("should ship tsconfig.json.template byte for byte", () => {
     expect(readTemplate("tsconfig.json.template")).toBe(TSCONFIG);
+  });
+
+  it("should ship .oxlintrc.json.template byte for byte", () => {
+    expect(readTemplate(".oxlintrc.json.template")).toBe(OXLINTRC);
+  });
+
+  it("should ship eslint.config.mjs.template byte for byte", () => {
+    expect(readTemplate("eslint.config.mjs.template")).toBe(ESLINT_CONFIG);
+  });
+
+  it("should ship .prettierrc.template byte for byte", () => {
+    expect(readTemplate(".prettierrc.template")).toBe(PRETTIERRC);
   });
 
   it("should ship package.json.template byte for byte", () => {

--- a/packages/cli/src/bootstrap/env/loadBootstrapTemplates.ts
+++ b/packages/cli/src/bootstrap/env/loadBootstrapTemplates.ts
@@ -6,6 +6,9 @@ type BootstrapTemplates = {
   agentsMd: string;
   tsconfig: string;
   packageJson: string;
+  oxlintrc: string;
+  eslintConfig: string;
+  prettierrc: string;
   esbuild: Record<FunctionStyle, string>;
   sampleIndex: Record<FunctionStyle, string>;
 };
@@ -17,6 +20,9 @@ const loadBootstrapTemplates = (
   agentsMd: readTemplate("AGENTS.md.template", startDir),
   tsconfig: readTemplate("tsconfig.json.template", startDir),
   packageJson: readTemplate("package.json.template", startDir),
+  oxlintrc: readTemplate(".oxlintrc.json.template", startDir),
+  eslintConfig: readTemplate("eslint.config.mjs.template", startDir),
+  prettierrc: readTemplate(".prettierrc.template", startDir),
   esbuild: {
     export: readTemplate("esbuild.export.mjs.template", startDir),
     global: readTemplate("esbuild.global.mjs.template", startDir),

--- a/packages/cli/src/bootstrap/flow/buildSteps.ts
+++ b/packages/cli/src/bootstrap/flow/buildSteps.ts
@@ -1,6 +1,7 @@
 import type { BootstrapStep } from "./context";
 import {
   installPromptStep,
+  linterStep,
   sampleStep,
   sheetsStep,
   styleStep,
@@ -15,7 +16,7 @@ import {
   sampleIndexStep,
 } from "./steps/writeSteps";
 
-// Future questions (e.g. linter selection) are added by inserting a step here.
+// Future questions are added by inserting a step here.
 const buildBootstrapSteps = (): BootstrapStep[] => [
   directoryStep,
   titleStep,
@@ -23,6 +24,7 @@ const buildBootstrapSteps = (): BootstrapStep[] => [
   claspCreateStep,
   manifestStep,
   styleStep,
+  linterStep,
   sampleStep,
   installPromptStep,
   projectFilesStep,

--- a/packages/cli/src/bootstrap/flow/context.ts
+++ b/packages/cli/src/bootstrap/flow/context.ts
@@ -6,6 +6,7 @@ import type { FileStore } from "../env/fileStore";
 import type { BootstrapTemplates } from "../env/loadBootstrapTemplates";
 import type { DirectoryOps } from "../env/targetDirectory";
 import type { FunctionStyle } from "../functionStyle";
+import type { LinterChoice } from "../linterChoice";
 import type { Prompter } from "./prompts";
 
 type BootstrapContext = {
@@ -13,6 +14,7 @@ type BootstrapContext = {
   title: string;
   withSheets: boolean;
   style: FunctionStyle;
+  linter: LinterChoice;
   wantSample: boolean;
   wantInstall: boolean;
   packageManager: PackageManager;
@@ -57,6 +59,7 @@ const createInitialContext = (
   title: path.basename(options.cwd) || "gassma-project",
   withSheets: true,
   style: "export",
+  linter: "oxlint",
   wantSample: true,
   wantInstall: true,
   packageManager: options.packageManager,

--- a/packages/cli/src/bootstrap/flow/steps/askSteps.ts
+++ b/packages/cli/src/bootstrap/flow/steps/askSteps.ts
@@ -52,6 +52,22 @@ const styleStep: BootstrapStep = {
   },
 };
 
+const linterStep: BootstrapStep = {
+  id: "linter",
+  run: async (context, deps) => {
+    const linter = await deps.prompter.select(
+      "Linter and formatter setup?",
+      [
+        { value: "oxlint", label: "oxlint + oxfmt", hint: "recommended" },
+        { value: "eslint", label: "eslint + prettier" },
+        { value: "none", label: "none" },
+      ],
+      "oxlint",
+    );
+    return { ...context, linter };
+  },
+};
+
 const sampleStep: BootstrapStep = {
   id: "sample",
   run: async (context, deps) => ({
@@ -76,4 +92,11 @@ const installPromptStep: BootstrapStep = {
   },
 };
 
-export { installPromptStep, sampleStep, sheetsStep, styleStep, titleStep };
+export {
+  installPromptStep,
+  linterStep,
+  sampleStep,
+  sheetsStep,
+  styleStep,
+  titleStep,
+};

--- a/packages/cli/src/bootstrap/flow/steps/writeSteps.ts
+++ b/packages/cli/src/bootstrap/flow/steps/writeSteps.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { linterConfigFiles } from "../../generators/linterSetup";
 import { mergeGitignore } from "../../generators/mergeGitignore";
 import { mergePackageJson } from "../../generators/mergePackageJson";
 import {
@@ -19,6 +20,7 @@ const writePackageJson = (context: BootstrapContext, deps: BootstrapDeps) => {
     name: sanitizePackageName(path.basename(context.cwd)),
     gassmaVersion: deps.gassmaVersion,
     style: context.style,
+    linter: context.linter,
   });
 
   if (!deps.store.exists(packageJsonPath)) {
@@ -68,6 +70,17 @@ const writeGitignore = (context: BootstrapContext, deps: BootstrapDeps) => {
   deps.prompter.info("Added missing entries to .gitignore");
 };
 
+const writeLinterConfigs = (context: BootstrapContext, deps: BootstrapDeps) => {
+  linterConfigFiles(context.linter, deps.templates).forEach((file) => {
+    writeIfMissing(
+      deps,
+      path.join(context.cwd, file.fileName),
+      file.content,
+      file.fileName,
+    );
+  });
+};
+
 const projectFilesStep: BootstrapStep = {
   id: "projectFiles",
   run: (context, deps) => {
@@ -91,6 +104,7 @@ const projectFilesStep: BootstrapStep = {
       deps.templates.agentsMd,
       "AGENTS.md",
     );
+    writeLinterConfigs(context, deps);
     return Promise.resolve(context);
   },
 };

--- a/packages/cli/src/bootstrap/generators/linterSetup.ts
+++ b/packages/cli/src/bootstrap/generators/linterSetup.ts
@@ -1,0 +1,50 @@
+import type { BootstrapTemplates } from "../env/loadBootstrapTemplates";
+import type { LinterChoice } from "../linterChoice";
+
+type LinterConfigFile = { fileName: string; content: string };
+
+const LINTER_DEV_DEPENDENCIES: Record<LinterChoice, Record<string, string>> = {
+  oxlint: { oxlint: "^1.76.0", oxfmt: "^0.61.0" },
+  eslint: {
+    eslint: "^10.8.0",
+    "eslint-config-prettier": "^10.1.8",
+    prettier: "^3.9.6",
+    "typescript-eslint": "^8.65.0",
+  },
+  none: {},
+};
+
+const LINTER_SCRIPTS: Record<LinterChoice, Record<string, string>> = {
+  oxlint: {
+    lint: "oxlint",
+    "lint:fix": "oxlint --fix",
+    format: "oxfmt",
+    "format:check": "oxfmt --check",
+  },
+  eslint: {
+    lint: "eslint .",
+    "lint:fix": "eslint . --fix",
+    format: "prettier --write .",
+    "format:check": "prettier --check .",
+  },
+  none: {},
+};
+
+const linterConfigFiles = (
+  linter: LinterChoice,
+  templates: BootstrapTemplates,
+): LinterConfigFile[] => {
+  if (linter === "oxlint") {
+    return [{ fileName: ".oxlintrc.json", content: templates.oxlintrc }];
+  }
+  if (linter === "eslint") {
+    return [
+      { fileName: "eslint.config.mjs", content: templates.eslintConfig },
+      { fileName: ".prettierrc", content: templates.prettierrc },
+    ];
+  }
+  return [];
+};
+
+export { LINTER_DEV_DEPENDENCIES, LINTER_SCRIPTS, linterConfigFiles };
+export type { LinterConfigFile };

--- a/packages/cli/src/bootstrap/generators/patchPackageJson.ts
+++ b/packages/cli/src/bootstrap/generators/patchPackageJson.ts
@@ -1,10 +1,13 @@
 import type { FunctionStyle } from "../functionStyle";
+import type { LinterChoice } from "../linterChoice";
 import { isRecord } from "../util/isRecord";
+import { LINTER_DEV_DEPENDENCIES, LINTER_SCRIPTS } from "./linterSetup";
 
 type PatchPackageJsonOptions = {
   name: string;
   gassmaVersion: string;
   style: FunctionStyle;
+  linter: LinterChoice;
 };
 
 const STYLE_PLUGINS: Record<FunctionStyle, string> = {
@@ -27,6 +30,19 @@ const pickDevDependencies = (
   return picked;
 };
 
+// npm tooling (oxfmt) expects package.json dependency blocks to be sorted.
+const sortByName = (
+  record: Record<string, unknown>,
+): Record<string, unknown> => {
+  const sorted: Record<string, unknown> = {};
+  Object.keys(record)
+    .sort()
+    .forEach((key) => {
+      sorted[key] = record[key];
+    });
+  return sorted;
+};
+
 const patchPackageJson = (
   template: string,
   options: PatchPackageJsonOptions,
@@ -39,11 +55,18 @@ const patchPackageJson = (
   return {
     ...parsed,
     name: options.name,
+    scripts: {
+      ...(isRecord(parsed.scripts) ? parsed.scripts : {}),
+      ...LINTER_SCRIPTS[options.linter],
+    },
     dependencies: {
       ...(isRecord(parsed.dependencies) ? parsed.dependencies : {}),
       gassma: `^${options.gassmaVersion}`,
     },
-    devDependencies: pickDevDependencies(parsed.devDependencies, options.style),
+    devDependencies: sortByName({
+      ...pickDevDependencies(parsed.devDependencies, options.style),
+      ...LINTER_DEV_DEPENDENCIES[options.linter],
+    }),
   };
 };
 

--- a/packages/cli/src/bootstrap/linterChoice.ts
+++ b/packages/cli/src/bootstrap/linterChoice.ts
@@ -1,0 +1,3 @@
+type LinterChoice = "oxlint" | "eslint" | "none";
+
+export type { LinterChoice };

--- a/packages/cli/templates/.oxlintrc.json.template
+++ b/packages/cli/templates/.oxlintrc.json.template
@@ -1,0 +1,5 @@
+{
+  "plugins": ["typescript"],
+  "categories": { "correctness": "error" },
+  "ignorePatterns": ["dist/**", "src/generated/**"]
+}

--- a/packages/cli/templates/.prettierrc.template
+++ b/packages/cli/templates/.prettierrc.template
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all"
+}

--- a/packages/cli/templates/AGENTS.md.template
+++ b/packages/cli/templates/AGENTS.md.template
@@ -7,6 +7,7 @@ A local development environment for Google Apps Script, powered by Clasp and GAS
 - `npx gassma generate` — generates the types and the client from gassma/schema.prisma
 - `npm run build` — bundles src/ into dist/ with esbuild
 - `npm run deploy` — build + clasp push (deploys to GAS)
+- `npm run lint` / `npm run format` — available if you chose a linter setup during bootstrap
 
 ## Development flow
 

--- a/packages/cli/templates/eslint.config.mjs.template
+++ b/packages/cli/templates/eslint.config.mjs.template
@@ -1,0 +1,11 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import prettier from "eslint-config-prettier/flat";
+import tseslint from "typescript-eslint";
+
+export default defineConfig([
+  globalIgnores(["dist/**", "src/generated/**"]),
+  {
+    files: ["**/*.ts"],
+    extends: [tseslint.configs.recommended, prettier],
+  },
+]);

--- a/packages/cli/templates/tsconfig.json.template
+++ b/packages/cli/templates/tsconfig.json.template
@@ -1,13 +1,7 @@
 {
   "compilerOptions": {
-    "lib": [
-      "esnext"
-    ],
-    "types": [
-      "google-apps-script"
-    ]
+    "lib": ["esnext"],
+    "types": ["google-apps-script"]
   },
-  "include": [
-    "./src"
-  ]
+  "include": ["./src"]
 }


### PR DESCRIPTION
## 概要

`gassma bootstrap` に **リンター/フォーマッターの選択**を追加します(ユーザーと設計を詰めて確定済み)。

```
Linter and formatter setup?
  ❯ oxlint + oxfmt   (recommended)   ← 既定(--yes でもこれ)
    eslint + prettier
    none
```

質問位置は **exposure style と sample の間**(コードの書き方 → その整え方 → サンプル、の流れ)。

## 各選択肢

| 選択 | devDeps | 設定ファイル | scripts |
|---|---|---|---|
| ① oxlint + oxfmt | `oxlint` ^1.76.0 / `oxfmt` ^0.61.0 | `.oxlintrc.json`(plugins: **typescript のみ** / categories.correctness: error / ignorePatterns: `dist/**`・`src/generated/**`) | `oxlint` / `--fix` / `oxfmt` / `--check` |
| ② eslint + prettier | **4つのみ**(eslint / typescript-eslint / prettier / eslint-config-prettier) | `eslint.config.mjs`(flat config: defineConfig + globalIgnores + tseslint.recommended + prettier) + `.prettierrc` | `eslint .` 系 / `prettier` 系 |
| ③ none | — | — | — |

## 意図的に入れないもの(決定事項)

- **type-aware linting**(`oxlint-tsgolint`): 型エラーは `tsc --noEmit` が拾う・GAS は同期実行で当たりが薄い・tsgo バイナリで重い。**素の oxlint で optional peer 警告が出ないことを、生成プロジェクトの実 install で実証済み**
- **pre-commit フック**(husky/lint-staged): scaffold が git フックを仕込むのは越権(create-next-app 等の前例と一致)。そもそも bootstrap は `git init` していないため husky は壊れる
- oxfmt の設定ファイル(既定で十分)、import/unicorn プラグイン(GAS で的外れなルールが多い)

## 実装

- `linterStep`(宣言的 BootstrapStep)+ `linterSetup.ts`(選択肢ごとの devDeps/scripts/設定ファイルを1箇所に集約)
- 設定ファイルは既存 `writeIfMissing` 経路 = **冪等スキップ・dry-run 計画化は自動適用**、テンプレートは verbatim コピー原則を維持
- scripts/devDeps は既存の package.json パッチ機構を拡張(**devDependencies のソートを追加** — `oxfmt --check` が要求するため)
- AGENTS.md は**選択非依存の1行のみ**追加(無置換コピーを維持)

## 実機検証(clasp シム + 一時ディレクトリ)

**3選択肢すべてを実際に生成**し、①②は `npm i && npm run lint && npm run format:check` が**クリーンに通ること**を確認(かつ違反ファイルを置くと正しく検出=空振りでないことも実証)。③はリンタ関連ファイル0。`--dry-run` は計画表示のみで書き込みゼロ。

途中で判明した2点(修正済み): oxfmt が `tsconfig.json` の配列整形と `package.json` の devDeps ソートを要求 → テンプレート整形とパッチ側ソートで対応。

## テスト

1237 → **1261**、Red 実測(13 fail)→ Green、flow 変更を stash した逆検証で7件 fail 再現。`npm pack --dry-run` に新テンプレート3本が載ることを確認。全ゲート green。

## マージ後(別 PR)

reference の bootstrap ページ(ja/en)に質問・選択別生成物・scripts・非対応事項(type-aware / フック)を追記します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtxX