### PR TITLE
fix: let the five operations Prisma allows be called with no argument

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaController/oneGassmaController";
+
+describe("getOneGassmaController no-arg overloads", () => {
+  const result = getOneGassmaController("", "User");
+  const resNoArg = `GassmaUserFindResult<unknown, unknown, unknown, GO, O, CMap>`;
+
+  it("should allow findMany without arguments", () => {
+    expect(result).toContain(`findMany(): ${resNoArg}[];`);
+  });
+
+  it("should allow findFirst without arguments", () => {
+    expect(result).toContain(`findFirst(): ${resNoArg} | null;`);
+  });
+
+  it("should allow findFirstOrThrow without arguments", () => {
+    expect(result).toContain(`findFirstOrThrow(): ${resNoArg};`);
+  });
+
+  it("should allow count without arguments", () => {
+    expect(result).toContain("count(): number;");
+  });
+
+  it("should allow deleteMany without arguments", () => {
+    expect(result).toContain("deleteMany(): DeleteManyReturn;");
+  });
+
+  it("should keep the argument-taking signatures next to the no-arg overloads", () => {
+    expect(result).toContain(
+      `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T)`,
+    );
+    expect(result).toContain("count(coutData: GassmaUserCountData): number;");
+    expect(result).toContain(
+      "deleteMany(deleteData: GassmaUserDeleteData): DeleteManyReturn;",
+    );
+  });
+
+  it("should prefix schema name in no-arg return types", () => {
+    const prefixed = getOneGassmaController("Hoge", "User");
+    expect(prefixed).toContain(
+      "findMany(): GassmaHogeUserFindResult<unknown, unknown, unknown, GO, O, CMap>[];",
+    );
+  });
+
+  it("should not add no-arg overloads to any other operation", () => {
+    expect(result).not.toContain("create():");
+    expect(result).not.toContain("createMany():");
+    expect(result).not.toContain("createManyAndReturn():");
+    expect(result).not.toContain("update():");
+    expect(result).not.toContain("updateMany():");
+    expect(result).not.toContain("updateManyAndReturn():");
+    expect(result).not.toContain("upsert():");
+    expect(result).not.toContain("delete():");
+    expect(result).not.toContain("aggregate():");
+    expect(result).not.toContain("groupBy():");
+  });
+});

--- a/packages/cli/src/__test__/types/query/optionalArgs.test-d.ts
+++ b/packages/cli/src/__test__/types/query/optionalArgs.test-d.ts
@@ -1,0 +1,112 @@
+import { expectTypeOf } from "vitest";
+import { GassmaClient } from "../__generated__/client";
+import type { GassmaClient as GassmaStrictClient } from "../__generated__/clientStrict";
+
+declare const client: GassmaClient;
+declare const strictClient: GassmaStrictClient;
+
+// findMany / findFirst / findFirstOrThrow / count / deleteMany は引数なしで呼べ、
+// 戻り値は {} を渡した場合と同一
+{
+  expectTypeOf(client.User.findMany()).toEqualTypeOf(client.User.findMany({}));
+  expectTypeOf(client.User.findFirst()).toEqualTypeOf(
+    client.User.findFirst({}),
+  );
+  expectTypeOf(client.User.findFirstOrThrow()).toEqualTypeOf(
+    client.User.findFirstOrThrow({}),
+  );
+  expectTypeOf(client.User.count()).toEqualTypeOf(client.User.count({}));
+  expectTypeOf(client.User.deleteMany()).toEqualTypeOf(
+    client.User.deleteMany({}),
+  );
+  expectTypeOf(client.User.count()).toEqualTypeOf<number>();
+  expectTypeOf(client.User.deleteMany().count).toEqualTypeOf<number>();
+}
+
+// 引数なし findMany の行は全フィールドを持つ(結果型が退化しない)
+{
+  const rows = client.User.findMany();
+  expectTypeOf(rows[0].id).toEqualTypeOf<number>();
+  expectTypeOf(rows[0].email).toEqualTypeOf<string>();
+  const found = client.User.findFirstOrThrow();
+  expectTypeOf(found.age).toEqualTypeOf<number | null>();
+}
+
+// globalOmit は引数なし呼び出しにも効く
+{
+  const omitClient = new GassmaClient({ omit: { User: { email: true } } });
+  const rows = omitClient.User.findMany();
+  expectTypeOf(rows).toEqualTypeOf(omitClient.User.findMany({}));
+  expectTypeOf(rows[0]).not.toHaveProperty("email");
+  expectTypeOf(rows[0].id).toEqualTypeOf<number>();
+}
+
+// $extends の result 拡張後(CMap が非空)でも引数なしで呼べ、算出フィールドも付く
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+  const rows = extended.User.findMany();
+  expectTypeOf(rows).toEqualTypeOf(extended.User.findMany({}));
+  expectTypeOf(rows[0].fullName).toEqualTypeOf<string>();
+  expectTypeOf(extended.User.findFirst()).toEqualTypeOf(
+    extended.User.findFirst({}),
+  );
+  expectTypeOf(extended.User.count()).toEqualTypeOf<number>();
+  expectTypeOf(extended.User.deleteMany().count).toEqualTypeOf<number>();
+}
+
+// $transaction のトランザクションクライアントでも引数なしで呼べる
+{
+  client.$transaction((tx) => {
+    expectTypeOf(tx.User.findMany()).toEqualTypeOf(tx.User.findMany({}));
+    expectTypeOf(tx.User.findFirst()).toEqualTypeOf(tx.User.findFirst({}));
+    return tx.User.count();
+  });
+}
+
+// strictUndefinedChecks 有効時のクライアントでも5操作は引数なしで呼べる
+{
+  expectTypeOf(strictClient.User.findMany()).toEqualTypeOf(
+    strictClient.User.findMany({}),
+  );
+  expectTypeOf(strictClient.User.findFirst()).toEqualTypeOf(
+    strictClient.User.findFirst({}),
+  );
+  expectTypeOf(strictClient.User.findFirstOrThrow()).toEqualTypeOf(
+    strictClient.User.findFirstOrThrow({}),
+  );
+  expectTypeOf(strictClient.User.count()).toEqualTypeOf<number>();
+  expectTypeOf(strictClient.User.deleteMany().count).toEqualTypeOf<number>();
+}
+
+// 上記5操作以外は引数なしでは呼べない
+{
+  // @ts-expect-error create は data 必須
+  client.User.create();
+  // @ts-expect-error createMany は data 必須
+  client.User.createMany();
+  // @ts-expect-error createManyAndReturn は data 必須
+  client.User.createManyAndReturn();
+  // @ts-expect-error update は data 必須
+  client.User.update();
+  // @ts-expect-error updateMany は data 必須
+  client.User.updateMany();
+  // @ts-expect-error updateManyAndReturn は data 必須
+  client.User.updateManyAndReturn();
+  // @ts-expect-error upsert は where / create / update 必須
+  client.User.upsert();
+  // @ts-expect-error delete は where 必須
+  client.User.delete();
+  // @ts-expect-error aggregate は引数必須
+  client.User.aggregate();
+  // @ts-expect-error groupBy は by 必須
+  client.User.groupBy();
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -3,6 +3,7 @@ const getOneGassmaController = (schemaName: string, sheetName: string) => {
   const fr = `${self}FindResult`;
   const c = `Gassma.At<CMap, "${sheetName}">`;
   const res = `${fr}<T["select"], T["include"], T["omit"], GO, O, CMap>`;
+  const resNoArg = `${fr}<unknown, unknown, unknown, GO, O, CMap>`;
   const arg = (dataSuffix: string) =>
     `T extends ${self}${dataSuffix} & Gassma.ComputedArgs<${c}>`;
 
@@ -20,16 +21,21 @@ export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, CMap
   createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: T): ${res}[];
   create<${arg("CreateData")}>(createdData: T): ${res};
   findFirst<${arg("FindFirstData")}>(findData: T): ${res} | null;
+  findFirst(): ${resNoArg} | null;
   findFirstOrThrow<${arg("FindFirstData")}>(findData: T): ${res};
+  findFirstOrThrow(): ${resNoArg};
   findMany<${arg("FindManyData")}>(findData: T): ${res}[];
+  findMany(): ${resNoArg}[];
   update<${arg("UpdateSingleData")}>(updateData: T): ${res} | null;
   updateMany(updateData: ${self}UpdateData): UpdateManyReturn;
   updateManyAndReturn(updateData: ${self}UpdateData): ${fr}<undefined, undefined, undefined, GO, O, CMap>[];
   upsert<${arg("UpsertSingleData")}>(upsertData: T): ${res};
   delete<${arg("DeleteSingleData")}>(deleteData: T): ${res} | null;
   deleteMany(deleteData: ${self}DeleteData): DeleteManyReturn;
+  deleteMany(): DeleteManyReturn;
   aggregate<T extends ${self}AggregateData>(aggregateData: T): ${self}AggregateResult<T>;
   count(coutData: ${self}CountData): number;
+  count(): number;
   groupBy<T extends ${self}GroupByData>(groupByData: T): ${self}GroupByResult<T>[];
 }
 `;


### PR DESCRIPTION
## 直す問題

Prisma では **`findMany()` / `findFirst()` / `findFirstOrThrow()` / `count()` / `deleteMany()` を引数なしで呼べます**(実測。`findMany()` は全件、`deleteMany()` は**全件削除**)。

生成型はこれらすべてで引数を必須にしていたため、`findMany()` と書くと型エラーになっていました。

```
error TS2554: Expected 1 arguments, but got 0.
```

**ランタイム側は本体 gassma#182 で対応しています。**

## やったこと

5操作に**引数なしのオーバーロードを追加**しました(既存の行は1バイトも変えていません)。

```ts
findMany<T extends ...>(findData: T): FindResult<T["select"], T["include"], T["omit"], GO, O, CMap>[];  // 既存(不変)
findMany(): FindResult<unknown, unknown, unknown, GO, O, CMap>[];                                        // 追加
```

生成物の実物:

```ts
findFirst(): GassmaUserFindResult<unknown, unknown, unknown, GO, O, CMap> | null;
findFirstOrThrow(): GassmaUserFindResult<unknown, unknown, unknown, GO, O, CMap>;
findMany(): GassmaUserFindResult<unknown, unknown, unknown, GO, O, CMap>[];
deleteMany(): DeleteManyReturn;
count(): number;
```

**他の操作は完全に従来どおり**です。

## なぜオーバーロードか(既存シグネチャを緩めなかった理由)

既存テストが**現行シグネチャを完全な文字列で固定**しています。既存行を書き換えると必ず落ちるため、行を残したままオーバーロードを足す形にしました。引数を渡した呼び出しは**従来と同一のシグネチャに解決**されます(引数の数が排他なので解決も一意)。

## 戻り値が `unknown` である理由

`findMany({})` を実測すると、TypeScript は `T` を `{}` と推論し、欠けているプロパティの `T["select"]` を **`unknown`** にします。同じ `unknown` を書けば、**引数なしと `{}` 渡しが同一の型**になります。

型テストで **plain / globalOmit / `$extends` result 拡張後 / `$transaction` の tx / strict クライアント**の5系統について、`{}` 渡しとの型の一致を固定しています。

## `$extends` の query フック型は変えていません

あれは利用者が**受け取る** args の型で、変更すると既存のフック実装の型が変わるためです。省略時にフックへ何が渡るかはランタイム(本体)の管轄です。

`$extends` 後のクライアントと `$transaction` の tx は同じ Controller 型を再利用するため、今回の変更が自動的に波及します(型テストで確認済み)。

## 検証

- テスト: **1307 passed**(既存 1299 は**1件も書き換えず**全通過、新規8件)
- 型テスト・typecheck・build(tsdown)すべて通過、変更3ファイルの biome 指摘ゼロ
- **生成物を実際に確認**: `client.d.ts` / `clientStrict.d.ts` とも**9モデル全部**に5操作のオーバーロードがあり、**他の操作には1件も無い**ことを確認
- TDD: 実装前に RED(ユニット6件失敗・型テストは TS2554)を確認してから実装

## 既知の制限

**`findMany(undefined)` のように明示的に `undefined` を渡す形は型エラーのまま**です(Prisma は `args?:` なので通ります)。通すには既存の固定行を変える必要があるため見送りました。必要なら別途対応します。

なおランタイム側(本体 #182)は `findMany(undefined)` も `{}` として扱うので、**実行時は問題ありません**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)