### PR TITLE
feat: accept Gassma.raw in generated write-input types (core #181 follow-up)

### DIFF
--- a/packages/cli/src/__test__/generate/generator.test.ts
+++ b/packages/cli/src/__test__/generate/generator.test.ts
@@ -70,7 +70,7 @@ describe("generater", () => {
 
   it("should limit NumberOperation to number columns in update data", () => {
     expect(result).toContain(
-      'data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) }>;',
+      'data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) | Gassma.RawValue }>;',
     );
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -62,9 +62,21 @@ describe("getGassmaCommonTypes", () => {
   });
 
   it("should not contain skip declarations by default", () => {
-    expect(result).not.toContain("skip");
+    expect(result).not.toContain("const skip");
     expect(result).not.toContain("SkipValue");
     expect(result).not.toContain("SkipOptional");
+  });
+
+  it("should generate RawValue type and the raw function", () => {
+    expect(result).toContain("type RawValue = {");
+    expect(result).toContain('readonly __gassmaRawValueBrand: "Gassma.raw";');
+    expect(result).toContain("function raw(value: string): RawValue;");
+  });
+
+  it("should generate RawAllowed helper", () => {
+    expect(result).toContain(
+      "type RawAllowed<T> = { [K in keyof T]: T[K] | RawValue };",
+    );
   });
 
   describe("strict mode", () => {
@@ -106,6 +118,13 @@ describe("getGassmaCommonTypes", () => {
 
     it("should not add SkipValue to array element types", () => {
       expect(strictResult).not.toContain("(T | SkipValue)[]");
+    });
+
+    it("should keep raw declarations in strict mode", () => {
+      expect(strictResult).toContain("function raw(value: string): RawValue;");
+      expect(strictResult).toContain(
+        "type RawAllowed<T> = { [K in keyof T]: T[K] | RawValue };",
+      );
     });
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCreate.test.ts
@@ -7,7 +7,7 @@ describe("getOneGassmaCreate", () => {
     const result = getOneGassmaCreate("", "User");
 
     expect(result).toContain("export type GassmaUserCreateData");
-    expect(result).toContain("data: GassmaUserUse");
+    expect(result).toContain("data: Gassma.RawAllowed<GassmaUserUse>");
   });
 
   it("should add nested write operations with target model types for oneToMany", () => {
@@ -26,16 +26,16 @@ describe("getOneGassmaCreate", () => {
 
     expect(result).toContain('"posts"?:');
     expect(result).toContain(
-      'create?: Omit<GassmaPostUse, "authorId"> | Omit<GassmaPostUse, "authorId">[]',
+      'create?: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> | Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[]',
     );
     expect(result).toContain(
-      'createMany?: { data: Omit<GassmaPostUse, "authorId">[] }',
+      'createMany?: { data: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[] }',
     );
     expect(result).toContain(
       "connect?: GassmaPostWhereUse | GassmaPostWhereUse[]",
     );
     expect(result).toContain(
-      'connectOrCreate?: { where: GassmaPostWhereUse; create: Omit<GassmaPostUse, "authorId"> }',
+      'connectOrCreate?: { where: GassmaPostWhereUse; create: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> }',
     );
   });
 
@@ -54,10 +54,12 @@ describe("getOneGassmaCreate", () => {
     const result = getOneGassmaCreate("", "User", relations);
 
     expect(result).toContain('"profile"?:');
-    expect(result).toContain('create?: Omit<GassmaProfileUse, "userId">');
+    expect(result).toContain(
+      'create?: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>',
+    );
     expect(result).toContain("connect?: GassmaProfileWhereUse");
     expect(result).toContain(
-      'connectOrCreate?: { where: GassmaProfileWhereUse; create: Omit<GassmaProfileUse, "userId"> }',
+      'connectOrCreate?: { where: GassmaProfileWhereUse; create: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">> }',
     );
   });
 
@@ -97,7 +99,7 @@ describe("getOneGassmaCreate", () => {
     const result = getOneGassmaCreate("", "Post", relations);
 
     expect(result).toContain(
-      'data: Omit<GassmaPostUse, "authorId"> & (Pick<GassmaPostUse, "authorId"> | { "author": { create?: GassmaUserUse; connect?: GassmaUserWhereUse; connectOrCreate?: { where: GassmaUserWhereUse; create: GassmaUserUse } } });',
+      'data: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> & (Gassma.RawAllowed<Pick<GassmaPostUse, "authorId">> | { "author": { create?: Gassma.RawAllowed<GassmaUserUse>; connect?: GassmaUserWhereUse; connectOrCreate?: { where: GassmaUserWhereUse; create: Gassma.RawAllowed<GassmaUserUse> } } });',
     );
   });
 
@@ -127,10 +129,10 @@ describe("getOneGassmaCreate", () => {
     const result = getOneGassmaCreate("", "Post", relations);
 
     expect(result).toContain(
-      'data: Omit<GassmaPostUse, "authorId"> & (Pick<GassmaPostUse, "authorId"> | { "author": {',
+      'data: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> & (Gassma.RawAllowed<Pick<GassmaPostUse, "authorId">> | { "author": {',
     );
     expect(result).toContain(
-      '"tags"?: { create?: GassmaTagUse | GassmaTagUse[]',
+      '"tags"?: { create?: Gassma.RawAllowed<GassmaTagUse> | Gassma.RawAllowed<GassmaTagUse>[]',
     );
     expect(result).not.toContain('"author"?:');
   });
@@ -155,9 +157,15 @@ describe("getOneGassmaCreate", () => {
 
     const result = getOneGassmaCreate("", "PostTag", relations);
 
-    expect(result).toContain('Omit<GassmaPostTagUse, "postId" | "tagId">');
-    expect(result).toContain('(Pick<GassmaPostTagUse, "postId"> | { "post": {');
-    expect(result).toContain('(Pick<GassmaPostTagUse, "tagId"> | { "tag": {');
+    expect(result).toContain(
+      'Gassma.RawAllowed<Omit<GassmaPostTagUse, "postId" | "tagId">>',
+    );
+    expect(result).toContain(
+      '(Gassma.RawAllowed<Pick<GassmaPostTagUse, "postId">> | { "post": {',
+    );
+    expect(result).toContain(
+      '(Gassma.RawAllowed<Pick<GassmaPostTagUse, "tagId">> | { "tag": {',
+    );
   });
 
   it("should include select property", () => {
@@ -199,7 +207,7 @@ describe("getOneGassmaCreate", () => {
 
     const result = getOneGassmaCreate("", "User", relations);
 
-    expect(result).toContain("data: GassmaUserUse;");
+    expect(result).toContain("data: Gassma.RawAllowed<GassmaUserUse>;");
     expect(result).not.toContain("NestedWriteOperation");
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCreateMany.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCreateMany.test.ts
@@ -5,12 +5,12 @@ describe("getOneGassmaCreateMany", () => {
   it("should emit CreateManyData with data array of Use", () => {
     const result = getOneGassmaCreateMany("", "User");
     expect(result).toContain("export type GassmaUserCreateManyData = {");
-    expect(result).toContain("data: GassmaUserUse[];");
+    expect(result).toContain("data: Gassma.RawAllowed<GassmaUserUse>[];");
   });
 
   it("should prepend schemaName", () => {
     const result = getOneGassmaCreateMany("Test", "User");
     expect(result).toContain("export type GassmaTestUserCreateManyData");
-    expect(result).toContain("GassmaTestUserUse[]");
+    expect(result).toContain("Gassma.RawAllowed<GassmaTestUserUse>[]");
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCreateManyAndReturnData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCreateManyAndReturnData.test.ts
@@ -11,7 +11,7 @@ describe("getOneGassmaCreateManyAndReturnData", () => {
   it("should include data property", () => {
     const result = getOneGassmaCreateManyAndReturnData("", "User");
 
-    expect(result).toContain("data: GassmaUserUse[]");
+    expect(result).toContain("data: Gassma.RawAllowed<GassmaUserUse>[]");
   });
 
   it("should include include property", () => {

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaUpdateData.test.ts
@@ -13,7 +13,7 @@ describe("getOneGassmaUpdateData", () => {
 
     expect(result).toContain("export type GassmaUserUpdateData");
     expect(result).toContain(
-      'data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" | "age" ? Gassma.NumberOperation : never) }>;',
+      'data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" | "age" ? Gassma.NumberOperation : never) | Gassma.RawValue }>;',
     );
   });
 
@@ -34,7 +34,9 @@ describe("getOneGassmaUpdateData", () => {
       "flag?": ["boolean"],
     });
 
-    expect(result).toContain("data: Partial<GassmaUserUse>;");
+    expect(result).toContain(
+      "data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>;",
+    );
     expect(result).not.toContain("NumberOperation");
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaUpdateSingleData.test.ts
@@ -24,7 +24,7 @@ describe("getOneGassmaUpdateSingleData", () => {
     const result = getOneGassmaUpdateSingleData("", "User", userContent);
 
     expect(result).toContain(
-      'data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) }>',
+      'data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) | Gassma.RawValue }>',
     );
   });
 
@@ -33,7 +33,9 @@ describe("getOneGassmaUpdateSingleData", () => {
       name: ["string"],
     });
 
-    expect(result).toContain("data: Partial<GassmaUserUse>");
+    expect(result).toContain(
+      "data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>",
+    );
     expect(result).not.toContain("NumberOperation");
   });
 
@@ -83,7 +85,7 @@ describe("getOneGassmaUpdateSingleData", () => {
 
     expect(result).toContain('"posts"?:');
     expect(result).toContain(
-      'create?: Omit<GassmaPostUse, "authorId"> | Omit<GassmaPostUse, "authorId">[]',
+      'create?: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> | Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[]',
     );
     expect(result).toContain(
       "connect?: GassmaPostWhereUse | GassmaPostWhereUse[]",
@@ -116,7 +118,7 @@ describe("getOneGassmaUpdateSingleData", () => {
     );
 
     expect(result).toContain(
-      'update?: { where: GassmaPostWhereUse; data: Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | (K extends "id" | "authorId" ? Gassma.NumberOperation : never) }> }',
+      'update?: { where: GassmaPostWhereUse; data: Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | (K extends "id" | "authorId" ? Gassma.NumberOperation : never) | Gassma.RawValue }> }',
     );
   });
 
@@ -146,12 +148,14 @@ describe("getOneGassmaUpdateSingleData", () => {
     );
 
     expect(result).toContain('"profile"?:');
-    expect(result).toContain('create?: Omit<GassmaProfileUse, "userId">;');
     expect(result).toContain(
-      'connectOrCreate?: { where: GassmaProfileWhereUse; create: Omit<GassmaProfileUse, "userId"> }',
+      'create?: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>;',
     );
     expect(result).toContain(
-      'update?: Partial<{ [K in keyof GassmaProfileUse]: GassmaProfileUse[K] | (K extends "id" | "userId" ? Gassma.NumberOperation : never) }>',
+      'connectOrCreate?: { where: GassmaProfileWhereUse; create: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">> }',
+    );
+    expect(result).toContain(
+      'update?: Partial<{ [K in keyof GassmaProfileUse]: GassmaProfileUse[K] | (K extends "id" | "userId" ? Gassma.NumberOperation : never) | Gassma.RawValue }>',
     );
     expect(result).toContain("delete?: true");
     expect(result).toContain("disconnect?: true");

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaUpsertSingleData.test.ts
@@ -28,14 +28,14 @@ describe("getOneGassmaUpsertSingleData", () => {
   it("should include create property", () => {
     const result = getOneGassmaUpsertSingleData("", "User", userContent);
 
-    expect(result).toContain("create: GassmaUserUse");
+    expect(result).toContain("create: Gassma.RawAllowed<GassmaUserUse>");
   });
 
   it("should include update with NumberOperation only on number columns", () => {
     const result = getOneGassmaUpsertSingleData("", "User", userContent);
 
     expect(result).toContain(
-      'update: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) }>',
+      'update: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) | Gassma.RawValue }>',
     );
   });
 
@@ -44,7 +44,9 @@ describe("getOneGassmaUpsertSingleData", () => {
       name: ["string"],
     });
 
-    expect(result).toContain("update: Partial<GassmaUserUse>");
+    expect(result).toContain(
+      "update: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>",
+    );
     expect(result).not.toContain("NumberOperation");
   });
 
@@ -94,7 +96,7 @@ describe("getOneGassmaUpsertSingleData", () => {
 
     expect(result).toContain('"posts"?:');
     expect(result).toContain(
-      'create?: Omit<GassmaPostUse, "authorId"> | Omit<GassmaPostUse, "authorId">[]',
+      'create?: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> | Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[]',
     );
     expect(result).toContain(
       "connect?: GassmaPostWhereUse | GassmaPostWhereUse[]",
@@ -127,7 +129,7 @@ describe("getOneGassmaUpsertSingleData", () => {
     );
 
     expect(result).toContain(
-      'update?: { where: GassmaPostWhereUse; data: Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | (K extends "id" | "authorId" ? Gassma.NumberOperation : never) }> }',
+      'update?: { where: GassmaPostWhereUse; data: Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | (K extends "id" | "authorId" ? Gassma.NumberOperation : never) | Gassma.RawValue }> }',
     );
   });
 
@@ -151,7 +153,7 @@ describe("getOneGassmaUpsertSingleData", () => {
     );
 
     expect(result).toContain(
-      'create: Omit<GassmaPostUse, "authorId"> & (Pick<GassmaPostUse, "authorId"> | { "author": { create?: GassmaUserUse; connect?: GassmaUserWhereUse; connectOrCreate?: { where: GassmaUserWhereUse; create: GassmaUserUse } } });',
+      'create: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> & (Gassma.RawAllowed<Pick<GassmaPostUse, "authorId">> | { "author": { create?: Gassma.RawAllowed<GassmaUserUse>; connect?: GassmaUserWhereUse; connectOrCreate?: { where: GassmaUserWhereUse; create: Gassma.RawAllowed<GassmaUserUse> } } });',
     );
   });
 
@@ -179,7 +181,7 @@ describe("getOneGassmaUpsertSingleData", () => {
     );
 
     expect(createPart).toContain(
-      'createMany?: { data: Omit<GassmaPostUse, "authorId">[] }',
+      'createMany?: { data: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[] }',
     );
     expect(createPart).not.toContain("update?:");
     expect(createPart).not.toContain("delete?:");
@@ -209,7 +211,7 @@ describe("getOneGassmaUpsertSingleData", () => {
     const updatePart = result.slice(result.indexOf("update:"));
 
     expect(updatePart).toContain(
-      'createMany?: { data: Omit<GassmaPostUse, "authorId">[] }',
+      'createMany?: { data: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[] }',
     );
     expect(updatePart).toContain(
       "deleteMany?: GassmaPostWhereUse | GassmaPostWhereUse[]",

--- a/packages/cli/src/__test__/generate/typeGenerate/strictSkip/writeData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/strictSkip/writeData.test.ts
@@ -39,19 +39,21 @@ const dictYaml: Record<string, Record<string, unknown[]>> = {
 };
 
 const idNumOp = '(K extends "id" ? Gassma.NumberOperation : never)';
-const postUpdateData = `Gassma.SkipOptional<Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | ${idNumOp} }>>`;
-const userUpdateData = `Gassma.SkipOptional<Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | ${idNumOp} }>>`;
+const postUpdateData = `Gassma.SkipOptional<Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | ${idNumOp} | Gassma.RawValue }>>`;
+const userUpdateData = `Gassma.SkipOptional<Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | ${idNumOp} | Gassma.RawValue }>>`;
 
 describe("strict buildCreateDataType", () => {
   it("should wrap base type with SkipOptional", () => {
     const result = buildCreateDataType("", "User", relations, true);
-    expect(result).toContain("Gassma.SkipOptional<GassmaUserUse>");
+    expect(result).toContain(
+      "Gassma.SkipOptional<Gassma.RawAllowed<GassmaUserUse>>",
+    );
   });
 
   it("should wrap FK-omitted base type with SkipOptional", () => {
     const result = buildCreateDataType("", "Post", relations, true);
     expect(result).toContain(
-      'Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">>',
+      'Gassma.SkipOptional<Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>>',
     );
   });
 
@@ -66,7 +68,7 @@ describe("strict buildCreateDataType", () => {
   it("should add SkipValue to FK relation operations", () => {
     const result = buildCreateDataType("", "Post", relations, true);
     expect(result).toContain(
-      '"author": { create?: Gassma.SkipOptional<GassmaUserUse> | Gassma.SkipValue; connect?: GassmaUserWhereUse | Gassma.SkipValue; connectOrCreate?: { where: GassmaUserWhereUse; create: Gassma.SkipOptional<GassmaUserUse> } | Gassma.SkipValue }',
+      '"author": { create?: Gassma.SkipOptional<Gassma.RawAllowed<GassmaUserUse>> | Gassma.SkipValue; connect?: GassmaUserWhereUse | Gassma.SkipValue; connectOrCreate?: { where: GassmaUserWhereUse; create: Gassma.SkipOptional<Gassma.RawAllowed<GassmaUserUse>> } | Gassma.SkipValue }',
     );
   });
 
@@ -98,16 +100,16 @@ describe("strict getNestedWriteFields", () => {
 
   it("should add SkipValue to create context operations", () => {
     expect(createFields).toContain(
-      'create?: Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">> | Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">>[] | Gassma.SkipValue',
+      'create?: Gassma.SkipOptional<Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>> | Gassma.SkipOptional<Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>>[] | Gassma.SkipValue',
     );
     expect(createFields).toContain(
-      'createMany?: { data: Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">>[] } | Gassma.SkipValue',
+      'createMany?: { data: Gassma.SkipOptional<Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>>[] } | Gassma.SkipValue',
     );
     expect(createFields).toContain(
       "connect?: GassmaPostWhereUse | GassmaPostWhereUse[] | Gassma.SkipValue",
     );
     expect(createFields).toContain(
-      'connectOrCreate?: { where: GassmaPostWhereUse; create: Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">> } | { where: GassmaPostWhereUse; create: Gassma.SkipOptional<Omit<GassmaPostUse, "authorId">> }[] | Gassma.SkipValue',
+      'connectOrCreate?: { where: GassmaPostWhereUse; create: Gassma.SkipOptional<Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>> } | { where: GassmaPostWhereUse; create: Gassma.SkipOptional<Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>> }[] | Gassma.SkipValue',
     );
   });
 
@@ -154,7 +156,7 @@ describe("strict getNestedWriteFields", () => {
       true,
     );
     expect(postUpdate).toContain(
-      "update?: Gassma.SkipOptional<Partial<GassmaUserUse>> | Gassma.SkipValue",
+      "update?: Gassma.SkipOptional<Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>> | Gassma.SkipValue",
     );
   });
 
@@ -169,7 +171,9 @@ describe("strict CreateData", () => {
   const result = getOneGassmaCreate("", "User", relations, true);
 
   it("should not add SkipValue to data itself", () => {
-    expect(result).toContain("data: Gassma.SkipOptional<GassmaUserUse>");
+    expect(result).toContain(
+      "data: Gassma.SkipOptional<Gassma.RawAllowed<GassmaUserUse>>",
+    );
   });
 
   it("should add SkipValue to include / select / omit", () => {
@@ -187,7 +191,9 @@ describe("strict CreateData", () => {
 describe("strict CreateManyData", () => {
   it("should wrap data elements with SkipOptional", () => {
     const result = getOneGassmaCreateMany("", "User", true);
-    expect(result).toContain("data: Gassma.SkipOptional<GassmaUserUse>[];");
+    expect(result).toContain(
+      "data: Gassma.SkipOptional<Gassma.RawAllowed<GassmaUserUse>>[];",
+    );
   });
 
   it("should keep non-strict output unchanged", () => {
@@ -199,7 +205,9 @@ describe("strict CreateManyAndReturnData", () => {
   const result = getOneGassmaCreateManyAndReturnData("", "User", true);
 
   it("should wrap data elements and add SkipValue to options", () => {
-    expect(result).toContain("data: Gassma.SkipOptional<GassmaUserUse>[];");
+    expect(result).toContain(
+      "data: Gassma.SkipOptional<Gassma.RawAllowed<GassmaUserUse>>[];",
+    );
     expect(result).toContain("include?: GassmaUserInclude | Gassma.SkipValue;");
     expect(result).toContain(
       "({ select?: GassmaUserSelect | Gassma.SkipValue; omit?: never } | { select?: never; omit?: GassmaUserOmit | Gassma.SkipValue })",
@@ -218,7 +226,7 @@ describe("strict UpdateData", () => {
 
   it("should add SkipValue to data values and optional arguments", () => {
     expect(result).toContain(
-      `data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | ${idNumOp} | Gassma.SkipValue }>;`,
+      `data: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | ${idNumOp} | Gassma.RawValue | Gassma.SkipValue }>;`,
     );
     expect(result).toContain("where?: GassmaUserWhereUse | Gassma.SkipValue;");
     expect(result).toContain("limit?: number | Gassma.SkipValue;");
@@ -247,7 +255,7 @@ describe("strict UpdateSingleData", () => {
 
   it("should add SkipValue to data values", () => {
     expect(result).toContain(
-      `Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | ${idNumOp} | Gassma.SkipValue }>`,
+      `Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | ${idNumOp} | Gassma.RawValue | Gassma.SkipValue }>`,
     );
   });
 
@@ -277,9 +285,11 @@ describe("strict UpsertSingleData", () => {
 
   it("should not add SkipValue to required where / create / update themselves", () => {
     expect(result).toContain("where: GassmaUserWhereUse;");
-    expect(result).toContain("create: Gassma.SkipOptional<GassmaUserUse>");
     expect(result).toContain(
-      `update: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | ${idNumOp} | Gassma.SkipValue }>`,
+      "create: Gassma.SkipOptional<Gassma.RawAllowed<GassmaUserUse>>",
+    );
+    expect(result).toContain(
+      `update: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | ${idNumOp} | Gassma.RawValue | Gassma.SkipValue }>`,
     );
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/util/buildCreateDataType.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/util/buildCreateDataType.test.ts
@@ -26,14 +26,16 @@ describe("buildCreateDataType", () => {
   };
 
   it("should return the bare Use type without relations", () => {
-    expect(buildCreateDataType("", "User")).toBe("GassmaUserUse");
+    expect(buildCreateDataType("", "User")).toBe(
+      "Gassma.RawAllowed<GassmaUserUse>",
+    );
   });
 
   it("should build the FK XOR for manyToOne relations", () => {
     const result = buildCreateDataType("", "Post", postRelations);
 
     expect(result).toBe(
-      'Omit<GassmaPostUse, "authorId"> & (Pick<GassmaPostUse, "authorId"> | { "author": { create?: GassmaUserUse; connect?: GassmaUserWhereUse; connectOrCreate?: { where: GassmaUserWhereUse; create: GassmaUserUse } } })',
+      'Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> & (Gassma.RawAllowed<Pick<GassmaPostUse, "authorId">> | { "author": { create?: Gassma.RawAllowed<GassmaUserUse>; connect?: GassmaUserWhereUse; connectOrCreate?: { where: GassmaUserWhereUse; create: Gassma.RawAllowed<GassmaUserUse> } } })',
     );
   });
 
@@ -52,7 +54,7 @@ describe("buildCreateDataType", () => {
     const result = buildCreateDataType("", "Profile", relations);
 
     expect(result).toBe(
-      'Omit<GassmaProfileUse, "userId"> & (Pick<GassmaProfileUse, "userId"> | { "user": { create?: GassmaUserUse; connect?: GassmaUserWhereUse; connectOrCreate?: { where: GassmaUserWhereUse; create: GassmaUserUse } } })',
+      'Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">> & (Gassma.RawAllowed<Pick<GassmaProfileUse, "userId">> | { "user": { create?: Gassma.RawAllowed<GassmaUserUse>; connect?: GassmaUserWhereUse; connectOrCreate?: { where: GassmaUserWhereUse; create: Gassma.RawAllowed<GassmaUserUse> } } })',
     );
   });
 
@@ -70,17 +72,19 @@ describe("buildCreateDataType", () => {
 
     const result = buildCreateDataType("", "User", relations);
 
-    expect(result).toContain("GassmaUserUse & {");
+    expect(result).toContain("Gassma.RawAllowed<GassmaUserUse> & {");
     expect(result).not.toContain("Pick<");
-    expect(result).toContain('create?: Omit<GassmaProfileUse, "userId">');
+    expect(result).toContain(
+      'create?: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>',
+    );
   });
 
   it("should append create-context nested fields for non-FK relations", () => {
     const result = buildCreateDataType("", "User", userRelations);
 
-    expect(result).toContain("GassmaUserUse & {");
+    expect(result).toContain("Gassma.RawAllowed<GassmaUserUse> & {");
     expect(result).toContain(
-      'createMany?: { data: Omit<GassmaPostUse, "authorId">[] }',
+      'createMany?: { data: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[] }',
     );
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/util/buildUpdateDataType.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/util/buildUpdateDataType.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from "vitest";
 import { buildUpdateDataType } from "../../../../generate/typeGenerate/util/buildUpdateDataType";
 
 describe("buildUpdateDataType", () => {
-  it("should add NumberOperation only to number columns", () => {
+  it("should add NumberOperation only to number columns and RawValue to all columns", () => {
     const result = buildUpdateDataType("GassmaUserUse", {
       id: ["number"],
       name: ["string"],
     });
 
     expect(result).toBe(
-      'Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) }>',
+      'Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) | Gassma.RawValue }>',
     );
   });
 
@@ -38,16 +38,21 @@ describe("buildUpdateDataType", () => {
       name: ["string"],
     });
 
-    expect(result).toBe("Partial<GassmaUserUse>");
+    expect(result).toBe(
+      "Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>",
+    );
   });
 
-  it("should collapse to plain Partial when there is no number column", () => {
+  it("should add only RawValue when there is no number column", () => {
     const result = buildUpdateDataType("GassmaUserUse", {
       name: ["string"],
       "flag?": ["boolean"],
     });
 
-    expect(result).toBe("Partial<GassmaUserUse>");
+    expect(result).toBe(
+      "Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>",
+    );
+    expect(result).not.toContain("NumberOperation");
   });
 
   it("should append SkipValue inside the mapped type when strict", () => {
@@ -58,11 +63,11 @@ describe("buildUpdateDataType", () => {
     );
 
     expect(result).toBe(
-      'Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) | Gassma.SkipValue }>',
+      'Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) | Gassma.RawValue | Gassma.SkipValue }>',
     );
   });
 
-  it("should keep the mapped form for SkipValue even without number columns when strict", () => {
+  it("should keep RawValue and SkipValue even without number columns when strict", () => {
     const result = buildUpdateDataType(
       "GassmaUserUse",
       { name: ["string"] },
@@ -70,7 +75,7 @@ describe("buildUpdateDataType", () => {
     );
 
     expect(result).toBe(
-      "Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.SkipValue }>",
+      "Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue | Gassma.SkipValue }>",
     );
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/util/getNestedWriteFields.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/util/getNestedWriteFields.test.ts
@@ -46,10 +46,10 @@ describe("getNestedWriteFields", () => {
       );
 
       expect(result).toContain('"author"?:');
-      expect(result).toContain("create?: GassmaUserUse");
+      expect(result).toContain("create?: Gassma.RawAllowed<GassmaUserUse>");
       expect(result).toContain("connect?: GassmaUserWhereUse");
       expect(result).toContain(
-        "connectOrCreate?: { where: GassmaUserWhereUse; create: GassmaUserUse }",
+        "connectOrCreate?: { where: GassmaUserWhereUse; create: Gassma.RawAllowed<GassmaUserUse> }",
       );
     });
 
@@ -61,7 +61,9 @@ describe("getNestedWriteFields", () => {
         "update",
       );
 
-      expect(result).toContain("update?: Partial<GassmaUserUse>");
+      expect(result).toContain(
+        "update?: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>",
+      );
       expect(result).toContain("delete?: true");
       expect(result).toContain("disconnect?: true");
     });
@@ -75,10 +77,10 @@ describe("getNestedWriteFields", () => {
       );
 
       expect(result).toContain(
-        'create?: Omit<GassmaPostUse, "authorId"> | Omit<GassmaPostUse, "authorId">[]',
+        'create?: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> | Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[]',
       );
       expect(result).toContain(
-        'connectOrCreate?: { where: GassmaPostWhereUse; create: Omit<GassmaPostUse, "authorId"> }',
+        'connectOrCreate?: { where: GassmaPostWhereUse; create: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> }',
       );
     });
 
@@ -90,9 +92,11 @@ describe("getNestedWriteFields", () => {
         "update",
       );
 
-      expect(result).toContain('create?: Omit<GassmaProfileUse, "userId">;');
       expect(result).toContain(
-        'connectOrCreate?: { where: GassmaProfileWhereUse; create: Omit<GassmaProfileUse, "userId"> }',
+        'create?: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>;',
+      );
+      expect(result).toContain(
+        'connectOrCreate?: { where: GassmaProfileWhereUse; create: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">> }',
       );
     });
 
@@ -105,7 +109,9 @@ describe("getNestedWriteFields", () => {
       );
 
       expect(result).toContain("connect?: GassmaProfileWhereUse;");
-      expect(result).toContain("update?: Partial<GassmaProfileUse>");
+      expect(result).toContain(
+        "update?: Partial<{ [K in keyof GassmaProfileUse]: GassmaProfileUse[K] | Gassma.RawValue }>",
+      );
       expect(result).toContain("delete?: true");
       expect(result).toContain("disconnect?: true");
     });
@@ -135,8 +141,10 @@ describe("getNestedWriteFields", () => {
 
       const result = getNestedWriteFields("", "Post", relations, "update");
 
-      expect(result).toContain("create?: GassmaUserUse;");
-      expect(result).toContain("create?: GassmaTagUse | GassmaTagUse[]");
+      expect(result).toContain("create?: Gassma.RawAllowed<GassmaUserUse>;");
+      expect(result).toContain(
+        "create?: Gassma.RawAllowed<GassmaTagUse> | Gassma.RawAllowed<GassmaTagUse>[]",
+      );
       expect(result).not.toContain("Omit<");
     });
 
@@ -149,7 +157,7 @@ describe("getNestedWriteFields", () => {
       );
 
       expect(result).toContain(
-        'createMany?: { data: Omit<GassmaPostUse, "authorId">[] }',
+        'createMany?: { data: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[] }',
       );
     });
 
@@ -196,7 +204,7 @@ describe("getNestedWriteFields", () => {
       );
 
       expect(result).toContain(
-        'update?: { where: GassmaPostWhereUse; data: Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | (K extends "id" | "authorId" ? Gassma.NumberOperation : never) }> } | { where: GassmaPostWhereUse; data: Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | (K extends "id" | "authorId" ? Gassma.NumberOperation : never) }> }[]',
+        'update?: { where: GassmaPostWhereUse; data: Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | (K extends "id" | "authorId" ? Gassma.NumberOperation : never) | Gassma.RawValue }> } | { where: GassmaPostWhereUse; data: Partial<{ [K in keyof GassmaPostUse]: GassmaPostUse[K] | (K extends "id" | "authorId" ? Gassma.NumberOperation : never) | Gassma.RawValue }> }[]',
       );
     });
 
@@ -215,7 +223,7 @@ describe("getNestedWriteFields", () => {
       );
 
       expect(result).toContain(
-        'update?: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) }>',
+        'update?: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | (K extends "id" ? Gassma.NumberOperation : never) | Gassma.RawValue }>',
       );
     });
 
@@ -233,7 +241,9 @@ describe("getNestedWriteFields", () => {
         dictYaml,
       );
 
-      expect(result).toContain("update?: Partial<GassmaUserUse>");
+      expect(result).toContain(
+        "update?: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>",
+      );
       expect(result).not.toContain("NumberOperation");
     });
 
@@ -251,7 +261,9 @@ describe("getNestedWriteFields", () => {
         dictYaml,
       );
 
-      expect(result).toContain("update?: Partial<GassmaUserUse>");
+      expect(result).toContain(
+        "update?: Partial<{ [K in keyof GassmaUserUse]: GassmaUserUse[K] | Gassma.RawValue }>",
+      );
     });
 
     it("should emit only ops the core processes for manyToMany", () => {
@@ -306,16 +318,16 @@ describe("getNestedWriteFields", () => {
       );
 
       expect(result).toContain(
-        'create?: Omit<GassmaPostUse, "authorId"> | Omit<GassmaPostUse, "authorId">[]',
+        'create?: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> | Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[]',
       );
       expect(result).toContain(
-        'createMany?: { data: Omit<GassmaPostUse, "authorId">[] }',
+        'createMany?: { data: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>[] }',
       );
       expect(result).toContain(
         "connect?: GassmaPostWhereUse | GassmaPostWhereUse[]",
       );
       expect(result).toContain(
-        'connectOrCreate?: { where: GassmaPostWhereUse; create: Omit<GassmaPostUse, "authorId"> }',
+        'connectOrCreate?: { where: GassmaPostWhereUse; create: Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">> }',
       );
       expect(result).not.toContain("update?:");
       expect(result).not.toContain("delete?:");
@@ -343,12 +355,14 @@ describe("getNestedWriteFields", () => {
 
       const result = getNestedWriteFields("", "Post", relations, "create");
 
-      expect(result).toContain("create?: GassmaTagUse | GassmaTagUse[]");
+      expect(result).toContain(
+        "create?: Gassma.RawAllowed<GassmaTagUse> | Gassma.RawAllowed<GassmaTagUse>[]",
+      );
       expect(result).toContain(
         "connect?: GassmaTagWhereUse | GassmaTagWhereUse[]",
       );
       expect(result).toContain(
-        "connectOrCreate?: { where: GassmaTagWhereUse; create: GassmaTagUse }",
+        "connectOrCreate?: { where: GassmaTagWhereUse; create: Gassma.RawAllowed<GassmaTagUse> }",
       );
       expect(result).not.toContain("createMany?:");
       expect(result).not.toContain("disconnect?:");
@@ -363,10 +377,12 @@ describe("getNestedWriteFields", () => {
         "create",
       );
 
-      expect(result).toContain('create?: Omit<GassmaProfileUse, "userId">');
+      expect(result).toContain(
+        'create?: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>',
+      );
       expect(result).toContain("connect?: GassmaProfileWhereUse");
       expect(result).toContain(
-        'connectOrCreate?: { where: GassmaProfileWhereUse; create: Omit<GassmaProfileUse, "userId"> }',
+        'connectOrCreate?: { where: GassmaProfileWhereUse; create: Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">> }',
       );
       expect(result).not.toContain("createMany?:");
       expect(result).not.toContain("update?:");

--- a/packages/cli/src/__test__/generate/typeGenerate/util/rawAllowed.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/util/rawAllowed.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { rawAllowedWrap } from "../../../../generate/typeGenerate/util/rawAllowed";
+
+describe("rawAllowedWrap", () => {
+  it("should wrap the type expression with Gassma.RawAllowed", () => {
+    expect(rawAllowedWrap("GassmaUserUse")).toBe(
+      "Gassma.RawAllowed<GassmaUserUse>",
+    );
+  });
+
+  it("should wrap composite type expressions as-is", () => {
+    expect(rawAllowedWrap('Omit<GassmaPostUse, "authorId">')).toBe(
+      'Gassma.RawAllowed<Omit<GassmaPostUse, "authorId">>',
+    );
+  });
+});

--- a/packages/cli/src/__test__/types/write/inverseOneToOne.test-d.ts
+++ b/packages/cli/src/__test__/types/write/inverseOneToOne.test-d.ts
@@ -54,26 +54,28 @@ declare const client: GassmaClient;
 {
   type CreateOps = NonNullable<GassmaUserCreateData["data"]["profile"]>;
   expectTypeOf<NonNullable<CreateOps["create"]>>().toEqualTypeOf<
-    Omit<GassmaProfileUse, "userId">
+    Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>
   >();
   expectTypeOf<
     NonNullable<CreateOps["connectOrCreate"]>["create"]
-  >().toEqualTypeOf<Omit<GassmaProfileUse, "userId">>();
+  >().toEqualTypeOf<Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>>();
 
   type UpdateOps = NonNullable<GassmaUserUpdateSingleData["data"]["profile"]>;
   expectTypeOf<NonNullable<UpdateOps["create"]>>().toEqualTypeOf<
-    Omit<GassmaProfileUse, "userId">
+    Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>
   >();
   expectTypeOf<
     NonNullable<UpdateOps["connectOrCreate"]>["create"]
-  >().toEqualTypeOf<Omit<GassmaProfileUse, "userId">>();
+  >().toEqualTypeOf<Gassma.RawAllowed<Omit<GassmaProfileUse, "userId">>>();
 
-  // update データは数値カラムのみ NumberOperation を受理する
+  // update データは数値カラムのみ NumberOperation を受理する（raw は全カラム）
   type ProfileUpdateData = NonNullable<UpdateOps["update"]>;
   expectTypeOf<ProfileUpdateData["userId"]>().toEqualTypeOf<
-    number | Gassma.NumberOperation | undefined
+    number | Gassma.NumberOperation | Gassma.RawValue | undefined
   >();
-  expectTypeOf<ProfileUpdateData["bio"]>().toEqualTypeOf<string | undefined>();
+  expectTypeOf<ProfileUpdateData["bio"]>().toEqualTypeOf<
+    string | Gassma.RawValue | undefined
+  >();
 }
 
 // inverse oneToOne(User.profile) の update 文脈: to-one op（delete / disconnect は true のみ）

--- a/packages/cli/src/__test__/types/write/multiFkCreate.test-d.ts
+++ b/packages/cli/src/__test__/types/write/multiFkCreate.test-d.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf } from "vitest";
 import type {
+  Gassma,
   GassmaClient,
   GassmaCourseUse,
   GassmaCourseWhereUse,
@@ -15,29 +16,29 @@ declare const client: GassmaClient;
 // 複数FKモデルの create data は FK ごとの XOR の交差になる
 {
   expectTypeOf<GassmaEnrollmentCreateData["data"]>().toEqualTypeOf<
-    Omit<GassmaEnrollmentUse, "studentId" | "courseId"> &
+    Gassma.RawAllowed<Omit<GassmaEnrollmentUse, "studentId" | "courseId">> &
       (
-        | Pick<GassmaEnrollmentUse, "studentId">
+        | Gassma.RawAllowed<Pick<GassmaEnrollmentUse, "studentId">>
         | {
             student: {
-              create?: GassmaStudentUse;
+              create?: Gassma.RawAllowed<GassmaStudentUse>;
               connect?: GassmaStudentWhereUse;
               connectOrCreate?: {
                 where: GassmaStudentWhereUse;
-                create: GassmaStudentUse;
+                create: Gassma.RawAllowed<GassmaStudentUse>;
               };
             };
           }
       ) &
       (
-        | Pick<GassmaEnrollmentUse, "courseId">
+        | Gassma.RawAllowed<Pick<GassmaEnrollmentUse, "courseId">>
         | {
             course: {
-              create?: GassmaCourseUse;
+              create?: Gassma.RawAllowed<GassmaCourseUse>;
               connect?: GassmaCourseWhereUse;
               connectOrCreate?: {
                 where: GassmaCourseWhereUse;
-                create: GassmaCourseUse;
+                create: Gassma.RawAllowed<GassmaCourseUse>;
               };
             };
           }

--- a/packages/cli/src/__test__/types/write/raw.test-d.ts
+++ b/packages/cli/src/__test__/types/write/raw.test-d.ts
@@ -1,0 +1,191 @@
+import { expectTypeOf } from "vitest";
+import { Gassma, type GassmaClient } from "../__generated__/client";
+import {
+  Gassma as GassmaStrict,
+  type GassmaClient as GassmaClientStrict,
+} from "../__generated__/clientStrict";
+
+declare const client: GassmaClient;
+declare const strictClient: GassmaClientStrict;
+
+// Gassma.raw の戻り値が RawValue になる（非 strict / strict 両方に生成される）
+{
+  expectTypeOf(Gassma.raw("=SUM(A1:A2)")).toEqualTypeOf<Gassma.RawValue>();
+  expectTypeOf(
+    GassmaStrict.raw("=SUM(A1:A2)"),
+  ).toEqualTypeOf<GassmaStrict.RawValue>();
+}
+
+// create: 全カラム型（string / number / boolean / Date / nullable）で raw を渡せる
+{
+  client.User.create({
+    data: {
+      email: Gassma.raw("=A1"),
+      name: Gassma.raw("=CONCAT(A1, B1)"),
+      age: Gassma.raw("=B1+1"),
+      isActive: Gassma.raw("=A1>5"),
+      score: Gassma.raw("=SUM(B2:B10)"),
+      createdAt: Gassma.raw("=TODAY()"),
+    },
+  });
+}
+
+// create: enum カラム・replaceType のリテラル union カラムでも raw を渡せる
+{
+  client.Member.create({
+    data: {
+      firstName: Gassma.raw("=A1"),
+      role: Gassma.raw("=A1"),
+      status: Gassma.raw("=A1"),
+      size: Gassma.raw("=A1"),
+    },
+  });
+}
+
+// create: FK スカラー（XOR の Pick 側）でも raw を渡せる
+{
+  client.Post.create({
+    data: { title: "t", authorId: Gassma.raw("=A1") },
+  });
+}
+
+// createMany / createManyAndReturn: 要素の全カラムで raw を渡せる
+{
+  client.User.createMany({
+    data: [{ email: Gassma.raw("=A1"), score: Gassma.raw("=SUM(B2:B10)") }],
+  });
+  client.User.createManyAndReturn({
+    data: [{ email: Gassma.raw("=A1"), score: Gassma.raw("=SUM(B2:B10)") }],
+  });
+}
+
+// update / updateMany / updateManyAndReturn: data の全カラムで raw を渡せる
+{
+  client.User.update({
+    where: { id: 1 },
+    data: {
+      email: Gassma.raw("=A1"),
+      age: Gassma.raw("=B1+1"),
+      isActive: Gassma.raw("=A1>5"),
+      createdAt: Gassma.raw("=TODAY()"),
+    },
+  });
+  client.User.updateMany({ data: { score: Gassma.raw("=SUM(B2:B10)") } });
+  client.User.updateManyAndReturn({ data: { name: Gassma.raw("=A1") } });
+}
+
+// upsert: create / update の両方で raw を渡せる
+{
+  client.User.upsert({
+    where: { id: 1 },
+    create: { email: Gassma.raw("=A1"), score: Gassma.raw("=SUM(B2:B10)") },
+    update: { email: Gassma.raw("=A1"), age: Gassma.raw("=B1+1") },
+  });
+}
+
+// nested write: create / createMany / connectOrCreate.create / update の data で raw を渡せる
+{
+  client.User.create({
+    data: {
+      email: "a@example.com",
+      score: 0,
+      posts: {
+        create: { title: Gassma.raw("=A1"), published: Gassma.raw("=B1>0") },
+        createMany: { data: [{ title: Gassma.raw("=A1") }] },
+      },
+    },
+  });
+  client.Post.create({
+    data: {
+      title: "t",
+      author: {
+        connectOrCreate: {
+          where: { id: 1 },
+          create: { email: Gassma.raw("=A1"), score: 0 },
+        },
+      },
+    },
+  });
+  client.User.update({
+    where: { id: 1 },
+    data: {
+      posts: {
+        update: { where: { id: 1 }, data: { title: Gassma.raw("=A1") } },
+      },
+    },
+  });
+}
+
+// strict: raw と skip を同じ data 内で併用できる
+{
+  strictClient.User.update({
+    where: { id: 1 },
+    data: { age: GassmaStrict.raw("=B1+1"), name: GassmaStrict.skip },
+  });
+  strictClient.User.create({
+    data: { email: GassmaStrict.raw("=A1"), score: 0 },
+  });
+}
+
+// where には raw を渡せない
+{
+  client.User.findMany({
+    // @ts-expect-error where の直接値に raw は不可
+    where: { name: Gassma.raw("=A1") },
+  });
+  client.User.findMany({
+    // @ts-expect-error where の equals に raw は不可
+    where: { name: { equals: Gassma.raw("=A1") } },
+  });
+  client.User.update({
+    // @ts-expect-error update の where に raw は不可
+    where: { id: Gassma.raw("=A1") },
+    data: { name: "x" },
+  });
+}
+
+// 結果型に RawValue は現れない
+{
+  const created = client.User.create({
+    data: {
+      email: "a@example.com",
+      score: 0,
+      createdAt: Gassma.raw("=TODAY()"),
+    },
+  });
+  expectTypeOf<(typeof created)["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<(typeof created)["createdAt"]>().toEqualTypeOf<Date>();
+
+  const found = client.User.findMany({});
+  expectTypeOf<(typeof found)[number]["email"]>().toEqualTypeOf<string>();
+
+  const updated = client.User.update({ where: { id: 1 }, data: {} });
+  expectTypeOf<
+    NonNullable<typeof updated>["createdAt"]
+  >().toEqualTypeOf<Date>();
+}
+
+// 型安全は維持: 不正な値は依然エラー
+{
+  client.User.create({
+    data: {
+      email: "a@example.com",
+      // @ts-expect-error 数値カラムに raw でない文字列は不可
+      score: "=SUM(A1:A2)",
+    },
+  });
+  client.User.create({
+    data: {
+      email: "a@example.com",
+      // @ts-expect-error ブランドのないオブジェクトは不可
+      score: {},
+    },
+  });
+  client.User.update({
+    where: { id: 1 },
+    data: {
+      // @ts-expect-error boolean カラムに数値は不可
+      isActive: 1,
+    },
+  });
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -10,7 +10,28 @@ const getGassmaCommonTypes = (strict?: boolean) => {
   const skipDecls = strict ? getSkipDeclarations() : "";
   const sk = strict ? " | SkipValue" : "";
 
-  return `${skipDecls}  type RelationsConfig = Record<string, Record<string, unknown>>;
+  return `${skipDecls}  type RawValue = {
+    readonly __gassmaRawValueBrand: "Gassma.raw";
+  };
+
+  /**
+   * Writes the value to the cell as-is, skipping formula-injection escaping.
+   * A string starting with \`=\` therefore becomes a live spreadsheet formula.
+   *
+   * Susceptible to formula injection: never pass unsanitized user input.
+   *
+   * @example
+   * \`\`\`
+   * gassma.Report.create({
+   *   data: { title: userInput, total: Gassma.raw("=SUM(B2:B10)") },
+   * });
+   * \`\`\`
+   */
+  function raw(value: string): RawValue;
+
+  type RawAllowed<T> = { [K in keyof T]: T[K] | RawValue };
+
+  type RelationsConfig = Record<string, Record<string, unknown>>;
 
   type NumberOperation = {
     increment?: number;

--- a/packages/cli/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateMany.ts
@@ -1,3 +1,4 @@
+import { rawAllowedWrap } from "../util/rawAllowed";
 import { skipOptionalWrap } from "../util/skipUnion";
 
 const getOneGassmaCreateMany = (
@@ -6,7 +7,7 @@ const getOneGassmaCreateMany = (
   strict?: boolean,
 ) => {
   const elementType = skipOptionalWrap(
-    `Gassma${schemaName}${sheetName}Use`,
+    rawAllowedWrap(`Gassma${schemaName}${sheetName}Use`),
     strict,
   );
 

--- a/packages/cli/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateManyAndReturnData.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCreateMany/oneGassmaCreateManyAndReturnData.ts
@@ -1,3 +1,4 @@
+import { rawAllowedWrap } from "../util/rawAllowed";
 import { skipOptionalWrap, skipUnion } from "../util/skipUnion";
 
 const getOneGassmaCreateManyAndReturnData = (
@@ -7,7 +8,7 @@ const getOneGassmaCreateManyAndReturnData = (
 ) => {
   const sk = skipUnion(strict);
   const elementType = skipOptionalWrap(
-    `Gassma${schemaName}${sheetName}Use`,
+    rawAllowedWrap(`Gassma${schemaName}${sheetName}Use`),
     strict,
   );
   const selectType = `Gassma${schemaName}${sheetName}Select`;

--- a/packages/cli/src/generate/typeGenerate/util/buildCreateDataType.ts
+++ b/packages/cli/src/generate/typeGenerate/util/buildCreateDataType.ts
@@ -3,6 +3,7 @@ import type {
   RelationsConfig,
 } from "../../read/extractRelations";
 import { getNestedWriteFields } from "./getNestedWriteFields";
+import { rawAllowedWrap } from "./rawAllowed";
 import { skipOptionalWrap, skipUnion } from "./skipUnion";
 
 const buildFkXorPart = (
@@ -14,10 +15,10 @@ const buildFkXorPart = (
 ): string => {
   const sk = skipUnion(strict);
   const target = `Gassma${schemaName}${rel.to}`;
-  const targetCreate = skipOptionalWrap(`${target}Use`, strict);
+  const targetCreate = skipOptionalWrap(rawAllowedWrap(`${target}Use`), strict);
   const ops = `create?: ${targetCreate}${sk}; connect?: ${target}WhereUse${sk}; connectOrCreate?: { where: ${target}WhereUse; create: ${targetCreate} }${sk}`;
 
-  return `(Pick<${use}, "${rel.field}"> | { "${relationName}": { ${ops} } })`;
+  return `(${rawAllowedWrap(`Pick<${use}, "${rel.field}">`)} | { "${relationName}": { ${ops} } })`;
 };
 
 const buildCreateDataType = (
@@ -44,8 +45,11 @@ const buildCreateDataType = (
     .join(" | ");
   const baseType =
     fkRelationNames.length > 0
-      ? skipOptionalWrap(`Omit<${use}, ${fkFieldsUnion}>`, strict)
-      : skipOptionalWrap(use, strict);
+      ? skipOptionalWrap(
+          rawAllowedWrap(`Omit<${use}, ${fkFieldsUnion}>`),
+          strict,
+        )
+      : skipOptionalWrap(rawAllowedWrap(use), strict);
   const xorParts = fkRelationNames.map((name) =>
     buildFkXorPart(schemaName, use, name, modelRelations[name], strict),
   );

--- a/packages/cli/src/generate/typeGenerate/util/buildUpdateDataType.ts
+++ b/packages/cli/src/generate/typeGenerate/util/buildUpdateDataType.ts
@@ -26,8 +26,7 @@ const buildUpdateDataType = (
   const numOp = numberOperationPart(sheetContent);
   const sk = skipUnion(strict);
 
-  if (numOp === "" && sk === "") return `Partial<${use}>`;
-  return `Partial<{ [K in keyof ${use}]: ${use}[K]${numOp}${sk} }>`;
+  return `Partial<{ [K in keyof ${use}]: ${use}[K]${numOp} | Gassma.RawValue${sk} }>`;
 };
 
 export { buildUpdateDataType };

--- a/packages/cli/src/generate/typeGenerate/util/getNestedWriteFields.ts
+++ b/packages/cli/src/generate/typeGenerate/util/getNestedWriteFields.ts
@@ -3,6 +3,7 @@ import type {
   RelationsConfig,
 } from "../../read/extractRelations";
 import { buildUpdateDataType } from "./buildUpdateDataType";
+import { rawAllowedWrap } from "./rawAllowed";
 import { skipOptionalWrap, skipUnion } from "./skipUnion";
 
 type NestedWriteContext = "create" | "update";
@@ -22,11 +23,11 @@ const buildBaseOpTypes = (
   target: string,
   strict?: boolean,
 ): BaseOpTypes => {
-  const rawChildCreate =
+  const baseChildCreate =
     rel.type === "oneToMany" || rel.type === "oneToOne"
       ? `Omit<${target}Use, "${rel.reference}">`
       : `${target}Use`;
-  const childCreate = skipOptionalWrap(rawChildCreate, strict);
+  const childCreate = skipOptionalWrap(rawAllowedWrap(baseChildCreate), strict);
   const isList = isListRelation(rel.type);
   const createType = isList ? `${childCreate} | ${childCreate}[]` : childCreate;
   const connectType = isList

--- a/packages/cli/src/generate/typeGenerate/util/rawAllowed.ts
+++ b/packages/cli/src/generate/typeGenerate/util/rawAllowed.ts
@@ -1,0 +1,4 @@
+const rawAllowedWrap = (typeExpr: string): string =>
+  `Gassma.RawAllowed<${typeExpr}>`;
+
+export { rawAllowedWrap };


### PR DESCRIPTION
## 概要

core の `Gassma.raw`(akahoshi1421/gassma#181)への cli 追随です。生成される**書き込み入力型の全カラム**に `| Gassma.RawValue` をユニオンします。

```ts
gassma.Report.create({
  data: {
    title: userInput,                  // 通常どおり
    total: Gassma.raw("=SUM(B2:B10)"), // 数値カラムでも型が通る
  },
});
```

## 全カラムに足す理由(型で分岐しない)

**数式の主用途は数値カラム**(`=SUM` / `=COUNTIF`)であり、文字列カラムに限定すると機能が半減します。boolean(`=A1>5`)・Date(`=TODAY()`)も同様に formula の結果になり得るため、**一律**が正解と判断しました(ユーザー決定)。

## 適用範囲は書き込みデータ型のみ

| 型 | RawValue |
|---|---|
| create / createMany / createManyAndReturn / update / updateMany(AndReturn) / upsert(create・update) / **nested write の data** | **足す** |
| WhereUse・結果型・orderBy・select・omit・cursor | **足さない** |

**fixture 全文 diff で機械検証済み**: 挿入は namespace 宣言21行のみ、置換はすべて data 系の行、**削除ゼロ**。読み取り側は完全にバイト不変です。

## 型安全は維持

`RawValue` は nominal(ブランドプロパティ必須)なので、数値カラムへの `"文字列"` も `{}` も**依然エラー**。`unknown` にする案は「その列の型チェックが全部消える」ため不採用でした。

## namespace ミラーへの追加

`RawValue` 型 + `raw()` 宣言(core と同一の警告 JSDoc)+ **`RawAllowed<T>` ヘルパー**。生成 namespace は実行時の `Gassma` グローバルの型面を担っており、strict が `skip` を値宣言としてミラーしている前例に倣いました。`RawAllowed` は homomorphic mapped type なので `?` 修飾が保存され、`SkipOptional` とも既存どおり合成されます(全箇所にインライン展開すると生成物が肥大するため — SkipOptional と同じ流儀)。

## テスト

1299 → **1304**、型テスト 28→29ファイル(新規 raw.test-d: 全カラム型 / FK スカラー / createMany / upsert 両側 / nested write 4種 / strict skip 併用 / **where では型エラー** / **結果型に RawValue 非出現** / 誤った値は依然エラー)。Red 実測37件、実装 stash の逆検証で66件 fail。@ts-expect-error の空振りは typecheck の TS2578 で担保。全ゲート green。

## 次

gassma-test 追随(再生成・ambient 再同期・**実機で数式として書かれるかの確認**)→ reference。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtxX