### PR TITLE
fix: require matching relation name when pairing unnamed inverse fields

### DIFF
--- a/packages/cli/src/__test__/generate/read/extractRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractRelations.test.ts
@@ -852,4 +852,199 @@ model PostTag {
       reference: "id",
     });
   });
+
+  describe("inverse field pairing by relation name", () => {
+    const namedListFirstSchema = `
+model User {
+  id     Int    @id
+  pinned Post[] @relation("Pinned")
+  posts  Post[]
+}
+
+model Post {
+  id       Int    @id
+  authorId Int
+  author   User   @relation(fields: [authorId], references: [id])
+  pinnedBy User[] @relation("Pinned")
+}
+`;
+    const unnamedListFirstSchema = `
+model User {
+  id     Int    @id
+  posts  Post[]
+  pinned Post[] @relation("Pinned")
+}
+
+model Post {
+  id       Int    @id
+  authorId Int
+  author   User   @relation(fields: [authorId], references: [id])
+  pinnedBy User[] @relation("Pinned")
+}
+`;
+    const expectedMixedRelations = {
+      User: {
+        pinned: {
+          type: "manyToMany",
+          to: "Post",
+          field: "id",
+          reference: "id",
+          through: {
+            sheet: "_Pinned",
+            field: "userId",
+            reference: "postId",
+          },
+        },
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+      Post: {
+        author: {
+          type: "manyToOne",
+          to: "User",
+          field: "authorId",
+          reference: "id",
+        },
+        pinnedBy: {
+          type: "manyToMany",
+          to: "User",
+          field: "id",
+          reference: "id",
+          through: {
+            sheet: "_Pinned",
+            field: "postId",
+            reference: "userId",
+          },
+        },
+      },
+    };
+
+    it("should pair an unnamed FK with the unnamed list even when a named list is declared first", () => {
+      expect(extractRelations(namedListFirstSchema)).toEqual(
+        expectedMixedRelations,
+      );
+    });
+
+    it("should extract the same relations for both list declaration orders", () => {
+      expect(extractRelations(namedListFirstSchema)).toEqual(
+        extractRelations(unnamedListFirstSchema),
+      );
+    });
+
+    it("should not invent an unnamed through sheet when a named list is declared first", () => {
+      const result = extractRelations(namedListFirstSchema);
+
+      const throughSheets = Object.values(result)
+        .flatMap((relations) => Object.values(relations))
+        .map((definition) => definition.through?.sheet)
+        .filter((sheet) => sheet !== undefined);
+
+      expect([...new Set(throughSheets)]).toEqual(["_Pinned"]);
+    });
+
+    it("should keep unnamed oneToMany and unnamed implicit manyToMany pairs working", () => {
+      const schema = `
+model User {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id       Int    @id
+  authorId Int
+  author   User   @relation(fields: [authorId], references: [id])
+  tags     Tag[]
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[]
+}
+`;
+      const result = extractRelations(schema);
+
+      expect(result).toEqual({
+        User: {
+          posts: {
+            type: "oneToMany",
+            to: "Post",
+            field: "id",
+            reference: "authorId",
+          },
+        },
+        Post: {
+          author: {
+            type: "manyToOne",
+            to: "User",
+            field: "authorId",
+            reference: "id",
+          },
+          tags: {
+            type: "manyToMany",
+            to: "Tag",
+            field: "id",
+            reference: "id",
+            through: {
+              sheet: "_PostToTag",
+              field: "postId",
+              reference: "tagId",
+            },
+          },
+        },
+        Tag: {
+          posts: {
+            type: "manyToMany",
+            to: "Post",
+            field: "id",
+            reference: "id",
+            through: {
+              sheet: "_PostToTag",
+              field: "tagId",
+              reference: "postId",
+            },
+          },
+        },
+      });
+    });
+
+    it("should keep named oneToMany and named manyToMany pairs working", () => {
+      const schema = `
+model User {
+  id     Int    @id
+  pinned Post[] @relation("Pinned")
+  posts  Post[] @relation("Written")
+}
+
+model Post {
+  id       Int    @id
+  authorId Int
+  author   User   @relation("Written", fields: [authorId], references: [id])
+  pinnedBy User[] @relation("Pinned")
+}
+`;
+      expect(extractRelations(schema)).toEqual(expectedMixedRelations);
+    });
+
+    it("should pair the name argument form the same as the shorthand", () => {
+      const schema = `
+model User {
+  id     Int    @id
+  pinned Post[] @relation(name: "Pinned")
+  posts  Post[]
+}
+
+model Post {
+  id       Int    @id
+  authorId Int
+  author   User   @relation(fields: [authorId], references: [id])
+  pinnedBy User[] @relation(name: "Pinned")
+}
+`;
+      expect(extractRelations(schema)).toEqual(expectedMixedRelations);
+    });
+  });
 });

--- a/packages/cli/src/__test__/generate/read/extractRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractRelations.test.ts
@@ -1046,5 +1046,86 @@ model Post {
 `;
       expect(extractRelations(schema)).toEqual(expectedMixedRelations);
     });
+
+    const namedListFirstOneToOneSchema = `
+model User {
+  id     Int    @id
+  pinned Post[] @relation("Pinned")
+  post   Post?
+}
+
+model Post {
+  id       Int    @id
+  authorId Int    @unique
+  author   User   @relation(fields: [authorId], references: [id])
+  pinnedBy User[] @relation("Pinned")
+}
+`;
+    const unnamedFieldFirstOneToOneSchema = `
+model User {
+  id     Int    @id
+  post   Post?
+  pinned Post[] @relation("Pinned")
+}
+
+model Post {
+  id       Int    @id
+  authorId Int    @unique
+  author   User   @relation(fields: [authorId], references: [id])
+  pinnedBy User[] @relation("Pinned")
+}
+`;
+    const expectedMixedOneToOneRelations = {
+      User: {
+        pinned: {
+          type: "manyToMany",
+          to: "Post",
+          field: "id",
+          reference: "id",
+          through: {
+            sheet: "_Pinned",
+            field: "userId",
+            reference: "postId",
+          },
+        },
+        post: {
+          type: "oneToOne",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+      Post: {
+        author: {
+          type: "manyToOne",
+          to: "User",
+          field: "authorId",
+          reference: "id",
+        },
+        pinnedBy: {
+          type: "manyToMany",
+          to: "User",
+          field: "id",
+          reference: "id",
+          through: {
+            sheet: "_Pinned",
+            field: "postId",
+            reference: "userId",
+          },
+        },
+      },
+    };
+
+    it("should pair an unnamed 1:1 FK with the unnamed field even when a named list is declared first", () => {
+      expect(extractRelations(namedListFirstOneToOneSchema)).toEqual(
+        expectedMixedOneToOneRelations,
+      );
+    });
+
+    it("should extract the same relations for both 1:1 declaration orders", () => {
+      expect(extractRelations(namedListFirstOneToOneSchema)).toEqual(
+        extractRelations(unnamedFieldFirstOneToOneSchema),
+      );
+    });
   });
 });

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -276,6 +276,46 @@ model User {
     );
   });
 
+  it("should write only the named through sheet when a named list precedes an unnamed list", () => {
+    writeSchema(`
+datasource db {
+  provider = "gassma"
+  url      = "https://docs.google.com/spreadsheets/d/abc123/edit"
+}
+
+model User {
+  id     Int    @id
+  pinned Post[] @relation("Pinned")
+  posts  Post[]
+}
+
+model Post {
+  id       Int    @id
+  authorId Int
+  author   User   @relation(fields: [authorId], references: [id])
+  pinnedBy User[] @relation("Pinned")
+}
+`);
+
+    migrate({ output: "./out" }, fixedDeps);
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toBe(`function gassmaMigrate() {
+  Gassma.migrateSheets({
+    spreadsheetId: "abc123",
+    models: [
+      { name: "User", columns: ["id"] },
+      { name: "Post", columns: ["id", "authorId"] },
+      { name: "_Pinned", columns: ["postId", "userId"] }
+    ]
+  });
+}
+`);
+  });
+
   it("should record the migration next to the schema with the timestamped name", () => {
     writeSchema(schemaWithDatasource);
 

--- a/packages/cli/src/generate/read/relationHelpers.ts
+++ b/packages/cli/src/generate/read/relationHelpers.ts
@@ -72,20 +72,11 @@ const findInverseField = (
     if (baseType.kind !== "typeId") return false;
     if (baseType.name.value !== targetModelName) return false;
 
-    if (relationName) {
-      if (getRelationName(m) !== relationName) return false;
-      const relAttr = findFirstAttribute(m.attributes, "relation");
-      if (relAttr) {
-        const relFields = getFieldReferences(relAttr.args, "fields");
-        if (relFields) return false;
-      }
-      return true;
-    }
+    if (getRelationName(m) !== relationName) return false;
 
     const attr = findFirstAttribute(m.attributes, "relation");
     if (!attr) return true;
-    const fields = getFieldReferences(attr.args, "fields");
-    return fields === null;
+    return getFieldReferences(attr.args, "fields") === null;
   });
 };
 


### PR DESCRIPTION
## 概要

**スキーマの意味を変えず、フィールドの宣言順を2行入れ替えただけで生成されるリレーションが壊れる**バグを修正します。

```prisma
model User {
  id     Int    @id
  pinned Post[] @relation("Pinned")   // ← posts より先に宣言されている
  posts  Post[]
}
model Post {
  id       Int    @id
  authorId Int
  author   User   @relation(fields: [authorId], references: [id])
  pinnedBy User[] @relation("Pinned")
}
```

| | 修正前(pinned が先) | 修正後 |
|---|---|---|
| `User.pinned` | **oneToMany** ❌ | manyToMany / `_Pinned` ✅ |
| `User.posts` | **manyToMany / `_PostToUser`** ❌ | oneToMany(id / authorId)✅ |

**1対多と多対多が丸ごと入れ替わり、存在しないはずの中間シート `_PostToUser` まで生成されていました。** エラーも警告も出ず、`prisma validate` も `gassma validate` も通ります。

## 原因

リレーションのペア探索が、**片側だけリレーション名を見ていませんでした**。

```ts
if (relationName) {
  if (getRelationName(m) !== relationName) return false;  // 名前あり側 → 相手の名前を確認している
  ...
}
// 名前なし側 → 相手の名前を一切見ていない
return fields === null;   // ← @relation("Pinned") を持つ候補も通ってしまう
```

`Post.author`(**無名**の FK)が相手を探すとき、User のメンバーを宣言順に走査して最初にヒットしたものを採用します。`pinned` は `@relation("Pinned")` を持つものの `fields:` は無いため、この条件を通過してしまいます。

結果 `User.pinned` が `author` の1対多の相手として登録され、行き場を失った `User.posts` を後段の暗黙多対多検出が誤って多対多と判定していました。

## 修正

非対称そのものを解消し、1つの条件に統合しました:

```diff
-    if (relationName) {
-      if (getRelationName(m) !== relationName) return false;
-      const relAttr = findFirstAttribute(m.attributes, "relation");
-      if (relAttr) {
-        const relFields = getFieldReferences(relAttr.args, "fields");
-        if (relFields) return false;
-      }
-      return true;
-    }
-    const attr = findFirstAttribute(m.attributes, "relation");
-    if (!attr) return true;
-    const fields = getFieldReferences(attr.args, "fields");
-    return fields === null;
+    if (getRelationName(m) !== relationName) return false;
+    const attr = findFirstAttribute(m.attributes, "relation");
+    if (!attr) return true;
+    return getFieldReferences(attr.args, "fields") === null;
```

「**無名は無名とペア(両方 null)、命名済みは同じ名前同士でペア**」という Prisma の対応付け規則を1つの `!==` で表現しています。

名前あり側の挙動は変わりません。**旧コードの `if (relAttr)` ガードはデッドコード**でした(名前が一致した時点で `@relation` 属性の存在が保証されるため)。

## 1:1 では逆側のフィールドが丸ごと欠落していました

検証で判明した副次的な影響です。リストの入れ替わりだけでなく、**無名の 1:1 と命名済みリレーションが同居した場合、逆側のフィールドが生成すらされていませんでした**:

```
// 修正前の base で実測 — "post" キーが生成物全体に0回しか出現しない
"User": { "pinned": { "type": "oneToMany", "to": "Post", "field": "id", "reference": "authorId" } }
```

修正後は `User.post` = `oneToOne(id / authorId)` が正しく生成されます。この回帰ガードもテストに含めました。

## `detectImplicitManyToMany` 側の修正は不要

同関数の inverse 探索もリレーション名を見ていませんが、**この修正だけで幽霊シートの生成が消えることを実測で確認**しました。理由は2つで、いずれもコードで裏取り済みです:

1. 上流修正後は `User.posts` が oneToMany として登録されるため、`detectImplicitManyToMany` 冒頭のガードでスキップされる
2. 同関数内の名前を見ない探索は**存在チェックにしか使われず**、見つけたフィールド自体は出力に一切使われない(through シート名は自フィールドのリレーション名、列名はモデル名、自己参照の A/B は名前一致で別途探索)

## テスト

t-wada 流 TDD(テストのみのコミット時点で 5 fail の Red を実機確認 → 実装コミットで Green)。**9ケース追加、全体1299件パス**。format / lint / typecheck / test:types / build すべて clean。

独立した検証エージェントによる敵対的レビューを実施しました:

- **既存ユーザーへの影響ゼロ** — base を別 worktree に展開してビルドし、**13スキーマ × 生成4ファイル**をバイト比較。1:1・1対多・暗黙多対多・自己参照・`@map`/`@@map`・enum・onDelete/onUpdate を含む網羅スキーマで、差分が出たのは**意図した修正対象のケースのみ**
- **リファクタの等価性をコードで証明** — `getFieldReferences` が空配列 `[]` を返すケースの旧新一致、名前あり時に候補が `@relation` を持たないケースが存在しないこと(=デッドコード)を確認
- 変異テスト4系統で Red 確認(旧バグロジックの復元、`if (!attr)` の反転、名前一致チェックの削除、属性付き候補の全拒否)。無名同士・命名同士の回帰ガードが実際に機能することも確認

## 不正スキーマでの挙動

片側だけ命名・両側で名前が食い違うといった `prisma validate` が弾く領域についても base と比較しましたが、**壊れ方の悪化はありません**。むしろ「無名 FK + 命名リストのみ」のケースでは、修正前の非対称な oneToMany/manyToMany 混在から、修正後は両側対称の多対多になり改善しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja