### PR TITLE
fix: reject @relation on a column marked @ignore

### DIFF
--- a/packages/cli/src/__test__/generate/read/ignoredRelationColumns.test.ts
+++ b/packages/cli/src/__test__/generate/read/ignoredRelationColumns.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+import { IgnoredRelationColumnError } from "../../../error/mainError";
+import { extractRelations } from "../../../generate/read/extractRelations";
+
+describe("extractRelations with @ignore columns", () => {
+  it("should reject a relation whose fields column has @ignore", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  authorId Int  @ignore
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(IgnoredRelationColumnError);
+    expect(() => extractRelations(schema)).toThrow(/Post\.author/);
+    expect(() => extractRelations(schema)).toThrow(/"authorId"/);
+    expect(() => extractRelations(schema)).toThrow(/@ignore/);
+    expect(() => extractRelations(schema)).toThrow(/onDelete/);
+    expect(() => extractRelations(schema)).toThrow(/[Rr]emove/);
+  });
+
+  it("should reject a relation whose references column has @ignore", () => {
+    const schema = `
+model User {
+  id    Int    @id @ignore
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(IgnoredRelationColumnError);
+    expect(() => extractRelations(schema)).toThrow(/"id"/);
+    expect(() => extractRelations(schema)).toThrow(/"User"/);
+  });
+
+  it("should reject the FK column of a one-to-one relation", () => {
+    const schema = `
+model User {
+  id      Int      @id
+  profile Profile?
+}
+
+model Profile {
+  id     Int  @id
+  user   User @relation(fields: [userId], references: [id])
+  userId Int  @unique @ignore
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(IgnoredRelationColumnError);
+    expect(() => extractRelations(schema)).toThrow(/Profile\.user/);
+    expect(() => extractRelations(schema)).toThrow(/"userId"/);
+  });
+
+  it("should reject a self relation running on an @ignore column", () => {
+    const schema = `
+model Category {
+  id       Int        @id
+  parentId Int?       @ignore
+  parent   Category?  @relation("Tree", fields: [parentId], references: [id])
+  children Category[] @relation("Tree")
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(IgnoredRelationColumnError);
+    expect(() => extractRelations(schema)).toThrow(/"parentId"/);
+  });
+
+  it("should reject an implicit manyToMany whose id column has @ignore", () => {
+    const schema = `
+model Post {
+  id   Int   @id @ignore
+  tags Tag[]
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[]
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(IgnoredRelationColumnError);
+    expect(() => extractRelations(schema)).toThrow(/"Post"/);
+    expect(() => extractRelations(schema)).toThrow(/"id"/);
+  });
+
+  it("should list every violating column in one error", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  posts Post[]
+  likes Like[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int  @ignore
+}
+
+model Like {
+  id      Int  @id
+  user    User @relation(fields: [userId], references: [id])
+  userId  Int  @ignore
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(/authorId/);
+    expect(() => extractRelations(schema)).toThrow(/userId/);
+
+    try {
+      extractRelations(schema);
+      expect.unreachable();
+    } catch (e) {
+      if (!(e instanceof IgnoredRelationColumnError)) throw e;
+      expect(e.details).toHaveLength(2);
+    }
+  });
+
+  it("should report a column shared by both relation sides only once", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int  @ignore
+}
+`;
+    try {
+      extractRelations(schema);
+      expect.unreachable();
+    } catch (e) {
+      if (!(e instanceof IgnoredRelationColumnError)) throw e;
+      expect(e.details).toHaveLength(1);
+    }
+  });
+
+  it("should accept @ignore on a column no relation uses", () => {
+    const schema = `
+model User {
+  id     Int    @id
+  secret String @ignore
+  posts  Post[]
+}
+
+model Post {
+  id       Int    @id
+  draft    String @ignore
+  author   User   @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  authorId Int
+}
+`;
+    expect(() => extractRelations(schema)).not.toThrow();
+  });
+
+  it("should accept a schema with relations and no @ignore at all", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int
+}
+`;
+    expect(() => extractRelations(schema)).not.toThrow();
+  });
+
+  it("should accept @ignore on the relation field itself", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id]) @ignore
+  authorId Int
+}
+`;
+    expect(() => extractRelations(schema)).not.toThrow();
+  });
+
+  it("should accept an implicit manyToMany when only a non-id column has @ignore", () => {
+    const schema = `
+model Post {
+  id    Int    @id
+  draft String @ignore
+  tags  Tag[]
+}
+
+model Tag {
+  id    Int    @id
+  memo  String @ignore
+  posts Post[]
+}
+`;
+    expect(() => extractRelations(schema)).not.toThrow();
+  });
+
+  it("should accept an explicit junction model with clean FK columns", () => {
+    const schema = `
+model Post {
+  id       Int       @id
+  postTags PostTag[]
+}
+
+model Tag {
+  id       Int       @id
+  postTags PostTag[]
+}
+
+model PostTag {
+  postId Int
+  tagId  Int
+  note   String @ignore
+  post   Post @relation(fields: [postId], references: [id])
+  tag    Tag  @relation(fields: [tagId], references: [id])
+
+  @@id([postId, tagId])
+}
+`;
+    expect(() => extractRelations(schema)).not.toThrow();
+  });
+
+  it("should reject an explicit junction model whose FK column has @ignore", () => {
+    const schema = `
+model Post {
+  id       Int       @id
+  postTags PostTag[]
+}
+
+model Tag {
+  id       Int       @id
+  postTags PostTag[]
+}
+
+model PostTag {
+  postId Int @ignore
+  tagId  Int
+  post   Post @relation(fields: [postId], references: [id])
+  tag    Tag  @relation(fields: [tagId], references: [id])
+
+  @@id([postId, tagId])
+}
+`;
+    expect(() => extractRelations(schema)).toThrow(IgnoredRelationColumnError);
+    expect(() => extractRelations(schema)).toThrow(/PostTag\.post/);
+    expect(() => extractRelations(schema)).toThrow(/"postId"/);
+  });
+});

--- a/packages/cli/src/__test__/validate/ignoredRelationColumns.test.ts
+++ b/packages/cli/src/__test__/validate/ignoredRelationColumns.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { validateSchema } from "../../validate/validate";
+
+describe("validateSchema with @ignore relation columns", () => {
+  it("should report ignoredRelationColumn for an @ignore FK column", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  authorId Int  @ignore
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ type: "ignoredRelationColumn" }),
+    );
+    const messages = result.errors.map((error) => error.message).join("\n");
+    expect(messages).toContain("authorId");
+    expect(messages).toContain("Post");
+    expect(messages).toContain("@ignore");
+  });
+
+  it("should report one error per violating column", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id    Int    @id
+  posts Post[]
+  likes Like[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int  @ignore
+}
+
+model Like {
+  id     Int  @id
+  user   User @relation(fields: [userId], references: [id])
+  userId Int  @ignore
+}
+`;
+    const result = validateSchema(schema);
+
+    const relationErrors = result.errors.filter(
+      (error) => error.type === "ignoredRelationColumn",
+    );
+    expect(relationErrors).toHaveLength(2);
+  });
+
+  it("should stay valid when @ignore is on a column no relation uses", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model User {
+  id     Int    @id
+  secret String @ignore
+  posts  Post[]
+}
+
+model Post {
+  id       Int  @id
+  author   User @relation(fields: [authorId], references: [id])
+  authorId Int
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("should keep through sheet conflicts out of validate results", () => {
+    const schema = `
+generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}
+
+model Post {
+  id   Int   @id
+  tags Tag[] @relation("Links")
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[] @relation("Links")
+}
+
+model User {
+  id     Int     @id
+  groups Group[] @relation("Links")
+}
+
+model Group {
+  id    Int    @id
+  users User[] @relation("Links")
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/packages/cli/src/error/mainError.ts
+++ b/packages/cli/src/error/mainError.ts
@@ -58,6 +58,18 @@ class MigrateOutputDirError extends Error {
   }
 }
 
+class IgnoredRelationColumnError extends Error {
+  readonly details: string[];
+
+  constructor(details: string[]) {
+    super(
+      "GASsmaIgnoredRelationColumnError: @relation uses a column marked @ignore.\n" +
+        details.map((detail) => `  - ${detail}`).join("\n"),
+    );
+    this.details = details;
+  }
+}
+
 class ThroughSheetConflictError extends Error {
   constructor(sheetName: string, firstPair: string, secondPair: string) {
     super(
@@ -76,5 +88,6 @@ export {
   GassmaConfigEnvError,
   GassmaConfigLoadError,
   MigrateOutputDirError,
+  IgnoredRelationColumnError,
   ThroughSheetConflictError,
 };

--- a/packages/cli/src/generate/read/assertNoIgnoredRelationColumns.ts
+++ b/packages/cli/src/generate/read/assertNoIgnoredRelationColumns.ts
@@ -1,0 +1,53 @@
+import { IgnoredRelationColumnError } from "../../error/mainError";
+import type { IgnoreConfig } from "./extractIgnore";
+import type { RelationsConfig } from "./extractRelations";
+
+type IgnoredRelationColumn = {
+  model: string;
+  column: string;
+  relation: string;
+};
+
+const describeViolation = (violation: IgnoredRelationColumn): string =>
+  `The relation "${violation.relation}" runs on the column "${violation.column}" of model "${violation.model}", which is marked @ignore. ` +
+  "GASsma drops @ignore columns from query conditions, so relation actions (onDelete / onUpdate) and nested writes lose the filter " +
+  "that narrows target rows and can rewrite or delete every row of the related sheet. " +
+  `Remove @ignore from "${violation.model}.${violation.column}", or remove the relation from the schema.`;
+
+const collectViolations = (
+  relations: RelationsConfig,
+  ignore: IgnoreConfig,
+): IgnoredRelationColumn[] => {
+  const violations: IgnoredRelationColumn[] = [];
+  const seen = new Set<string>();
+
+  const record = (model: string, column: string, relation: string): void => {
+    if (!ignore[model]?.includes(column)) return;
+    const key = `${model}.${column}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    violations.push({ model, column, relation });
+  };
+
+  Object.keys(relations).forEach((modelName) => {
+    Object.keys(relations[modelName]).forEach((relationName) => {
+      const definition = relations[modelName][relationName];
+      const relation = `${modelName}.${relationName}`;
+      record(modelName, definition.field, relation);
+      record(definition.to, definition.reference, relation);
+    });
+  });
+
+  return violations;
+};
+
+const assertNoIgnoredRelationColumns = (
+  relations: RelationsConfig,
+  ignore: IgnoreConfig,
+): void => {
+  const violations = collectViolations(relations, ignore);
+  if (violations.length === 0) return;
+  throw new IgnoredRelationColumnError(violations.map(describeViolation));
+};
+
+export { assertNoIgnoredRelationColumns };

--- a/packages/cli/src/generate/read/extractRelations.ts
+++ b/packages/cli/src/generate/read/extractRelations.ts
@@ -3,8 +3,10 @@ import {
   findFirstAttribute,
 } from "@loancrate/prisma-schema-parser";
 import type { ModelDeclaration } from "@loancrate/prisma-schema-parser";
+import { assertNoIgnoredRelationColumns } from "./assertNoIgnoredRelationColumns";
 import { assertUniqueThroughSheets } from "./assertUniqueThroughSheets";
 import { detectImplicitManyToMany } from "./detectImplicitManyToMany";
+import { extractIgnore } from "./extractIgnore";
 import {
   getRelationName,
   getFieldReferences,
@@ -126,6 +128,7 @@ const extractRelations = (schemaText: string): RelationsConfig => {
 
   detectImplicitManyToMany(models, result);
   assertUniqueThroughSheets(result);
+  assertNoIgnoredRelationColumns(result, extractIgnore(schemaText));
 
   return result;
 };

--- a/packages/cli/src/validate/validate.ts
+++ b/packages/cli/src/validate/validate.ts
@@ -1,14 +1,37 @@
 import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import { IgnoredRelationColumnError } from "../error/mainError";
 import { countModelsInAst } from "../generate/read/countModels";
+import { extractRelations } from "../generate/read/extractRelations";
 
 type ValidationError = {
-  type: "syntax" | "missingGenerator" | "missingOutput" | "noModels";
+  type:
+    | "syntax"
+    | "missingGenerator"
+    | "missingOutput"
+    | "noModels"
+    | "ignoredRelationColumn";
   message: string;
 };
 
 type ValidationResult = {
   valid: boolean;
   errors: ValidationError[];
+};
+
+const collectIgnoredRelationColumnErrors = (
+  schemaText: string,
+): ValidationError[] => {
+  try {
+    extractRelations(schemaText);
+  } catch (e) {
+    if (e instanceof IgnoredRelationColumnError) {
+      return e.details.map((message) => ({
+        type: "ignoredRelationColumn",
+        message,
+      }));
+    }
+  }
+  return [];
 };
 
 const validateSchema = (schemaText: string): ValidationResult => {
@@ -50,6 +73,8 @@ const validateSchema = (schemaText: string): ValidationResult => {
           "You don't have any models defined in your schema, so nothing will be generated. At least one model is required.",
       });
     }
+
+    errors.push(...collectIgnoredRelationColumnErrors(schemaText));
   } catch (e) {
     errors.push({
       type: "syntax",


### PR DESCRIPTION
## 直す問題

GASsma 本体では、`@ignore` の付いた列を `@relation` に使うと、**エラーも警告も出ずに子シートの全行が壊れます。**

本体が `where` から無視列を落とすため、リレーションの追従処理で**絞り込み条件が消えて `{}` = 全行一致**になります。Cascade なら全行削除、SetNull なら全行 null、nested write なら全行書き換えです。

**本体側でも起動時に弾く対応を入れています(gassma#177)。** この PR は**開発時点で気づけるように、生成のタイミングで弾く**ものです。

## Prisma はどうしているか(実測)

`npx prisma validate` は**通ります**が、生成される API から**列もリレーションも消えます**。

```ts
export type PostInclude = {}   // include できるものが何もない
export type PostCreateInput = { title: string; updatedAt?: Date | string }
```

`include: { author: true }` は型が `never`。**FK が使えないならリレーションも使わせない**という設計で、整合性は DB の外部キー制約が守ります。

**gassma にはリレーションを消す仕組みも制約もない**ため、拒否します。

## やること

`generate` と `validate` の両方でエラーにします。

```
❌ Validation failed:
  - The relation "Post.author" runs on the column "authorId" of model "Post",
    which is marked @ignore. GASsma drops @ignore columns from query conditions,
    so relation actions (onDelete / onUpdate) and nested writes lose the filter
    that narrows target rows and can rewrite or delete every row of the related
    sheet. Remove @ignore from "Post.authorId", or remove the relation from the
    schema.
```

チェックは `extractRelations` の中(既存の `assertUniqueThroughSheets` と同じ場所)に置いています。**呼び出す経路すべてが自動的に守られる**ためです。

## 弾く / 弾かない

**弾く**
- `@relation(fields: [...])` の列に `@ignore`
- `references: [...]` が指す**相手モデル側**の列に `@ignore`
- 暗黙 manyToMany の両モデルの `id` に `@ignore`
- 明示中間モデルの FK 列

**弾かない(安全側)**
- **リレーションと無関係な列の `@ignore`** ← 誤検知しないことをテストで固定
- **リレーションフィールド自体への `@ignore`**(`author User @relation(...) @ignore`)。Prisma でリレーションを除外する正規の手段なので通します
- 複合 FK の2列目以降(`extractRelations` が `fields[0]` しか設定に載せず、実行時に到達しないため)

## 注意点

- **`migrate` も同じスキーマを弾くようになります。** `buildMigrateModels` が `extractRelations` を呼ぶためです。危険なスキーマは `generate` でも必ず落ちるので、一貫した挙動と判断しました
- **`validate` は `ThroughSheetConflictError` を従来どおり握りつぶします。** `validate` はこれまで `extractRelations` を呼んでおらず through 競合を検出していなかったため、今回の追加で挙動が変わらないようにしました(テストで固定)。検出すべきなら別途対応します

## 検証

- テスト: **1278 passed**(既存 1261 は**1件も書き換えず**全通過、新規17件)
- 実 CLI で危険なスキーマが弾かれること、**`@ignore` があってもリレーションと無関係なら通ること**を確認済み
- typecheck / build(tsdown) 通過、変更ファイルの biome 指摘ゼロ
- TDD: 拒否系テストが実装前に8件失敗することを確認してから実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)