### PR TITLE
feat: add db push command that skips the migration trail

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -158,6 +158,19 @@ Generate a GAS function that syncs spreadsheet sheets with your schema. It write
 |`--config <path>`|Custom path to your GASsma config file|
 |`--accept-data-loss`|Delete sheets and columns that are not in the schema|
 
+### db push
+
+Generate a GAS function that syncs spreadsheet sheets with your schema, like `migrate`, but without recording a migration trail. It writes the same runnable stub `gassma-migration.js` into the output directory and never touches the `migrations/` directory. Use it when you do not need a migration history. `clasp push` is not run automatically: push the stub yourself, then run the `gassmaMigrate` function once in the Apps Script editor.
+
+#### options
+
+|name|description|
+|--|--|
+|`--output <dir>`|Directory to write gassma-migration.js (defaults to rootDir in .clasp.json)|
+|`--schema <path>`|Path to a specific .prisma file to push from|
+|`--config <path>`|Custom path to your GASsma config file|
+|`--accept-data-loss`|Delete sheets and columns that are not in the schema|
+
 ### bootstrap
 
 Interactively set up a local GAS development environment (clasp + esbuild + TypeScript + GASsma). It creates an Apps Script project via clasp, registers the GASsma library, generates project files (`package.json`, `esbuild.mjs`, `tsconfig.json`, `.gitignore`, a sample `src/index.ts`), runs `gassma init`, and installs dependencies.

--- a/packages/cli/docs/README.ja.md
+++ b/packages/cli/docs/README.ja.md
@@ -158,6 +158,19 @@ function myFunction() {
 |`--config <path>`|GASsma config ファイルのカスタムパス|
 |`--accept-data-loss`|スキーマに無いシート・列を削除|
 
+### db push
+
+`migrate` と同様に、スキーマに合わせてスプレッドシートのシートを同期する GAS 関数を生成しますが、証跡は記録しません。同じ実行用スタブ `gassma-migration.js` を出力ディレクトリに生成し、`migrations/` ディレクトリには一切触れません。マイグレーション履歴が不要な場合に使ってください。`clasp push` は自動実行されません。スタブを push した後、Apps Script エディタで `gassmaMigrate` 関数を 1 回実行してください。
+
+#### オプション
+
+|名前|説明|
+|--|--|
+|`--output <dir>`|gassma-migration.js の出力先ディレクトリ（デフォルトは .clasp.json の rootDir）|
+|`--schema <path>`|同期対象の `.prisma` ファイルのパス|
+|`--config <path>`|GASsma config ファイルのカスタムパス|
+|`--accept-data-loss`|スキーマに無いシート・列を削除|
+
 ### bootstrap
 
 GAS のローカル開発環境（clasp + esbuild + TypeScript + GASsma）を対話形式でセットアップします。clasp で Apps Script プロジェクトを作成し、GASsma ライブラリを登録し、プロジェクトファイル（`package.json`・`esbuild.mjs`・`tsconfig.json`・`.gitignore`・サンプルの `src/index.ts`）を生成して `gassma init` を実行し、依存関係をインストールします。

--- a/packages/cli/src/__test__/command/dbPushFlag.test.ts
+++ b/packages/cli/src/__test__/command/dbPushFlag.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const projectRoot = path.resolve(__dirname, "../../..");
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+const commandTs = path.join(projectRoot, "src", "command.ts");
+
+describe("gassma db push (e2e)", () => {
+  const ctx = { tmpDir: "" };
+
+  beforeEach(() => {
+    ctx.tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "gassma-db-push-e2e-")),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(ctx.tmpDir, { recursive: true, force: true });
+  });
+
+  const runCli = (args: string[]): string =>
+    execFileSync(process.execPath, [tsxCli, commandTs, ...args], {
+      cwd: ctx.tmpDir,
+      stdio: "pipe",
+    }).toString();
+
+  const writeSchema = (): void => {
+    fs.mkdirSync(path.join(ctx.tmpDir, "gassma"), { recursive: true });
+    fs.writeFileSync(
+      path.join(ctx.tmpDir, "gassma", "schema.prisma"),
+      "model User {\n  id   Int    @id\n  name String\n}\n",
+    );
+  };
+
+  it(
+    "should list the push command in the db help output",
+    { timeout: 120_000 },
+    () => {
+      const output = runCli(["db", "--help"]);
+
+      expect(output).toContain("push");
+    },
+  );
+
+  it(
+    "should list the db push options in the help output",
+    { timeout: 120_000 },
+    () => {
+      const output = runCli(["db", "push", "--help"]);
+
+      expect(output).toContain("--output");
+      expect(output).toContain("--schema");
+      expect(output).toContain("--config");
+      expect(output).toContain("--accept-data-loss");
+      expect(output).not.toContain("--name");
+    },
+  );
+
+  it(
+    "should generate the stub without a migrations directory end to end",
+    { timeout: 120_000 },
+    () => {
+      writeSchema();
+
+      const output = runCli(["db", "push", "--output", "./dist"]);
+
+      expect(output).toContain("gassma-migration.js");
+      const stub = fs.readFileSync(
+        path.join(ctx.tmpDir, "dist", "gassma-migration.js"),
+        "utf-8",
+      );
+      expect(stub).toContain("function gassmaMigrate()");
+      expect(fs.existsSync(path.join(ctx.tmpDir, "gassma", "migrations"))).toBe(
+        false,
+      );
+    },
+  );
+
+  it(
+    "should include acceptDataLoss in the stub when --accept-data-loss is given",
+    { timeout: 120_000 },
+    () => {
+      writeSchema();
+
+      runCli(["db", "push", "--output", "./dist", "--accept-data-loss"]);
+
+      const stub = fs.readFileSync(
+        path.join(ctx.tmpDir, "dist", "gassma-migration.js"),
+        "utf-8",
+      );
+      expect(stub).toContain("acceptDataLoss: true,");
+    },
+  );
+
+  it("should reject the --name option", { timeout: 120_000 }, () => {
+    writeSchema();
+
+    expect(() =>
+      runCli(["db", "push", "--output", "./dist", "--name", "init"]),
+    ).toThrow(/unknown option '--name'/);
+  });
+});

--- a/packages/cli/src/__test__/db/dbPushCommand.test.ts
+++ b/packages/cli/src/__test__/db/dbPushCommand.test.ts
@@ -121,7 +121,7 @@ describe("dbPush", () => {
     dbPush({ output: "./out", acceptDataLoss: true });
 
     expect(getLoggedOutput()).toContain(
-      "deletes sheets and columns that are not in the schema",
+      'Running the "gassmaMigrate" function will delete sheets and columns that are not in the schema.',
     );
   });
 
@@ -131,7 +131,7 @@ describe("dbPush", () => {
     dbPush({ output: "./out" });
 
     expect(getLoggedOutput()).not.toContain(
-      "deletes sheets and columns that are not in the schema",
+      "will delete sheets and columns that are not in the schema",
     );
   });
 

--- a/packages/cli/src/__test__/db/dbPushCommand.test.ts
+++ b/packages/cli/src/__test__/db/dbPushCommand.test.ts
@@ -1,0 +1,204 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dbPush } from "../../db/dbPushCommand";
+import { migrate } from "../../migrate/migrateCommand";
+
+const schemaWithDatasource = `
+datasource db {
+  provider = "gassma"
+  url      = "https://docs.google.com/spreadsheets/d/abc123/edit"
+}
+
+model User {
+  id   Int    @id
+  name String
+}
+`;
+
+const fixedDeps = {
+  now: () => new Date(Date.UTC(2026, 6, 29, 4, 5, 6)),
+};
+
+const writeSchema = (schema: string): void => {
+  fs.mkdirSync("gassma", { recursive: true });
+  fs.writeFileSync(path.join("gassma", "schema.prisma"), schema);
+};
+
+const getLoggedOutput = (): string =>
+  vi
+    .mocked(console.log)
+    .mock.calls.map((call) => call.join(" "))
+    .join("\n");
+
+describe("dbPush", () => {
+  const ctx = { tmpDir: "", originalCwd: "" };
+
+  beforeEach(() => {
+    ctx.tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "gassma-db-push-cmd-")),
+    );
+    ctx.originalCwd = process.cwd();
+    process.chdir(ctx.tmpDir);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(ctx.originalCwd);
+    fs.rmSync(ctx.tmpDir, { recursive: true, force: true });
+  });
+
+  it("should write gassma-migration.js into the --output directory", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out" });
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toBe(`function gassmaMigrate() {
+  Gassma.migrateSheets({
+    spreadsheetId: "abc123",
+    models: [
+      { name: "User", columns: ["id", "name"] }
+    ]
+  });
+}
+`);
+  });
+
+  it("should write the same stub content as migrate", () => {
+    writeSchema(schemaWithDatasource);
+
+    migrate({ output: "./migrate-out" }, fixedDeps);
+    dbPush({ output: "./push-out" });
+
+    expect(
+      fs.readFileSync(path.join("push-out", "gassma-migration.js"), "utf-8"),
+    ).toBe(
+      fs.readFileSync(path.join("migrate-out", "gassma-migration.js"), "utf-8"),
+    );
+  });
+
+  it("should not create a migrations directory even when run twice", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out" });
+    dbPush({ output: "./out" });
+
+    expect(fs.existsSync(path.join("gassma", "migrations"))).toBe(false);
+    expect(fs.existsSync("migrations")).toBe(false);
+    expect(fs.readdirSync("gassma")).toEqual(["schema.prisma"]);
+  });
+
+  it("should include acceptDataLoss between spreadsheetId and models when requested", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out", acceptDataLoss: true });
+
+    const content = fs.readFileSync(
+      path.join("out", "gassma-migration.js"),
+      "utf-8",
+    );
+    expect(content).toBe(`function gassmaMigrate() {
+  Gassma.migrateSheets({
+    spreadsheetId: "abc123",
+    acceptDataLoss: true,
+    models: [
+      { name: "User", columns: ["id", "name"] }
+    ]
+  });
+}
+`);
+  });
+
+  it("should warn about deletions when acceptDataLoss is requested", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out", acceptDataLoss: true });
+
+    expect(getLoggedOutput()).toContain(
+      "deletes sheets and columns that are not in the schema",
+    );
+  });
+
+  it("should not warn about deletions without acceptDataLoss", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out" });
+
+    expect(getLoggedOutput()).not.toContain(
+      "deletes sheets and columns that are not in the schema",
+    );
+  });
+
+  it("should resolve the output directory from rootDir in .clasp.json", () => {
+    writeSchema(schemaWithDatasource);
+    fs.writeFileSync(".clasp.json", JSON.stringify({ rootDir: "./dist" }));
+
+    dbPush();
+
+    expect(fs.existsSync(path.join("dist", "gassma-migration.js"))).toBe(true);
+  });
+
+  it("should throw when no output directory can be resolved", () => {
+    writeSchema(schemaWithDatasource);
+
+    expect(() => dbPush()).toThrow("--output");
+  });
+
+  it("should not print the already-in-sync message when run twice", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out" });
+    dbPush({ output: "./out" });
+
+    const logged = getLoggedOutput();
+    expect(logged).not.toContain("Already in sync");
+    expect(logged).not.toContain("no new migration recorded");
+  });
+
+  it("should rewrite gassma-migration.js on every run", () => {
+    writeSchema(schemaWithDatasource);
+    dbPush({ output: "./out" });
+    fs.rmSync(path.join("out", "gassma-migration.js"));
+
+    dbPush({ output: "./out" });
+
+    expect(fs.existsSync(path.join("out", "gassma-migration.js"))).toBe(true);
+  });
+
+  it("should print next steps after generating", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out" });
+
+    const logged = getLoggedOutput();
+    expect(logged).toContain("clasp push");
+    expect(logged).toContain("gassmaMigrate");
+  });
+
+  it("should announce the sync script instead of a migration", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out" });
+
+    const logged = getLoggedOutput();
+    expect(logged).toContain("✅ Sync script generated");
+    expect(logged).not.toContain("Migration generated");
+  });
+
+  it("should keep migrate recording a trail after db push", () => {
+    writeSchema(schemaWithDatasource);
+
+    dbPush({ output: "./out" });
+    migrate({ output: "./out" }, fixedDeps);
+
+    expect(fs.readdirSync(path.join("gassma", "migrations"))).toEqual([
+      "20260729040506",
+    ]);
+  });
+});

--- a/packages/cli/src/__test__/migrate/migrateCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateCommand.test.ts
@@ -517,7 +517,7 @@ model Post {
       .mock.calls.map((call) => call.join(" "))
       .join("\n");
     expect(logged).toContain(
-      "deletes sheets and columns that are not in the schema",
+      'Running the "gassmaMigrate" function will delete sheets and columns that are not in the schema.',
     );
   });
 
@@ -531,7 +531,7 @@ model Post {
       .mock.calls.map((call) => call.join(" "))
       .join("\n");
     expect(logged).not.toContain(
-      "deletes sheets and columns that are not in the schema",
+      "will delete sheets and columns that are not in the schema",
     );
   });
 });

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { bootstrap } from "./bootstrap/bootstrapCommand";
+import { dbPush } from "./db/dbPushCommand";
 import { debugCommand } from "./debug/debugCommand";
 import { ArgumentError } from "./error/mainError";
 import { format } from "./format/formatCommand";
@@ -79,6 +80,33 @@ program
   .action((options) => {
     migrate({
       name: options.name,
+      output: options.output,
+      schema: options.schema,
+      config: options.config,
+      acceptDataLoss: options.acceptDataLoss,
+    });
+  });
+
+const db = program
+  .command("db")
+  .description("Manage your spreadsheet sheets during development");
+
+db.command("push")
+  .description(
+    "Generate a GAS function that syncs spreadsheet sheets with your schema, without recording a migration",
+  )
+  .option(
+    "--output <dir>",
+    "Directory to write gassma-migration.js (defaults to rootDir in .clasp.json)",
+  )
+  .option("--schema <path>", "Path to a specific .prisma file to push from")
+  .option("--config <path>", "Custom path to your GASsma config file")
+  .option(
+    "--accept-data-loss",
+    "Delete sheets and columns that are not in the schema",
+  )
+  .action((options) => {
+    dbPush({
       output: options.output,
       schema: options.schema,
       config: options.config,

--- a/packages/cli/src/db/dbPushCommand.ts
+++ b/packages/cli/src/db/dbPushCommand.ts
@@ -1,0 +1,17 @@
+import { generateMigrationStub } from "../migrate/generateMigrationStub";
+import type { MigrationStubOptions } from "../migrate/generateMigrationStub";
+import { printNextSteps } from "../migrate/printNextSteps";
+
+type DbPushOptions = MigrationStubOptions;
+
+function dbPush(options?: DbPushOptions) {
+  const stub = generateMigrationStub(options);
+  printNextSteps(
+    stub.stubPath,
+    "✅ Sync script generated",
+    stub.acceptDataLoss,
+  );
+}
+
+export { dbPush };
+export type { DbPushOptions };

--- a/packages/cli/src/migrate/generateMigrationStub.ts
+++ b/packages/cli/src/migrate/generateMigrationStub.ts
@@ -1,0 +1,106 @@
+import fs from "fs";
+import path from "path";
+import { extractSpreadsheetId } from "../config/extractSpreadsheetId";
+import { filterOutputFiles } from "../config/filterOutputFiles";
+import { loadConfig } from "../config/loadConfig";
+import { logLoadedConfig } from "../config/logLoadedConfig";
+import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
+import { NoModelsError } from "../error/mainError";
+import { findBaseDir } from "../generate/generate";
+import { mergeSchemaFiles } from "../generate/mergeSchemaFiles";
+import { extractDatasourceUrl } from "../generate/read/extractDatasourceUrl";
+import { readTemplate } from "../util/readTemplate";
+import { buildMigrateModels } from "./buildMigrateModels";
+import { patchMigrationScript } from "./patchMigrationScript";
+import type { MigrateSheetsDefinition } from "./patchMigrationScript";
+import { resolveOutputDir } from "./resolveOutputDir";
+import { resolveUserSymbol } from "./resolveUserSymbol";
+
+const STUB_FILE_NAME = "gassma-migration.js";
+
+type MigrationStubOptions = {
+  output?: string;
+  schema?: string;
+  config?: string;
+  acceptDataLoss?: boolean;
+};
+
+type MigrationStubResult = {
+  stubPath: string;
+  content: string;
+  baseDir: string;
+  acceptDataLoss: boolean;
+};
+
+const resolveSpreadsheetId = (
+  schemaText: string,
+  configUrl: string | undefined,
+): string | undefined => {
+  const fromConfig = extractSpreadsheetId(configUrl);
+  const fromSchema = extractDatasourceUrl(schemaText);
+  const resolved = extractSpreadsheetId(fromSchema ?? fromConfig);
+  return resolved === undefined || resolved === "" ? undefined : resolved;
+};
+
+const buildDefinition = (
+  schemaText: string,
+  configUrl: string | undefined,
+  schemaLocation: string,
+  acceptDataLoss: boolean,
+): MigrateSheetsDefinition => {
+  const models = buildMigrateModels(schemaText);
+  if (models.length === 0) throw new NoModelsError(schemaLocation);
+
+  const spreadsheetId = resolveSpreadsheetId(schemaText, configUrl);
+  return {
+    ...(spreadsheetId === undefined ? {} : { spreadsheetId }),
+    ...(acceptDataLoss ? { acceptDataLoss: true } : {}),
+    models,
+  };
+};
+
+const writeMigrationStub = (outputDir: string, content: string): string => {
+  fs.mkdirSync(outputDir, { recursive: true });
+  const stubPath = path.join(outputDir, STUB_FILE_NAME);
+  fs.writeFileSync(stubPath, content, "utf-8");
+  console.log(`📄 Wrote ${stubPath}`);
+  return stubPath;
+};
+
+const generateMigrationStub = (
+  options?: MigrationStubOptions,
+): MigrationStubResult => {
+  const allFiles = resolveSchemaFiles({
+    schema: options?.schema,
+    config: options?.config,
+  });
+  const baseDir = findBaseDir(allFiles.map((f) => f.filePath));
+  const files = filterOutputFiles(allFiles, baseDir);
+  const loaded = loadConfig(options?.config);
+  logLoadedConfig(loaded?.filePath);
+
+  const schemaText = mergeSchemaFiles(files.map((f) => f.filePath));
+  const schemaLocation = path.resolve(
+    files.length === 1 ? files[0].filePath : baseDir,
+  );
+  const acceptDataLoss = options?.acceptDataLoss === true;
+  const definition = buildDefinition(
+    schemaText,
+    loaded?.config.datasource?.url,
+    schemaLocation,
+    acceptDataLoss,
+  );
+
+  const outputDir = resolveOutputDir(options?.output, process.cwd());
+  const userSymbol = resolveUserSymbol(outputDir);
+  const content = patchMigrationScript(
+    readTemplate("gassma-migration.js.template"),
+    { userSymbol, definition },
+  );
+
+  const stubPath = writeMigrationStub(outputDir, content);
+  return { stubPath, content, baseDir, acceptDataLoss };
+};
+
+export { STUB_FILE_NAME, generateMigrationStub };
+export type { MigrationStubOptions, MigrationStubResult };

--- a/packages/cli/src/migrate/migrateCommand.ts
+++ b/packages/cli/src/migrate/migrateCommand.ts
@@ -1,25 +1,11 @@
-import fs from "fs";
 import path from "path";
-import { extractSpreadsheetId } from "../config/extractSpreadsheetId";
-import { filterOutputFiles } from "../config/filterOutputFiles";
-import { loadConfig } from "../config/loadConfig";
-import { logLoadedConfig } from "../config/logLoadedConfig";
-import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
-import { NoModelsError } from "../error/mainError";
-import { findBaseDir } from "../generate/generate";
-import { mergeSchemaFiles } from "../generate/mergeSchemaFiles";
-import { extractDatasourceUrl } from "../generate/read/extractDatasourceUrl";
-import { readTemplate } from "../util/readTemplate";
-import { buildMigrateModels } from "./buildMigrateModels";
+import { STUB_FILE_NAME, generateMigrationStub } from "./generateMigrationStub";
 import { buildMigrationDirName } from "./migrationDirName";
 import {
   findLatestMigrationContent,
   writeMigrationTrail,
 } from "./migrationTrail";
-import { patchMigrationScript } from "./patchMigrationScript";
-import type { MigrateSheetsDefinition } from "./patchMigrationScript";
-import { resolveOutputDir } from "./resolveOutputDir";
-import { resolveUserSymbol } from "./resolveUserSymbol";
+import { printNextSteps } from "./printNextSteps";
 
 type MigrateOptions = {
   name?: string;
@@ -34,43 +20,6 @@ type MigrateDeps = {
 };
 
 const defaultDeps: MigrateDeps = { now: () => new Date() };
-
-const STUB_FILE_NAME = "gassma-migration.js";
-
-const resolveSpreadsheetId = (
-  schemaText: string,
-  configUrl: string | undefined,
-): string | undefined => {
-  const fromConfig = extractSpreadsheetId(configUrl);
-  const fromSchema = extractDatasourceUrl(schemaText);
-  const resolved = extractSpreadsheetId(fromSchema ?? fromConfig);
-  return resolved === undefined || resolved === "" ? undefined : resolved;
-};
-
-const buildDefinition = (
-  schemaText: string,
-  configUrl: string | undefined,
-  schemaLocation: string,
-  acceptDataLoss: boolean,
-): MigrateSheetsDefinition => {
-  const models = buildMigrateModels(schemaText);
-  if (models.length === 0) throw new NoModelsError(schemaLocation);
-
-  const spreadsheetId = resolveSpreadsheetId(schemaText, configUrl);
-  return {
-    ...(spreadsheetId === undefined ? {} : { spreadsheetId }),
-    ...(acceptDataLoss ? { acceptDataLoss: true } : {}),
-    models,
-  };
-};
-
-const writeMigrationStub = (outputDir: string, content: string): string => {
-  fs.mkdirSync(outputDir, { recursive: true });
-  const stubPath = path.join(outputDir, STUB_FILE_NAME);
-  fs.writeFileSync(stubPath, content, "utf-8");
-  console.log(`📄 Wrote ${stubPath}`);
-  return stubPath;
-};
 
 const recordMigration = (
   baseDir: string,
@@ -92,60 +41,20 @@ const recordMigration = (
   return true;
 };
 
-const printNextSteps = (
-  stubPath: string,
-  recorded: boolean,
-  acceptDataLoss: boolean,
-): void => {
-  const headline = recorded
+const buildHeadline = (recorded: boolean): string =>
+  recorded
     ? "✅ Migration generated"
     : `✅ Refreshed ${STUB_FILE_NAME} (no new migration recorded)`;
-  console.log(`\n${headline}\n`);
-  if (acceptDataLoss)
-    console.log(
-      "⚠️ This migration deletes sheets and columns that are not in the schema.\n",
-    );
-  console.log("Next steps:");
-  console.log(`  1. Run "clasp push" (or "npm run push") to upload ${STUB_FILE_NAME}
-  2. In the Apps Script editor, run the "gassmaMigrate" function once`);
-  console.log(
-    '\nNote: push with "clasp push" directly. A full clean build (e.g. "npm run deploy")' +
-      ` may wipe the output directory and delete ${stubPath} before it is pushed.`,
-  );
-};
 
 function migrate(options?: MigrateOptions, deps: MigrateDeps = defaultDeps) {
-  const allFiles = resolveSchemaFiles({
-    schema: options?.schema,
-    config: options?.config,
-  });
-  const baseDir = findBaseDir(allFiles.map((f) => f.filePath));
-  const files = filterOutputFiles(allFiles, baseDir);
-  const loaded = loadConfig(options?.config);
-  logLoadedConfig(loaded?.filePath);
-
-  const schemaText = mergeSchemaFiles(files.map((f) => f.filePath));
-  const schemaLocation = path.resolve(
-    files.length === 1 ? files[0].filePath : baseDir,
+  const stub = generateMigrationStub(options);
+  const recorded = recordMigration(
+    stub.baseDir,
+    stub.content,
+    options?.name,
+    deps,
   );
-  const acceptDataLoss = options?.acceptDataLoss === true;
-  const definition = buildDefinition(
-    schemaText,
-    loaded?.config.datasource?.url,
-    schemaLocation,
-    acceptDataLoss,
-  );
-
-  const outputDir = resolveOutputDir(options?.output, process.cwd());
-  const userSymbol = resolveUserSymbol(outputDir);
-  const content = patchMigrationScript(
-    readTemplate("gassma-migration.js.template"),
-    { userSymbol, definition },
-  );
-
-  const stubPath = writeMigrationStub(outputDir, content);
-  const recorded = recordMigration(baseDir, content, options?.name, deps);
-  printNextSteps(stubPath, recorded, acceptDataLoss);
+  printNextSteps(stub.stubPath, buildHeadline(recorded), stub.acceptDataLoss);
 }
 
 export { migrate };

--- a/packages/cli/src/migrate/printNextSteps.ts
+++ b/packages/cli/src/migrate/printNextSteps.ts
@@ -1,0 +1,22 @@
+import { STUB_FILE_NAME } from "./generateMigrationStub";
+
+const printNextSteps = (
+  stubPath: string,
+  headline: string,
+  acceptDataLoss: boolean,
+): void => {
+  console.log(`\n${headline}\n`);
+  if (acceptDataLoss)
+    console.log(
+      "⚠️ This migration deletes sheets and columns that are not in the schema.\n",
+    );
+  console.log("Next steps:");
+  console.log(`  1. Run "clasp push" (or "npm run push") to upload ${STUB_FILE_NAME}
+  2. In the Apps Script editor, run the "gassmaMigrate" function once`);
+  console.log(
+    '\nNote: push with "clasp push" directly. A full clean build (e.g. "npm run deploy")' +
+      ` may wipe the output directory and delete ${stubPath} before it is pushed.`,
+  );
+};
+
+export { printNextSteps };

--- a/packages/cli/src/migrate/printNextSteps.ts
+++ b/packages/cli/src/migrate/printNextSteps.ts
@@ -8,7 +8,7 @@ const printNextSteps = (
   console.log(`\n${headline}\n`);
   if (acceptDataLoss)
     console.log(
-      "⚠️ This migration deletes sheets and columns that are not in the schema.\n",
+      '⚠️ Running the "gassmaMigrate" function will delete sheets and columns that are not in the schema.\n',
     );
   console.log("Next steps:");
   console.log(`  1. Run "clasp push" (or "npm run push") to upload ${STUB_FILE_NAME}


### PR DESCRIPTION
## 概要

新コマンド **`npx gassma db push`** を追加します。`migrate` と**同一の同期スクリプトを生成し、違いは証跡(`migrations/`)を作らないことだけ**です。

```
npx gassma migrate   → スタブ + 証跡(gassma/migrations/<timestamp>/migration.js)
npx gassma db push   → スタブのみ
```

```
npx gassma db push [--accept-data-loss] [--output <dir>] [--schema <path>] [--config <path>]
```

## なぜ別コマンドなのか

Prisma が**フラグではなく別コマンドで分けている**ためです(実測):

| コマンド | migration ファイル | オプション |
|---|---|---|
| `prisma migrate dev` | **作る** | `--config` / `--schema` / `--url` / `--name` / `--create-only` |
| `prisma db push` | **作らない** | `--config` / `--schema` / `--url` / `--accept-data-loss` / `--force-reset` |

`--name` は証跡が無いため持たせていません(本家の `db push` にもありません)。`--force-reset` は「DB を作り直す」概念がスプレッドシートに無いため対象外です。

あわせて **`db` というサブコマンドの名前空間**ができるので、将来の `gassma db seed` が自然に収まります。

## 実装

コピーではなく**抽出**によって共通化しました。差分は「証跡を書くかどうか」の1点だけです。

| ファイル | 内容 |
|---|---|
| `migrate/generateMigrationStub.ts`(新規) | スキーマ読み取り → 定義構築 → テンプレートのパッチ → 出力先解決 → スタブ書き込み |
| `migrate/printNextSteps.ts`(新規) | Next steps 表示(見出しは呼び出し側が渡す) |
| `migrate/migrateCommand.ts` | 152行 → **61行**。上記を呼び、証跡の記録だけを担う |
| `db/dbPushCommand.ts`(新規) | **17行**。上記を呼ぶだけ |

`db` はトップレベルのコマンドなので、既存構造の規則(トップレベルコマンド名 = `src/` 直下のディレクトリ名)に従い `src/db/` を新設しています。

## データ損失の警告文言を変更

`--accept-data-loss` 時の警告から "migration" の語を外しました。**「migration を作らない」ことが存在理由の `db push` で "This migration" と言うのは矛盾**するためです。

```diff
- ⚠️ This migration deletes sheets and columns that are not in the schema.
+ ⚠️ Running the "gassmaMigrate" function will delete sheets and columns that are not in the schema.
```

生成と実行に時間差がある gassma の構造では、**削除が起きるのが「生成された関数を GAS で実行した時」であること**を明示する方が正確です。両コマンドで同一文言です。

## テスト

t-wada 流 TDD(Red を実測確認)。**全体1317件パス**、format / lint / typecheck / test:types / build すべて clean。

独立した検証エージェントによる敵対的レビューを実施しました。**リファクタで `migrate` の挙動が変わっていないこと**が焦点です:

- base(5b3d2a9)を別 worktree に展開してビルドし、**6パターンのスキーマ**(リレーション / `@map`+`@@map` / 暗黙多対多 / enum+`@default` / datasource なし / `--accept-data-loss`)で base と比較 → **スタブ・証跡ともバイト一致**、標準出力も警告文言の変更分を除いて完全一致
- 既存の migrate テストの diff を確認 → 変更は**警告文言のアサーション2箇所のみ**
- 見出しの出し分け(`✅ Migration generated` / `✅ Refreshed gassma-migration.js (no new migration recorded)`)が従来どおり動くことを実測
- **既存の証跡がある状態で `db push` を3回実行 → `migrations/` は md5+mtime レベルで完全不変**(消しも壊しもしない)
- `--help` を base と diff → トップレベルに `db` が増えた2行のみ。`migrate --help` は差分ゼロ
- 変異テスト4系統で Red 確認。「db push が証跡を作らない」「migrate が証跡を作る」の**両方向のガード**が機能

## ドキュメント

`docs/README.ja.md` と `README.md` に `db push` の節を追加しました(`migrate` との違いが分かる形で)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja