### PR TITLE
fix: sync generated error classes with gassma index.d.ts

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -30,6 +30,35 @@ describe("getGassmaErrorClasses", () => {
     expect(result).toContain("constructor(value: number)");
   });
 
+  it("should include GassmaFindFirstTakeError", () => {
+    expect(result).toContain("class GassmaFindFirstTakeError extends Error");
+  });
+
+  it("should include GassmaUndefinedValueError", () => {
+    expect(result).toContain("class GassmaUndefinedValueError extends Error");
+    expect(result).toContain("constructor(path: string)");
+  });
+
+  it("should include GassmaSkipInArrayError", () => {
+    expect(result).toContain("class GassmaSkipInArrayError extends Error");
+  });
+
+  it("should include GassmaMissingArgumentError", () => {
+    expect(result).toContain("class GassmaMissingArgumentError extends Error");
+    expect(result).toContain("constructor(argumentName: string)");
+  });
+
+  it("should include RelationIgnoredColumnError", () => {
+    expect(result).toContain("class RelationIgnoredColumnError extends Error");
+    expect(result).toContain(
+      "constructor(sheetName: string, relationName: string, columnName: string, ignoredSheetName: string)",
+    );
+  });
+
+  it("should not include GassmaTargetSheetNotFoundError removed from gassma", () => {
+    expect(result).not.toContain("GassmaTargetSheetNotFoundError");
+  });
+
   it("should include GassmaLimitNegativeError", () => {
     expect(result).toContain("class GassmaLimitNegativeError extends Error");
   });
@@ -157,9 +186,6 @@ describe("getGassmaErrorClasses", () => {
 
   it("should include relation errors from relationError.ts", () => {
     expect(result).toContain("class GassmaRelationNotFoundError extends Error");
-    expect(result).toContain(
-      "class GassmaTargetSheetNotFoundError extends Error",
-    );
     expect(result).toContain("class GassmaThroughRequiredError extends Error");
     expect(result).toContain(
       "class GassmaIncludeSelectConflictError extends Error",

--- a/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -11,6 +11,7 @@ const errorClassDefinitions: ErrorClassDef[] = [
     extends: "Error",
     params: "value: number",
   },
+  { name: "GassmaFindFirstTakeError", extends: "Error", params: "" },
   {
     name: "GassmaLimitNegativeError",
     extends: "Error",
@@ -112,6 +113,12 @@ const errorClassDefinitions: ErrorClassDef[] = [
     params: "sheetName: string, relationName: string, value: string",
   },
   {
+    name: "RelationIgnoredColumnError",
+    extends: "Error",
+    params:
+      "sheetName: string, relationName: string, columnName: string, ignoredSheetName: string",
+  },
+  {
     name: "NestedWriteConnectNotFoundError",
     extends: "Error",
     params: "sheetName: string",
@@ -143,14 +150,20 @@ const errorClassDefinitions: ErrorClassDef[] = [
     params: "relationName: string, relationType: string",
   },
   {
+    name: "GassmaUndefinedValueError",
+    extends: "Error",
+    params: "path: string",
+  },
+  { name: "GassmaSkipInArrayError", extends: "Error", params: "path: string" },
+  {
+    name: "GassmaMissingArgumentError",
+    extends: "Error",
+    params: "argumentName: string",
+  },
+  {
     name: "GassmaRelationNotFoundError",
     extends: "Error",
     params: "relationName: string, sheetName: string",
-  },
-  {
-    name: "GassmaTargetSheetNotFoundError",
-    extends: "Error",
-    params: "targetSheetName: string",
   },
   {
     name: "GassmaThroughRequiredError",


### PR DESCRIPTION
## 概要

生成されるクライアントの `namespace Gassma` に含まれるエラークラス一覧が、**本体(gassma)の公開エラークラスとズレていました**。

| | 修正前 | 修正後 |
|---|---|---|
| 本体 `index.d.ts` の公開エラークラス | 48 | 48 |
| CLI が生成するエラークラス | **44** | **48** |

## 何が起きていたか

**本体にあるのに CLI が生成しない(5件)**

```
GassmaFindFirstTakeError / GassmaMissingArgumentError
GassmaSkipInArrayError / GassmaUndefinedValueError
RelationIgnoredColumnError
```

利用者が `catch (e) { if (e instanceof Gassma.GassmaMissingArgumentError) ... }` と書いても、**型が存在しないためコンパイルできませんでした**(実行時には投げられるのに)。

**CLI が生成するのに本体に無い幽霊(1件)**

```
GassmaTargetSheetNotFoundError   ← 本体で削除済み
```

こちらは逆に、型はあるのに実体が無い状態でした。

## 修正

`errorClassDefinitions.ts` に5件追加・1件削除しました。追加分のシグネチャは本体の `index.d.ts` と同一です:

| クラス | extends | constructor |
|---|---|---|
| `GassmaFindFirstTakeError` | Error | `()` |
| `RelationIgnoredColumnError` | Error | `(sheetName, relationName, columnName, ignoredSheetName)` |
| `GassmaUndefinedValueError` | Error | `(path: string)` |
| `GassmaSkipInArrayError` | Error | `(path: string)` |
| `GassmaMissingArgumentError` | Error | `(argumentName: string)` |

## 検証

t-wada 流 TDD(テスト先行で 6 failed を確認 → 実装で Green)。**全体1336件パス**、format / lint / typecheck / test:types / build すべて clean。

一致は目視ではなく**機械的に確認**しています:

- 本体 `index.d.ts` から抽出したクラス名48件と、CLI 生成物のクラス名48件を `diff` → **exit 0(差分ゼロ)**
- さらに折り返しを正規化したうえで、**extends 先 + コンストラクタ + メンバー込みの48行**が `diff` exit 0 で完全一致
- 実 CLI で `generate` を走らせ、生成された `schemaClient.d.ts` に5クラスが存在し幽霊が0件であることも確認

テストには「追加した5クラスが生成物に含まれる」「幽霊クラスが含まれない」の両方を固定しました。

## 補足: 再発防止について

このドリフトは**少なくとも2回目**の発生です。根本原因は、**本体のエラークラス面が CLI 側では手書きリスト1箇所にしか存在せず、機械的な参照経路がゼロ**であることです(npm の `gassma` パッケージは CLI 自身で、本体は GAS ライブラリとしてのみ配布されており npm 未公開)。

再発防止策の選択肢は調査済みですが、仕様追加になるため**この PR には含めていません**。別途相談させてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja