### PR TITLE
feat: add --accept-data-loss flag to migrate command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -156,6 +156,7 @@ Generate a GAS function that syncs spreadsheet sheets with your schema. It write
 |`--output <dir>`|Directory to write gassma-migration.js (defaults to rootDir in .clasp.json)|
 |`--schema <path>`|Path to a specific .prisma file to migrate from|
 |`--config <path>`|Custom path to your GASsma config file|
+|`--accept-data-loss`|Delete sheets and columns that are not in the schema|
 
 ### bootstrap
 

--- a/packages/cli/docs/README.ja.md
+++ b/packages/cli/docs/README.ja.md
@@ -156,6 +156,7 @@ function myFunction() {
 |`--output <dir>`|gassma-migration.js の出力先ディレクトリ（デフォルトは .clasp.json の rootDir）|
 |`--schema <path>`|マイグレーション対象の `.prisma` ファイルのパス|
 |`--config <path>`|GASsma config ファイルのカスタムパス|
+|`--accept-data-loss`|スキーマに無いシート・列を削除|
 
 ### bootstrap
 

--- a/packages/cli/src/__test__/command/migrateFlag.test.ts
+++ b/packages/cli/src/__test__/command/migrateFlag.test.ts
@@ -66,4 +66,35 @@ describe("gassma migrate (e2e)", () => {
       expect(migrations[0]).toMatch(/^\d{14}_init$/);
     },
   );
+
+  it(
+    "should include acceptDataLoss in the stub when --accept-data-loss is given",
+    { timeout: 120_000 },
+    () => {
+      fs.mkdirSync(path.join(tmpDir, "gassma"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "gassma", "schema.prisma"),
+        "model User {\n  id   Int    @id\n  name String\n}\n",
+      );
+
+      execFileSync(
+        process.execPath,
+        [
+          tsxCli,
+          commandTs,
+          "migrate",
+          "--output",
+          "./dist",
+          "--accept-data-loss",
+        ],
+        { cwd: tmpDir, stdio: "pipe" },
+      );
+
+      const stub = fs.readFileSync(
+        path.join(tmpDir, "dist", "gassma-migration.js"),
+        "utf-8",
+      );
+      expect(stub).toContain("acceptDataLoss: true,");
+    },
+  );
 });

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -73,6 +73,40 @@ describe("migrate", () => {
 `);
   });
 
+  it("should include acceptDataLoss between spreadsheetId and models when requested", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out", acceptDataLoss: true }, fixedDeps);
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toBe(`function gassmaMigrate() {
+  Gassma.migrateSheets({
+    spreadsheetId: "abc123",
+    acceptDataLoss: true,
+    models: [
+      { name: "User", columns: ["id", "name"] }
+    ]
+  });
+}
+`);
+  });
+
+  it("should include acceptDataLoss when no spreadsheetId is available", () => {
+    writeSchema(schemaWithoutDatasource);
+
+    migrate({ output: "./out", acceptDataLoss: true }, fixedDeps);
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toContain("acceptDataLoss: true,");
+    expect(content).not.toContain("spreadsheetId");
+  });
+
   it("should resolve the output directory from rootDir in .clasp.json", () => {
     writeSchema(schemaWithDatasource);
     fs.writeFileSync(".clasp.json", JSON.stringify({ rootDir: "./dist" }));
@@ -258,6 +292,35 @@ model User {
     );
   });
 
+  it("should record acceptDataLoss in the migration trail", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out", acceptDataLoss: true }, fixedDeps);
+
+    const trail = fs.readFileSync(
+      path.join("gassma", "migrations", "20260729040506", "migration.js"),
+      "utf-8",
+    );
+    expect(trail).toBe(
+      fs.readFileSync(path.join("out", "gassma-migration.js"), "utf-8"),
+    );
+    expect(trail).toContain("acceptDataLoss: true,");
+  });
+
+  it("should not record a second migration when run twice with acceptDataLoss", () => {
+    writeSchema(schemaWithDatasource);
+    migrate({ output: "./out", acceptDataLoss: true }, fixedDeps);
+
+    const laterDeps = {
+      now: () => new Date(Date.UTC(2026, 6, 30, 0, 0, 0)),
+    };
+    migrate({ output: "./out", acceptDataLoss: true }, laterDeps);
+
+    expect(fs.readdirSync(path.join("gassma", "migrations"))).toEqual([
+      "20260729040506",
+    ]);
+  });
+
   it("should name the migration directory with the timestamp only when --name is omitted", () => {
     writeSchema(schemaWithDatasource);
 
@@ -402,5 +465,33 @@ model Post {
       .join("\n");
     expect(logged).toContain("clasp push");
     expect(logged).toContain("gassmaMigrate");
+  });
+
+  it("should warn about deletions when acceptDataLoss is requested", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out", acceptDataLoss: true }, fixedDeps);
+
+    const logged = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).toContain(
+      "deletes sheets and columns that are not in the schema",
+    );
+  });
+
+  it("should not warn about deletions without acceptDataLoss", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const logged = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).not.toContain(
+      "deletes sheets and columns that are not in the schema",
+    );
   });
 });

--- a/packages/cli/src/__test__/migrate/patchMigrationScript.test.ts
+++ b/packages/cli/src/__test__/migrate/patchMigrationScript.test.ts
@@ -60,6 +60,49 @@ describe("patchMigrationScript", () => {
     expect(result).not.toContain("spreadsheetId");
   });
 
+  it("should include acceptDataLoss after spreadsheetId when true", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      definition: {
+        ...baseOptions.definition,
+        spreadsheetId: "abc123",
+        acceptDataLoss: true,
+      },
+    });
+    expect(result).toBe(`function gassmaMigrate() {
+  Gassma.migrateSheets({
+    spreadsheetId: "abc123",
+    acceptDataLoss: true,
+    models: [
+      { name: "User", columns: ["id", "name"] }
+    ]
+  });
+}
+`);
+  });
+
+  it("should include acceptDataLoss when spreadsheetId is absent", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      definition: { ...baseOptions.definition, acceptDataLoss: true },
+    });
+    expect(result).toContain("acceptDataLoss: true,");
+    expect(result).not.toContain("spreadsheetId");
+  });
+
+  it("should omit acceptDataLoss when not given", () => {
+    const result = patchMigrationScript(template, baseOptions);
+    expect(result).not.toContain("acceptDataLoss");
+  });
+
+  it("should omit acceptDataLoss when false", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      definition: { ...baseOptions.definition, acceptDataLoss: false },
+    });
+    expect(result).not.toContain("acceptDataLoss");
+  });
+
   it("should escape double quotes in sheet and column names", () => {
     const result = patchMigrationScript(template, {
       ...baseOptions,
@@ -80,6 +123,18 @@ describe("patchMigrationScript", () => {
           { name: "User", columns: ["id", "name"] },
           { name: "_PostToTag", columns: ["postId", "tagId"] },
         ],
+      },
+    });
+    expect(() => new Function(result)).not.toThrow();
+  });
+
+  it("should produce syntactically valid JavaScript with acceptDataLoss", () => {
+    const result = patchMigrationScript(template, {
+      ...baseOptions,
+      definition: {
+        spreadsheetId: "abc123",
+        acceptDataLoss: true,
+        models: [{ name: "User", columns: ["id", "name"] }],
       },
     });
     expect(() => new Function(result)).not.toThrow();

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -72,12 +72,17 @@ program
   )
   .option("--schema <path>", "Path to a specific .prisma file to migrate from")
   .option("--config <path>", "Custom path to your GASsma config file")
+  .option(
+    "--accept-data-loss",
+    "Delete sheets and columns that are not in the schema",
+  )
   .action((options) => {
     migrate({
       name: options.name,
       output: options.output,
       schema: options.schema,
       config: options.config,
+      acceptDataLoss: options.acceptDataLoss,
     });
   });
 

--- a/packages/cli/src/migrate/migrateCommand.ts
+++ b/packages/cli/src/migrate/migrateCommand.ts
@@ -26,6 +26,7 @@ type MigrateOptions = {
   output?: string;
   schema?: string;
   config?: string;
+  acceptDataLoss?: boolean;
 };
 
 type MigrateDeps = {
@@ -50,6 +51,7 @@ const buildDefinition = (
   schemaText: string,
   configUrl: string | undefined,
   schemaLocation: string,
+  acceptDataLoss: boolean,
 ): MigrateSheetsDefinition => {
   const models = buildMigrateModels(schemaText);
   if (models.length === 0) throw new NoModelsError(schemaLocation);
@@ -57,6 +59,7 @@ const buildDefinition = (
   const spreadsheetId = resolveSpreadsheetId(schemaText, configUrl);
   return {
     ...(spreadsheetId === undefined ? {} : { spreadsheetId }),
+    ...(acceptDataLoss ? { acceptDataLoss: true } : {}),
     models,
   };
 };
@@ -89,11 +92,19 @@ const recordMigration = (
   return true;
 };
 
-const printNextSteps = (stubPath: string, recorded: boolean): void => {
+const printNextSteps = (
+  stubPath: string,
+  recorded: boolean,
+  acceptDataLoss: boolean,
+): void => {
   const headline = recorded
     ? "✅ Migration generated"
     : `✅ Refreshed ${STUB_FILE_NAME} (no new migration recorded)`;
   console.log(`\n${headline}\n`);
+  if (acceptDataLoss)
+    console.log(
+      "⚠️ This migration deletes sheets and columns that are not in the schema.\n",
+    );
   console.log("Next steps:");
   console.log(`  1. Run "clasp push" (or "npm run push") to upload ${STUB_FILE_NAME}
   2. In the Apps Script editor, run the "gassmaMigrate" function once`);
@@ -117,10 +128,12 @@ function migrate(options?: MigrateOptions, deps: MigrateDeps = defaultDeps) {
   const schemaLocation = path.resolve(
     files.length === 1 ? files[0].filePath : baseDir,
   );
+  const acceptDataLoss = options?.acceptDataLoss === true;
   const definition = buildDefinition(
     schemaText,
     loaded?.config.datasource?.url,
     schemaLocation,
+    acceptDataLoss,
   );
 
   const outputDir = resolveOutputDir(options?.output, process.cwd());
@@ -132,7 +145,7 @@ function migrate(options?: MigrateOptions, deps: MigrateDeps = defaultDeps) {
 
   const stubPath = writeMigrationStub(outputDir, content);
   const recorded = recordMigration(baseDir, content, options?.name, deps);
-  printNextSteps(stubPath, recorded);
+  printNextSteps(stubPath, recorded, acceptDataLoss);
 }
 
 export { migrate };

--- a/packages/cli/src/migrate/patchMigrationScript.ts
+++ b/packages/cli/src/migrate/patchMigrationScript.ts
@@ -2,6 +2,7 @@ import type { MigrateModelDefinition } from "./buildMigrateModels";
 
 type MigrateSheetsDefinition = {
   spreadsheetId?: string;
+  acceptDataLoss?: boolean;
   models: MigrateModelDefinition[];
 };
 
@@ -22,6 +23,8 @@ const renderDefinition = (definition: MigrateSheetsDefinition): string => {
     definition.spreadsheetId === undefined
       ? []
       : [`    spreadsheetId: ${quote(definition.spreadsheetId)},`];
+  const acceptDataLossLines =
+    definition.acceptDataLoss === true ? ["    acceptDataLoss: true,"] : [];
   const lastIndex = definition.models.length - 1;
   const modelLines = definition.models.map(
     (model, index) =>
@@ -31,6 +34,7 @@ const renderDefinition = (definition: MigrateSheetsDefinition): string => {
   return [
     "{",
     ...spreadsheetIdLines,
+    ...acceptDataLossLines,
     "    models: [",
     ...modelLines,
     "    ]",


### PR DESCRIPTION
## 概要

`npx gassma migrate` に **`--accept-data-loss` フラグ**を追加します。gassma 本体 PR #178 で `migrateSheets` に入った削除機能を、CLI から使えるようにするものです。

schema から列やモデルを削除しても、これまではシート側に残り続けて**スキーマと実体が永久に乖離**していました。このフラグでその掃除ができます。

```
npx gassma migrate                      → 従来どおり(余分な列・シートは警告のみで残る)
npx gassma migrate --accept-data-loss   → 余分な列・シートを削除する定義を生成
```

生成される実行用スタブの差:

```js
// フラグなし(現状と1バイトも変わりません)
Gassma.migrateSheets({
  spreadsheetId: "...",
  models: [...]
});

// --accept-data-loss 付き
Gassma.migrateSheets({
  spreadsheetId: "...",
  acceptDataLoss: true,
  models: [...]
});
```

## 削除の実際の挙動(本体側)

GAS で `gassmaMigrate` を実行したとき、schema に無い列・シートが削除されます。**データが入っている場合は件数を警告してから**削除します(Prisma の文言に倣ったもの):

```
You are about to drop the column "memo" on the sheet "User", which still contains 2 non-empty values.
You are about to drop the sheet "Old", which still contains 2 rows.
```

## Next steps に警告を追加

フラグを付けたときだけ、生成後の案内に1行加わります:

```
✅ Migration generated
⚠️ This migration deletes sheets and columns that are not in the schema.
```

生成と実行の間に時間差があるため、**push して実行する時点で何が起きるか**が分かるようにしています。

## 後方互換

**フラグを付けない場合の生成物は現状と完全に同一**です。base(9072829)を別 worktree に展開してビルドし、**4パターンの schema で `cmp` によるバイト比較**を行って確認しました:

| パターン | 結果 |
|---|---|
| spreadsheetId あり + 単一モデル | BYTE-IDENTICAL |
| spreadsheetId なし + 3モデル(optional / DateTime / relation) | BYTE-IDENTICAL |
| `@map` + `@@map` | BYTE-IDENTICAL |
| 暗黙多対多(`_PostToTag` の中間シート生成) | BYTE-IDENTICAL |

## 証跡との関係

証跡(`migrations/<timestamp>/migration.js`)の中身は実行用スタブと同一、という既存の性質を維持しています。したがって:

- フラグ付きで実行 → 証跡にも `acceptDataLoss: true` が入る(**破壊的なマイグレーションを実行したという記録**として残る)
- 同じフラグで2回実行 → 内容が同じなので証跡は増えない(冪等性を維持)
- フラグの有無を切り替える → 定義が変わるので新しい証跡が1件作られる

## テスト

t-wada 流 TDD(Red を実測確認)。**全体1290件パス**、format / lint / typecheck / test:types / build すべて clean。

独立した検証エージェントによる敵対的レビューを実施し、以下を実測で確認しています:

- 生成物を `new Function` で実評価し、`acceptDataLoss` が**文字列 `"true"` ではなく真偽値 `true`** として渡ることを確認(本体は `=== true` の厳密比較で読むため、文字列だと無言で無効化される)
- 本体 `origin/main` の `MigrateSheetsOptions` と生成オブジェクトの形が一致することを型定義と突き合わせて確認
- 変異テスト4系統で Red を確認(常に出力する / 文字列に劣化させる / フラグを無視する / commander の配線を外す)。特に **commander の配線を外す変異は unit では捕まらず e2e が捕捉**しており、テストの層が適切に機能しています

## ドキュメント

`docs/README.ja.md` と `README.md` の migrate のオプション表に `--accept-data-loss` を追加しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja