### PR TITLE
feat: emit Prisma-parity _count types with _all and true shorthand

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaAggregateData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaAggregateData.test.ts
@@ -23,11 +23,20 @@ describe("getOneGassmaAggregateData", () => {
     expect(result).toContain("_sum?: GassmaUserNumberSelect;");
   });
 
-  it("should keep _count, _max and _min as full Select", () => {
+  it("should keep _max and _min as full Select", () => {
     const result = getOneGassmaAggregateData("", "User");
 
-    expect(result).toContain("_count?: GassmaUserSelect;");
     expect(result).toContain("_max?: GassmaUserSelect;");
     expect(result).toContain("_min?: GassmaUserSelect;");
+  });
+
+  it("should allow CountSelect and the true shorthand only for _count", () => {
+    const result = getOneGassmaAggregateData("", "User");
+
+    expect(result).toContain("_count?: GassmaUserCountSelect | true;");
+    expect(result).not.toContain("_max?: GassmaUserSelect | true;");
+    expect(result).not.toContain("_min?: GassmaUserSelect | true;");
+    expect(result).not.toContain("_avg?: GassmaUserNumberSelect | true;");
+    expect(result).not.toContain("_sum?: GassmaUserNumberSelect | true;");
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaAggregateField.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaAggregateField.test.ts
@@ -17,6 +17,12 @@ describe("getOneGassmaAggregateField", () => {
     );
   });
 
+  it("should resolve the _count true shorthand to number", () => {
+    const result = getOneGassmaAggregateField("", "User");
+    expect(result).toContain("? T extends true");
+    expect(result).toContain("? number");
+  });
+
   it("should map _avg and _sum keys to number | null", () => {
     const result = getOneGassmaAggregateField("", "User");
     expect(result).toContain('K extends "_avg" | "_sum"');

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCountSelect.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCountSelect.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { getOneGassmaCountSelect } from "../../../generate/typeGenerate/gassmaSelect/oneGassmaCountSelect";
+
+describe("getOneGassmaCountSelect", () => {
+  it("should extend Select with _all", () => {
+    const result = getOneGassmaCountSelect("", "User");
+    expect(result).toContain(
+      "export type GassmaUserCountSelect = GassmaUserSelect & {",
+    );
+    expect(result).toContain('"_all"?: true;');
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaCountSelect("Test", "User");
+    expect(result).toContain(
+      "export type GassmaTestUserCountSelect = GassmaTestUserSelect & {",
+    );
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/strictSkip/selectOmitIncludeOrderBy.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/strictSkip/selectOmitIncludeOrderBy.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { getOneGassmaSelect } from "../../../../generate/typeGenerate/gassmaSelect/oneGassmaSelect";
 import { getOneGassmaFindSelect } from "../../../../generate/typeGenerate/gassmaSelect/oneGassmaFindSelect";
 import { getOneGassmaNumberSelect } from "../../../../generate/typeGenerate/gassmaSelect/oneGassmaNumberSelect";
+import { getOneGassmaCountSelect } from "../../../../generate/typeGenerate/gassmaSelect/oneGassmaCountSelect";
 import { getOneGassmaOmit } from "../../../../generate/typeGenerate/gassmaOmit/oneGassmaOmit";
 import { getOneGassmaInclude } from "../../../../generate/typeGenerate/gassmaInclude/oneGassmaInclude";
 import { getOneGassmaOrderBy } from "../../../../generate/typeGenerate/gassmaOrderBy/oneGassmaOrderBy";
@@ -47,6 +48,17 @@ describe("strict NumberSelect", () => {
     expect(
       getOneGassmaNumberSelect({ id: ["number"] }, "", "User"),
     ).not.toContain("Skip");
+  });
+});
+
+describe("strict CountSelect", () => {
+  it("should add SkipValue to _all", () => {
+    const result = getOneGassmaCountSelect("", "User", true);
+    expect(result).toContain('"_all"?: true | Gassma.SkipValue;');
+  });
+
+  it("should keep non-strict output unchanged", () => {
+    expect(getOneGassmaCountSelect("", "User")).not.toContain("Skip");
   });
 });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/strictSkip/topLevelData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/strictSkip/topLevelData.test.ts
@@ -90,7 +90,9 @@ describe("strict AggregateData", () => {
     expect(result).toContain(
       "_avg?: GassmaUserNumberSelect | Gassma.SkipValue;",
     );
-    expect(result).toContain("_count?: GassmaUserSelect | Gassma.SkipValue;");
+    expect(result).toContain(
+      "_count?: GassmaUserCountSelect | true | Gassma.SkipValue;",
+    );
     expect(result).toContain("_max?: GassmaUserSelect | Gassma.SkipValue;");
     expect(result).toContain("_min?: GassmaUserSelect | Gassma.SkipValue;");
     expect(result).toContain(

--- a/packages/cli/src/__test__/types/aggregate/countAll.test-d.ts
+++ b/packages/cli/src/__test__/types/aggregate/countAll.test-d.ts
@@ -1,0 +1,106 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// aggregate: _count: true は number を返す（Prisma 準拠の省略形）
+{
+  const r = client.User.aggregate({ _count: true });
+  expectTypeOf<(typeof r)["_count"]>().toEqualTypeOf<number>();
+}
+
+// aggregate: _count: { _all: true } は { _all: number } を返す
+{
+  const r = client.User.aggregate({ _count: { _all: true } });
+  expectTypeOf<(typeof r)["_count"]["_all"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof r)["_count"]>().not.toHaveProperty("email");
+}
+
+// aggregate: _count: { 列: true } は従来どおり非 NULL カウント型（回帰ガード）
+{
+  const r = client.User.aggregate({ _count: { email: true } });
+  expectTypeOf<(typeof r)["_count"]["email"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof r)["_count"]>().not.toHaveProperty("_all");
+}
+
+// aggregate: _all と列の混在
+{
+  const r = client.User.aggregate({ _count: { _all: true, name: true } });
+  expectTypeOf<(typeof r)["_count"]["_all"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof r)["_count"]["name"]>().toEqualTypeOf<number>();
+}
+
+// aggregate: _all は _count 専用（_avg / _sum / _max / _min は拒否）
+{
+  // @ts-expect-error _avg に _all は指定不可
+  client.User.aggregate({ _avg: { _all: true } });
+  // @ts-expect-error _sum に _all は指定不可
+  client.User.aggregate({ _sum: { _all: true } });
+  // @ts-expect-error _max に _all は指定不可
+  client.User.aggregate({ _max: { _all: true } });
+  // @ts-expect-error _min に _all は指定不可
+  client.User.aggregate({ _min: { _all: true } });
+}
+
+// aggregate: true 省略形も _count 専用
+{
+  // @ts-expect-error _avg: true は指定不可
+  client.User.aggregate({ _avg: true });
+  // @ts-expect-error _sum: true は指定不可
+  client.User.aggregate({ _sum: true });
+  // @ts-expect-error _max: true は指定不可
+  client.User.aggregate({ _max: true });
+  // @ts-expect-error _min: true は指定不可
+  client.User.aggregate({ _min: true });
+}
+
+// groupBy: _count: true は各要素の _count を number にする
+{
+  const r = client.User.groupBy({ by: ["isActive"], _count: true });
+  expectTypeOf<(typeof r)[number]["_count"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof r)[number]["isActive"]>().toEqualTypeOf<boolean>();
+}
+
+// groupBy: _count: { _all: true } は { _all: number } を返す
+{
+  const r = client.User.groupBy({ by: ["isActive"], _count: { _all: true } });
+  expectTypeOf<(typeof r)[number]["_count"]["_all"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof r)[number]["_count"]>().not.toHaveProperty("email");
+}
+
+// groupBy: _count: { 列: true } は従来どおり（回帰ガード）
+{
+  const r = client.User.groupBy({ by: ["isActive"], _count: { email: true } });
+  expectTypeOf<(typeof r)[number]["_count"]["email"]>().toEqualTypeOf<number>();
+}
+
+// groupBy: _all と列の混在
+{
+  const r = client.User.groupBy({
+    by: ["isActive"],
+    _count: { _all: true, email: true },
+  });
+  expectTypeOf<(typeof r)[number]["_count"]["_all"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof r)[number]["_count"]["email"]>().toEqualTypeOf<number>();
+}
+
+// groupBy: _all / true 省略形は _count 専用
+{
+  // @ts-expect-error _avg に _all は指定不可
+  client.User.groupBy({ by: ["isActive"], _avg: { _all: true } });
+  // @ts-expect-error _sum: true は指定不可
+  client.User.groupBy({ by: ["isActive"], _sum: true });
+  // @ts-expect-error _max に _all は指定不可
+  client.User.groupBy({ by: ["isActive"], _max: { _all: true } });
+  // @ts-expect-error _min: true は指定不可
+  client.User.groupBy({ by: ["isActive"], _min: true });
+}
+
+// groupBy: having の _count は数値 Filter のまま（対象外の回帰ガード）
+{
+  client.User.groupBy({
+    by: ["email"],
+    _count: { _all: true },
+    having: { email: { _count: { gt: 2 } } },
+  });
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaAggregateData/oneGassmaAggregateData.ts
@@ -19,7 +19,7 @@ export type Gassma${schemaName}${sheetName}AggregateData = {
   skip?: number${sk};
   cursor?: ${cursorType}${sk};
   _avg?: Gassma${schemaName}${sheetName}NumberSelect${sk};
-  _count?: Gassma${schemaName}${sheetName}Select${sk};
+  _count?: Gassma${schemaName}${sheetName}CountSelect | true${sk};
   _max?: Gassma${schemaName}${sheetName}Select${sk};
   _min?: Gassma${schemaName}${sheetName}Select${sk};
   _sum?: Gassma${schemaName}${sheetName}NumberSelect${sk};

--- a/packages/cli/src/generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaAggregateField/oneGassmaAggregateField.ts
@@ -3,7 +3,9 @@ const getOneGassmaAggregateField = (schemaName: string, sheetName: string) => {
 export type Gassma${schemaName}${sheetName}AggregateField<T, K extends string> = T extends undefined
   ? never
   : K extends "_count"
-    ? { [P in keyof T as T[P] extends true ? P : never]: number }
+    ? T extends true
+      ? number
+      : { [P in keyof T as T[P] extends true ? P : never]: number }
     : K extends "_avg" | "_sum"
       ? { [P in keyof T as T[P] extends true ? P : never]: number | null }
       : {

--- a/packages/cli/src/generate/typeGenerate/gassmaSelect.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaSelect.ts
@@ -2,6 +2,7 @@ import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import type { RelationsConfig } from "../read/extractRelations";
 import { getOneGassmaSelect } from "./gassmaSelect/oneGassmaSelect";
 import { getOneGassmaNumberSelect } from "./gassmaSelect/oneGassmaNumberSelect";
+import { getOneGassmaCountSelect } from "./gassmaSelect/oneGassmaCountSelect";
 import { getOneGassmaFindSelect } from "./gassmaSelect/oneGassmaFindSelect";
 
 const getGassmaSelect = (
@@ -26,6 +27,11 @@ const getGassmaSelect = (
         ) +
         getOneGassmaNumberSelect(
           sheetContent,
+          schemaName,
+          removedSpaceCurrentSheetName,
+          strict,
+        ) +
+        getOneGassmaCountSelect(
           schemaName,
           removedSpaceCurrentSheetName,
           strict,

--- a/packages/cli/src/generate/typeGenerate/gassmaSelect/oneGassmaCountSelect.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaSelect/oneGassmaCountSelect.ts
@@ -1,0 +1,14 @@
+import { skipUnion } from "../util/skipUnion";
+
+const getOneGassmaCountSelect = (
+  schemaName: string,
+  sheetName: string,
+  strict?: boolean,
+) => {
+  const sk = skipUnion(strict);
+  const self = `Gassma${schemaName}${sheetName}`;
+
+  return `\nexport type ${self}CountSelect = ${self}Select & {\n  "_all"?: true${sk};\n};\n`;
+};
+
+export { getOneGassmaCountSelect };


### PR DESCRIPTION
## 概要

本体 gassma #186 で `_count` に入った Prisma 準拠の2つの形に、**型生成を追随**させます。

| 指定 | 結果の型 |
|---|---|
| `_count: true` | **`number`** |
| `_count: { _all: true }` | **`{ _all: number }`** |
| `_count: { <列>: true }` | `{ <列>: number }`(**変更なし**) |
| 混在 | 両方入る |

`aggregate` と `groupBy` の両方に効きます。

## Prisma の生成型を読んで設計しています

サンドボックスで `prisma generate` して実物を確認しました:

```ts
export type ItemCountAggregateInputType = {
  id?: true
  cat?: true
  memo?: true
  _all?: true          // ← _count の入力型だけに _all がある
}
// aggregate:  _count?: true | ItemCountAggregateInputType
// _avg/_sum/_min/_max は各自の InputType のみ(_all なし・true 省略形なし)

// 結果型は入力に応じて分岐
P extends '_count' ? T[P] extends true ? number : GetScalarType<T[P], AggregateItem[P]>
```

## 生成される型

```ts
export type GassmaSchemaUserCountSelect = GassmaSchemaUserSelect & {
  "_all"?: true;
};
// AggregateData:  _count?: GassmaSchemaUserCountSelect | true;
// AggregateField: K extends "_count" ? T extends true ? number
//                   : { [P in keyof T as T[P] extends true ? P : never]: number }
```

Prisma は列を展開した独立型を生成しますが、**列定義の二重管理を避けるため交差型**にしています(`GroupByData` が `Omit` 合成である既存の前例に倣った形です)。

## `_all` と `true` は `_count` 専用です

`_avg` / `_sum` / `_max` / `_min` の入力型には**追加していません**。Prisma も同じで、渡すと型エラーになります(実測確認済み)。この境界が崩れないよう、**型エラーになること自体をテストで固定**しています。

## 検証

t-wada 流 TDD(型レベル Red → Green)。**全体1342件パス**、format / lint / typecheck / test:types / build すべて clean。

独立した検証エージェントによる敵対的レビューを実施しました:

- **交差型と Prisma の展開型が等価であることを型プローブで確認** — `keyof` 一致・相互代入可・値型一致。`Select` は index signature ではなく閉じた列の型なので「何でも通る」危険はありません
- **拒否挙動が Prisma と完全一致**(エラー種別まで): `_count: { nonExistent: true }` → 両方 TS2353 / `_count: { _all: false }` → 両方 TS2322 / `_count: false`・他モデルの列 → 両方拒否
- **結果型の厳密一致を検証** — `{ _all: true }` の結果に指定していない列が混入しないこと、`{ email: true }` に `_all` が混入しないことを `Equal` 型で確認
- **`@ts-expect-error` の空振りが無いこと**を、わざと合法コードに書き換えて TS2578 が出ることで確認
- **既存生成物への影響ゼロ** — base(249ff09)を別 worktree に展開してビルドし、3種の生成物を直接 diff。差分は `_count` 関連の3パターンのみで、**それ以外はゼロ**
- 変異テスト4系統で Red 確認

## 補足: 検証で見つかった別の既存問題(この PR の範囲外)

**有効な列と混ぜた不正キーが型を素通りします**:

```ts
_count: { id: true, typo: true }   // gassma: 通ってしまう / Prisma: TS2353 で拒否
_avg:   { age: true, _all: true }  // 同上
```

単独の `{ typo: true }` は正しく拒否されるので、TypeScript の excess property check が効かない条件で漏れています。原因は、Prisma が `aggregate<T>(args: Subset<T, UserAggregateArgs>)` というガジェット型で捕捉しているのに対し、gassma-cli は裸の `aggregate<T extends AggregateData>(data: T)` である点です。

**base でも同じ挙動であることを実測しており、この PR での導入・悪化ではありません**。また交差型ではなく展開型を選んでいても直りません。集計に限らず全 API 面に及ぶ可能性があり、修正はシグネチャの横断変更になるため別課題としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja