### PR TITLE
perf: FindResult の条件型チェーンをルックアップマップ型に置換

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResult.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResult.test.ts
@@ -41,7 +41,7 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O, CMap>[]',
+      '"posts": GassmaPostFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O, CMap>[];',
     );
   });
 
@@ -58,7 +58,7 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "profile" ? GassmaProfileFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Profile": infer TO } ? TO extends GassmaProfileOmit ? TO : {} : {}, O, CMap> | null',
+      '"profile": GassmaProfileFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Profile": infer TO } ? TO extends GassmaProfileOmit ? TO : {} : {}, O, CMap> | null;',
     );
   });
 
@@ -75,11 +75,11 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "Post", relations);
     expect(result).toContain(
-      'K extends "author" ? GassmaUserFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "User": infer TO } ? TO extends GassmaUserOmit ? TO : {} : {}, O, CMap> | null',
+      '"author": GassmaUserFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "User": infer TO } ? TO extends GassmaUserOmit ? TO : {} : {}, O, CMap> | null;',
     );
   });
 
-  it("should keep FindResultBase relation branches structural (no CMap)", () => {
+  it("should keep FindResultBase relation map entries structural (no CMap)", () => {
     const relations: RelationsConfig = {
       User: {
         posts: {
@@ -92,11 +92,11 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "posts" ? GassmaPostFindResultBase<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O>[]',
+      '"posts": GassmaPostFindResultBase<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O>[];',
     );
   });
 
-  it("should pass target model globalOmit and full config to select-relation branches", () => {
+  it("should pass target model globalOmit and full config to select-relation map entries", () => {
     const relations: RelationsConfig = {
       User: {
         posts: {
@@ -109,7 +109,7 @@ describe("getOneGassmaFindResult", () => {
     };
     const result = getOneGassmaFindResult("", "User", relations);
     expect(result).toContain(
-      'K extends "posts" ? GassmaPostFindResult<Gassma.SelectOf<S[K]>, Gassma.IncludeOf<S[K]>, Gassma.OmitOf<S[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O, CMap>[]',
+      '"posts": GassmaPostFindResult<Gassma.SelectOf<S[K]>, Gassma.IncludeOf<S[K]>, Gassma.OmitOf<S[K]>, O extends { "Post": infer TO } ? TO extends GassmaPostOmit ? TO : {} : {}, O, CMap>[];',
     );
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResultRelationLookup.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResultRelationLookup.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { RelationsConfig } from "../../../generate/read/extractRelations";
+import { getOneGassmaFindResult } from "../../../generate/typeGenerate/gassmaFindResult/oneGassmaFindResult";
+
+const userRelations: RelationsConfig = {
+  User: {
+    posts: {
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "authorId",
+    },
+    profile: {
+      type: "oneToOne",
+      to: "Profile",
+      field: "id",
+      reference: "userId",
+    },
+  },
+};
+
+describe("getOneGassmaFindResult relation lookup map", () => {
+  it("should resolve relations via a single lookup map instead of a conditional chain", () => {
+    const result = getOneGassmaFindResult("", "User", userRelations);
+    expect(result).toContain('K extends "posts" | "profile" ? {');
+    expect(result).toContain("}[K] :");
+    expect(result).not.toContain('K extends "posts" ? Gassma');
+    expect(result).not.toContain('K extends "profile" ? Gassma');
+  });
+
+  it("should map manyToMany to a TargetFindResult[] map entry", () => {
+    const relations: RelationsConfig = {
+      Post: {
+        tags: {
+          type: "manyToMany",
+          to: "Tag",
+          field: "id",
+          reference: "id",
+        },
+      },
+    };
+    const result = getOneGassmaFindResult("", "Post", relations);
+    expect(result).toContain(
+      '"tags": GassmaTagFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "Tag": infer TO } ? TO extends GassmaTagOmit ? TO : {} : {}, O, CMap>[];',
+    );
+  });
+
+  it("should keep _count resolution after the lookup map", () => {
+    const result = getOneGassmaFindResult("", "User", userRelations);
+    expect(result).toContain(
+      '}[K] :\n          K extends "_count" ? Gassma.CountResult<S[K]>',
+    );
+    expect(result).toContain(
+      '}[K] :\n          K extends "_count" ? Gassma.CountResult<I[K]>',
+    );
+  });
+
+  it("should emit no lookup map for a model without relations", () => {
+    const result = getOneGassmaFindResult("", "Member");
+    expect(result).not.toContain("}[K]");
+    expect(result).toContain('K extends "_count" ? Gassma.CountResult<S[K]>');
+    expect(result).toContain('K extends "_count" ? Gassma.CountResult<I[K]>');
+    expect(result).toContain('K extends "_count" ? K : never');
+  });
+});

--- a/packages/cli/src/__test__/types/read/relationKinds.test-d.ts
+++ b/packages/cli/src/__test__/types/read/relationKinds.test-d.ts
@@ -1,0 +1,138 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+declare const clientOmit: GassmaClient<{ Post: { published: true } }>;
+
+// manyToMany: Post.tags を直接 include → 配列
+{
+  const p = client.Post.findFirst({
+    where: { id: 1 },
+    include: { tags: true },
+  });
+  type P = NonNullable<typeof p>;
+  expectTypeOf<P["tags"]>().toBeArray();
+  expectTypeOf<P["tags"][number]["name"]>().toEqualTypeOf<string>();
+}
+
+// manyToMany 逆側: Tag.posts → 配列
+{
+  const t = client.Tag.findFirst({
+    where: { id: 1 },
+    include: { posts: true },
+  });
+  type T = NonNullable<typeof t>;
+  expectTypeOf<T["posts"]>().toBeArray();
+  expectTypeOf<T["posts"][number]["title"]>().toEqualTypeOf<string>();
+}
+
+// oneToOne 逆側(FK 保有側): Profile.user → User | null
+{
+  const pr = client.Profile.findFirst({
+    where: { id: 1 },
+    include: { user: true },
+  });
+  type Pr = NonNullable<typeof pr>;
+  expectTypeOf<Pr["user"]>().toBeNullable();
+  expectTypeOf<NonNullable<Pr["user"]>["email"]>().toEqualTypeOf<string>();
+}
+
+// 3段以上の深いネスト include: User -> posts -> tags -> posts
+{
+  const u = client.User.findFirst({
+    where: { id: 1 },
+    include: {
+      posts: {
+        include: {
+          tags: { include: { posts: { select: { title: true } } } },
+        },
+      },
+    },
+  });
+  type U = NonNullable<typeof u>;
+  type DeepPost = U["posts"][number]["tags"][number]["posts"][number];
+  expectTypeOf<DeepPost["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<DeepPost>().not.toHaveProperty("id");
+}
+
+// 4段ネスト(自己参照): Category children -> children -> parent -> children
+{
+  const c = client.Category.findFirst({
+    where: { id: 1 },
+    include: {
+      children: {
+        include: {
+          children: { include: { parent: { include: { children: true } } } },
+        },
+      },
+    },
+  });
+  type C = NonNullable<typeof c>;
+  type Deep = NonNullable<
+    C["children"][number]["children"][number]["parent"]
+  >["children"];
+  expectTypeOf<Deep>().toBeArray();
+  expectTypeOf<Deep[number]["name"]>().toEqualTypeOf<string>();
+}
+
+// omit と include の併用: スカラーだけ落ちてリレーションは残る
+{
+  const p = client.Post.findFirst({
+    where: { id: 1 },
+    omit: { published: true },
+    include: { author: true, tags: true },
+  });
+  type P = NonNullable<typeof p>;
+  expectTypeOf<P>().not.toHaveProperty("published");
+  expectTypeOf<P["author"]>().toBeNullable();
+  expectTypeOf<P["tags"]>().toBeArray();
+  expectTypeOf<P["title"]>().toEqualTypeOf<string>();
+}
+
+// グローバルomit と include の併用
+{
+  const p = clientOmit.Post.findFirst({
+    where: { id: 1 },
+    include: { author: true },
+  });
+  type P = NonNullable<typeof p>;
+  expectTypeOf<P>().not.toHaveProperty("published");
+  expectTypeOf<P["author"]>().toBeNullable();
+}
+
+// select と include の役割分担: select 内リレーション + _count
+{
+  const u = client.User.findFirst({
+    where: { id: 1 },
+    select: {
+      id: true,
+      posts: { select: { title: true } },
+      profile: true,
+      _count: { select: { posts: true } },
+    },
+  });
+  type U = NonNullable<typeof u>;
+  expectTypeOf<U["posts"]>().toBeArray();
+  expectTypeOf<U["profile"]>().toBeNullable();
+  expectTypeOf<U["_count"]["posts"]>().toEqualTypeOf<number>();
+  expectTypeOf<U>().not.toHaveProperty("email");
+}
+
+// リレーションを持たないモデル: 結果はスカラーのみで include キーが存在しない
+{
+  const m = client.Member.findFirstOrThrow({ where: { id: 1 } });
+  type M = typeof m;
+  expectTypeOf<M["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<M>().not.toHaveProperty("_count");
+}
+
+// リレーションを持たないモデルの select
+{
+  const m = client.Member.findFirstOrThrow({
+    where: { id: 1 },
+    select: { id: true, role: true },
+  });
+  type M = typeof m;
+  expectTypeOf<M["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<M>().not.toHaveProperty("firstName");
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -10,17 +10,17 @@ const getOneGassmaFindResult = (
   const modelRelations = relations?.[sheetName] ?? {};
   const relNames = Object.keys(modelRelations);
 
+  const relUnion = relNames.map((r) => `"${r}"`).join(" | ");
   const relKeyUnion =
-    relNames.length > 0
-      ? `${relNames.map((r) => `"${r}"`).join(" | ")} | "_count"`
-      : `"_count"`;
+    relNames.length > 0 ? `${relUnion} | "_count"` : `"_count"`;
 
   const relationBranch = (
     source: string,
     childName: string,
     childArgs: string,
-  ) =>
-    relNames
+  ) => {
+    if (relNames.length === 0) return "";
+    const entries = relNames
       .map((relationName) => {
         const def = modelRelations[relationName];
         const targetFR = `${prefix}${def.to}${childName}`;
@@ -28,9 +28,13 @@ const getOneGassmaFindResult = (
         const inner = `${targetFR}<Gassma.SelectOf<${source}[K]>, Gassma.IncludeOf<${source}[K]>, Gassma.OmitOf<${source}[K]>, ${targetGO}, O${childArgs}>`;
         const isList = def.type === "oneToMany" || def.type === "manyToMany";
         const result = isList ? `${inner}[]` : `${inner} | null`;
-        return `          K extends "${relationName}" ? ${result} :`;
+        return `            "${relationName}": ${result};`;
       })
       .join("\n");
+    return `          K extends ${relUnion} ? {
+${entries}
+          }[K] :`;
+  };
 
   const structural = (childName: string, childArgs: string) => {
     const selectResult = `{


### PR DESCRIPTION
本体の計算量調査(gassma #184〜#191)の推奨着手順 **7番目**。cli 側の最後の項目です。

> [!IMPORTANT]
> **生成される `.d.ts` の見た目が変わります**(gassma-test の生成物で 352 diff 行)。結果の**型が同一である**ことは 30 ケースで厳密同一を確認済みです(後述)。この点は確認のうえ進めています。

## 問題

生成される FindResult 型が、リレーションごとの**条件型チェーン**になっていました。

```ts
K extends "posts" ? GassmaPostFindResult<...>[] :
K extends "profile" ? GassmaProfileFindResult<...> | null :
K extends "_count" ? Gassma.CountResult<S[K]> :
GassmaUserDefaultFindResult[K & keyof GassmaUserDefaultFindResult];
```

1つのキーを解決するのに最大 R 段たどり、mapped type がそれを**キーの数だけ**繰り返すため、リレーション数 R に対して二次以上になります。**1モデルに 199 リレーションが集まるスキーマで `tsc` に 8.10秒**でした。

## 修正

**ルックアップマップ型**にして、1回のユニオン判定 + 1回のインデックスアクセスで解決します。

```ts
K extends "posts" | "profile" ? {
  "posts": GassmaPostFindResult<...>[];
  "profile": GassmaProfileFindResult<...> | null;
}[K] :
K extends "_count" ? Gassma.CountResult<S[K]> :
GassmaUserDefaultFindResult[K & keyof GassmaUserDefaultFindResult];
```

インデックスは `[K & (union)]` ではなく **`[K]` 単独**にしています。条件型の true 分岐内では substitution により K の制約がユニオンに絞られるため合法で、**キーごとの交差型計算(それ自体がユニオン走査)すら発生しません**。この成立性は、実装前に独立した `tsc` 検証で旧形式との厳密同一を確認してから書いています。

`_count` 分岐・default 分岐・`S`(select)と `I`(include)の両側・`FindResultBase` / `FindResultCore` / `FindResult` の3段関係はすべて保存。**リレーション0件のモデルは出力が1文字も変わりません**。

## 性能実測

| fan-in R | 修正前 | 修正後 | 倍率 | インスタンス化(前) | (後) |
|---|---|---|---|---|---|
| 25 | 0.08s | **0.05s** | 1.6x | 8,502 | 7,070 |
| 50 | 0.26s | **0.09s** | 2.9x | 17,752 | 13,595 |
| 100 | 1.27s | **0.14s** | 9.1x | 40,002 | 26,645 |
| 200 | **8.10s** | **0.26s** | **31x** | 99,502 | 52,745 |

R を倍にしたときの時間倍率は、修正前が ×3.3 → ×4.9 → ×6.4(二次超)、修正後が ×1.8 → ×1.6 → ×1.9(線形)。

**通常規模で退行していません**。R=25 で 0.08 → 0.05s、実スキーマ(gassma-test、最大 fan-in 4)でも 0.03〜0.04s → 0.04〜0.05s(ノイズ範囲)、インスタンス化数は 3,026 → 2,953 と微減です。

## 型が同一であることの検証

型のコード生成は**壊れても実行時に現れない**ため、3層で確認しています。

### 1. 厳密同一性(30ケース)

修正前後の生成 `.d.ts` を並べ、**invariance トリック**で判定しました。

```ts
(<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
```

相互 `extends` より強い等価性判定です。**判定器そのものが差を検出できること(異なる型で false になること)の自己検証も入れて**います — これが無いと「常に true を返す判定で全ケース通過」という型テスト最大の罠を踏みます。

fixture スキーマ 25 ケース + gassma-test の実スキーマ 5 ケースで**すべて同一**。ケースは include 単体 / 3〜4段ネスト / select + `_count` / omit / globalOmit / `O` 伝播 / CMap(computed)/ リレーション無し / 複合PK / strict 版 / Base / Core を網羅しています。

### 2. 生成物の差分が `relationBranch` 由来のみであること

gassma-test をコピーした環境で修正前後の `generate` を実行し、

- **`gassmaClient.js` は完全一致**
- `.d.ts` と fixture 2種の diff の**全変更行を正規表現で全数検査**し、削除行はすべて旧チェーン行、追加行はすべてマップ頭 / エントリ / `}[K] :` 行に一致(**不一致 0 行**)

### 3. 型テスト

既存の `*.test-d.ts`(include / select / omit / globalOmit / strict)が新生成物で "no errors"。加えて `relationKinds.test-d.ts` を新規追加し、**4種リレーションの配列性 / `| null` の向き**(manyToMany 両側・oneToOne の FK 側)、3段/4段(自己参照)ネスト、omit × include 併用、リレーション無しモデルを直接固定しました。

## テストの変更について

**既存テスト5件の期待値を更新しています。** 旧形式の生成文字列そのものを `toContain` で固定していたため、本変更と両立しないものです。

削除ではなく書き換えを選びました。差分は **+7/-7 行**で、**型の中身(CMap のスレッディング、globalOmit、`SelectOf`/`IncludeOf`/`OmitOf`)は1バイトも変わらず、包み方だけ**が変わっていることがレビューで1対1に追えます。

```diff
-  'K extends "posts" ? GassmaPostFindResult<...省略...CMap>[]',
+  '"posts": GassmaPostFindResult<...省略...CMap>[];',
```

実態と合わなくなったテスト名2件(`relation branches` → `relation map entries`)も併せて更新しました。新規追加した単体テストのうち既存5件と実質同一だったものは削除し、既存ファイルに無い観点(マップ構造そのもの・**manyToMany**・`_count` の解決順序・リレーション0件時の不変)の4件だけを残しています。

## 検証結果

`npm test`(177 files / **1,346 tests** 全 green)/ `test:types`(209 files、**no errors**)/ `typecheck` / `lint` / `format:check` / `build` すべて pass。実装の変更は 1 ファイル +10/-6 行(83行、200行制限内)です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)