### PR TITLE
fix: reject excess keys on generic controller methods

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -79,6 +79,12 @@ describe("getGassmaCommonTypes", () => {
     );
   });
 
+  it("should generate Subset helper rejecting excess keys", () => {
+    expect(result).toContain(
+      "type Subset<T, U> = { [K in keyof T]: K extends keyof U ? T[K] : never };",
+    );
+  });
+
   describe("strict mode", () => {
     const strictResult = getGassmaCommonTypes(true);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -4,7 +4,7 @@ import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaCon
 describe("getOneGassmaController", () => {
   const result = getOneGassmaController("", "User");
   const res = `GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O, CMap>`;
-  const sub = (dataType: string) => `Gassma.Subset<T, ${dataType}>`;
+  const sub = (dataType: string) => `T & Gassma.Subset<T, ${dataType}>`;
   const withComputed = (dataType: string) =>
     `${dataType} & Gassma.ComputedArgs<Gassma.At<CMap, "User">>`;
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -4,6 +4,9 @@ import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaCon
 describe("getOneGassmaController", () => {
   const result = getOneGassmaController("", "User");
   const res = `GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O, CMap>`;
+  const sub = (dataType: string) => `Gassma.Subset<T, ${dataType}>`;
+  const withComputed = (dataType: string) =>
+    `${dataType} & Gassma.ComputedArgs<Gassma.At<CMap, "User">>`;
 
   it("should generate controller class declaration with GO, O and computed map CMap", () => {
     expect(result).toContain(
@@ -49,19 +52,19 @@ describe("getOneGassmaController", () => {
 
   it("should have generic delete method with model-specific type", () => {
     expect(result).toContain(
-      `delete<T extends GassmaUserDeleteSingleData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(deleteData: T): ${res} | null`,
+      `delete<T extends ${withComputed("GassmaUserDeleteSingleData")}>(deleteData: ${sub(withComputed("GassmaUserDeleteSingleData"))}): ${res} | null`,
     );
   });
 
   it("should have generic upsert method with model-specific type", () => {
     expect(result).toContain(
-      `upsert<T extends GassmaUserUpsertSingleData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(upsertData: T): ${res}`,
+      `upsert<T extends ${withComputed("GassmaUserUpsertSingleData")}>(upsertData: ${sub(withComputed("GassmaUserUpsertSingleData"))}): ${res}`,
     );
   });
 
   it("should include createManyAndReturn method with generic type", () => {
     expect(result).toContain(
-      `createManyAndReturn<T extends GassmaUserCreateManyAndReturnData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(createdData: T): ${res}[]`,
+      `createManyAndReturn<T extends ${withComputed("GassmaUserCreateManyAndReturnData")}>(createdData: ${sub(withComputed("GassmaUserCreateManyAndReturnData"))}): ${res}[]`,
     );
   });
 
@@ -73,35 +76,35 @@ describe("getOneGassmaController", () => {
 
   it("should use FindFirstData for findFirst", () => {
     expect(result).toContain(
-      `findFirst<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T): ${res} | null`,
+      `findFirst<T extends ${withComputed("GassmaUserFindFirstData")}>(findData: ${sub(withComputed("GassmaUserFindFirstData"))}): ${res} | null`,
     );
   });
 
   it("should use FindFirstData for findFirstOrThrow", () => {
     expect(result).toContain(
-      `findFirstOrThrow<T extends GassmaUserFindFirstData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T): ${res}`,
+      `findFirstOrThrow<T extends ${withComputed("GassmaUserFindFirstData")}>(findData: ${sub(withComputed("GassmaUserFindFirstData"))}): ${res}`,
     );
   });
 
   it("should have generic create method with FindResult return", () => {
     expect(result).toContain(
-      `create<T extends GassmaUserCreateData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(createdData: T): ${res}`,
+      `create<T extends ${withComputed("GassmaUserCreateData")}>(createdData: ${sub(withComputed("GassmaUserCreateData"))}): ${res}`,
     );
   });
 
   it("should have generic update method with model-specific type", () => {
     expect(result).toContain(
-      `update<T extends GassmaUserUpdateSingleData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(updateData: T): ${res} | null`,
+      `update<T extends ${withComputed("GassmaUserUpdateSingleData")}>(updateData: ${sub(withComputed("GassmaUserUpdateSingleData"))}): ${res} | null`,
     );
   });
 
   it("should not wrap aggregate-family returns with computed fields", () => {
     expect(result).toContain(
-      "aggregate<T extends GassmaUserAggregateData>(aggregateData: T): GassmaUserAggregateResult<T>",
+      `aggregate<T extends GassmaUserAggregateData>(aggregateData: ${sub("GassmaUserAggregateData")}): GassmaUserAggregateResult<T>`,
     );
     expect(result).toContain("count(coutData: GassmaUserCountData): number");
     expect(result).toContain(
-      "groupBy<T extends GassmaUserGroupByData>(groupByData: T): GassmaUserGroupByResult<T>[]",
+      `groupBy<T extends GassmaUserGroupByData>(groupByData: ${sub("GassmaUserGroupByData")}): GassmaUserGroupByResult<T>[]`,
     );
     expect(result).toContain(
       "createMany(createdData: GassmaUserCreateManyData): CreateManyReturn",

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
@@ -27,7 +27,7 @@ describe("getOneGassmaController no-arg overloads", () => {
 
   it("should keep the argument-taking signatures next to the no-arg overloads", () => {
     expect(result).toContain(
-      `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: Gassma.Subset<T, GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>)`,
+      `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T & Gassma.Subset<T, GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>)`,
     );
     expect(result).toContain("count(coutData: GassmaUserCountData): number;");
     expect(result).toContain(

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
@@ -27,7 +27,7 @@ describe("getOneGassmaController no-arg overloads", () => {
 
   it("should keep the argument-taking signatures next to the no-arg overloads", () => {
     expect(result).toContain(
-      `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T)`,
+      `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: Gassma.Subset<T, GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>)`,
     );
     expect(result).toContain("count(coutData: GassmaUserCountData): number;");
     expect(result).toContain(

--- a/packages/cli/src/__test__/types/aggregate/excessKeys.test-d.ts
+++ b/packages/cli/src/__test__/types/aggregate/excessKeys.test-d.ts
@@ -1,0 +1,60 @@
+import { expectTypeOf } from "vitest";
+import type {
+  GassmaClient,
+  GassmaUserAggregateData,
+} from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// aggregate: 余分なキーは有効なキーと混ぜても拒否される（Prisma の Subset 準拠）
+{
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.aggregate({ where: {}, typo: true });
+  // @ts-expect-error 余分キー typo は単独でも指定不可
+  client.User.aggregate({ typo: true });
+  // @ts-expect-error _count 内の未知キーは指定不可
+  client.User.aggregate({ _count: { typo: true } });
+}
+
+// groupBy: 余分なキーは有効なキーと混ぜても拒否される
+{
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.groupBy({ by: ["id"], typo: true });
+  // @ts-expect-error where と併用しても余分キーは指定不可
+  client.User.groupBy({ by: ["id"], where: { id: 1 }, typo: true });
+}
+
+// count: 余分なキーは拒否される（回帰ガード）
+{
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.count({ where: { id: 1 }, typo: true });
+}
+
+// aggregate: 正当な呼び出しの結果型は変わらない
+{
+  const r = client.User.aggregate({
+    where: { id: 1 },
+    _count: { id: true },
+    _avg: { age: true },
+  });
+  expectTypeOf<typeof r>().branded.toEqualTypeOf<{
+    _count: { id: number };
+    _avg: { age: number | null };
+  }>();
+}
+
+// aggregate: 変数渡し（非リテラル）も従来どおり通る
+{
+  const args: GassmaUserAggregateData = { _count: true };
+  client.User.aggregate(args);
+}
+
+// groupBy: 正当な呼び出しの結果型は変わらない
+{
+  const r = client.User.groupBy({ by: ["isActive"], _count: { id: true } });
+  expectTypeOf<keyof (typeof r)[number]>().toEqualTypeOf<
+    "isActive" | "_count"
+  >();
+  expectTypeOf<(typeof r)[number]["isActive"]>().toEqualTypeOf<boolean>();
+  expectTypeOf<(typeof r)[number]["_count"]["id"]>().toEqualTypeOf<number>();
+}

--- a/packages/cli/src/__test__/types/query/excessKeys.test-d.ts
+++ b/packages/cli/src/__test__/types/query/excessKeys.test-d.ts
@@ -1,0 +1,50 @@
+import { expectTypeOf } from "vitest";
+import type {
+  GassmaClient,
+  GassmaUserFindManyData,
+} from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+// findMany / findFirst / findFirstOrThrow: 余分なキーは有効なキーと混ぜても拒否される
+{
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.findMany({ where: { id: 1 }, typo: true });
+  // @ts-expect-error 余分キー typo は単独でも指定不可
+  client.User.findMany({ typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.findFirst({ where: { id: 1 }, typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.findFirstOrThrow({ where: { id: 1 }, typo: true });
+}
+
+// findMany: 正当な呼び出しの結果型は変わらない（select の絞り込み）
+{
+  const r = client.User.findMany({
+    where: { email: { contains: "a" } },
+    select: { id: true, name: true },
+    take: 1,
+  });
+  expectTypeOf<typeof r>().branded.toEqualTypeOf<
+    { id: number; name: string | null }[]
+  >();
+}
+
+// findMany: orderBy の文字列リテラルは従来どおり通る（widening 回帰ガード)
+{
+  client.User.findMany({ orderBy: { id: "asc" } });
+  client.User.findMany({ orderBy: [{ id: "asc" }, { email: "desc" }] });
+}
+
+// findFirst: 結果は単一 | null のまま
+{
+  const r = client.User.findFirst({ where: { id: 1 } });
+  expectTypeOf<NonNullable<typeof r>["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<typeof r>().toBeNullable();
+}
+
+// findMany: 変数渡し（非リテラル）も従来どおり通る
+{
+  const args: GassmaUserFindManyData = { where: { id: 1 } };
+  client.User.findMany(args);
+}

--- a/packages/cli/src/__test__/types/write/excessKeys.test-d.ts
+++ b/packages/cli/src/__test__/types/write/excessKeys.test-d.ts
@@ -1,0 +1,52 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+
+declare const client: GassmaClient;
+
+const row = { email: "a@example.com", score: 0 };
+const rows = [row];
+
+// 書き込み系: 余分なキーは有効なキーと混ぜても拒否される
+{
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.create({ data: row, typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.createManyAndReturn({ data: rows, typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.update({ where: { id: 1 }, data: {}, typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.upsert({ where: { id: 1 }, create: row, update: {}, typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.delete({ where: { id: 1 }, typo: true });
+}
+
+// 非ジェネリックな書き込み系も余分なキーを拒否する（回帰ガード）
+{
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.createMany({ data: rows, typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.updateMany({ where: { id: 1 }, data: {}, typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.deleteMany({ where: { id: 1 }, typo: true });
+  // @ts-expect-error 余分キー typo は指定不可
+  client.User.updateManyAndReturn({ data: {}, typo: true });
+}
+
+// 正当な呼び出しの結果型は変わらない
+{
+  const r = client.User.create({ data: row, select: { id: true } });
+  expectTypeOf<typeof r>().branded.toEqualTypeOf<{ id: number }>();
+}
+{
+  const r = client.User.delete({ where: { id: 1 }, select: { email: true } });
+  expectTypeOf<typeof r>().branded.toEqualTypeOf<{ email: string } | null>();
+}
+{
+  const r = client.User.upsert({
+    where: { id: 1 },
+    create: row,
+    update: { name: "x" },
+  });
+  expectTypeOf<(typeof r)["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<typeof r>().not.toBeNullable();
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -91,6 +91,7 @@ const getGassmaCommonTypes = (strict?: boolean) => {
       ? Omit<Base, keyof SelectedComputed<C, S>> & SelectedComputed<C, S>
       : Omit<Base, keyof ActiveComputed<C, QO>> & ActiveComputed<C, QO>;
 
+  type Subset<T, U> = { [K in keyof T]: K extends keyof U ? T[K] : never };
   type ExactKeys<T, Shape> = Shape & { [K in Exclude<keyof T, keyof Shape>]?: never };
   type StrictGlobalOmit<O, Config> = Config & {
     [K in keyof O]?: K extends keyof Config

--- a/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -4,8 +4,11 @@ const getOneGassmaController = (schemaName: string, sheetName: string) => {
   const c = `Gassma.At<CMap, "${sheetName}">`;
   const res = `${fr}<T["select"], T["include"], T["omit"], GO, O, CMap>`;
   const resNoArg = `${fr}<unknown, unknown, unknown, GO, O, CMap>`;
-  const arg = (dataSuffix: string) =>
-    `T extends ${self}${dataSuffix} & Gassma.ComputedArgs<${c}>`;
+  const withComputed = (dataSuffix: string) =>
+    `${self}${dataSuffix} & Gassma.ComputedArgs<${c}>`;
+  const arg = (dataSuffix: string) => `T extends ${withComputed(dataSuffix)}`;
+  const sub = (dataSuffix: string) =>
+    `T & Gassma.Subset<T, ${withComputed(dataSuffix)}>`;
 
   return `
 export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, CMap = {}> {
@@ -18,25 +21,25 @@ export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, CMap
     endColumnValue: number | string
   ): void;
   createMany(createdData: ${self}CreateManyData): CreateManyReturn;
-  createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: T): ${res}[];
-  create<${arg("CreateData")}>(createdData: T): ${res};
-  findFirst<${arg("FindFirstData")}>(findData: T): ${res} | null;
+  createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: ${sub("CreateManyAndReturnData")}): ${res}[];
+  create<${arg("CreateData")}>(createdData: ${sub("CreateData")}): ${res};
+  findFirst<${arg("FindFirstData")}>(findData: ${sub("FindFirstData")}): ${res} | null;
   findFirst(): ${resNoArg} | null;
-  findFirstOrThrow<${arg("FindFirstData")}>(findData: T): ${res};
+  findFirstOrThrow<${arg("FindFirstData")}>(findData: ${sub("FindFirstData")}): ${res};
   findFirstOrThrow(): ${resNoArg};
-  findMany<${arg("FindManyData")}>(findData: T): ${res}[];
+  findMany<${arg("FindManyData")}>(findData: ${sub("FindManyData")}): ${res}[];
   findMany(): ${resNoArg}[];
-  update<${arg("UpdateSingleData")}>(updateData: T): ${res} | null;
+  update<${arg("UpdateSingleData")}>(updateData: ${sub("UpdateSingleData")}): ${res} | null;
   updateMany(updateData: ${self}UpdateData): UpdateManyReturn;
   updateManyAndReturn(updateData: ${self}UpdateData): ${fr}<undefined, undefined, undefined, GO, O, CMap>[];
-  upsert<${arg("UpsertSingleData")}>(upsertData: T): ${res};
-  delete<${arg("DeleteSingleData")}>(deleteData: T): ${res} | null;
+  upsert<${arg("UpsertSingleData")}>(upsertData: ${sub("UpsertSingleData")}): ${res};
+  delete<${arg("DeleteSingleData")}>(deleteData: ${sub("DeleteSingleData")}): ${res} | null;
   deleteMany(deleteData: ${self}DeleteData): DeleteManyReturn;
   deleteMany(): DeleteManyReturn;
-  aggregate<T extends ${self}AggregateData>(aggregateData: T): ${self}AggregateResult<T>;
+  aggregate<T extends ${self}AggregateData>(aggregateData: T & Gassma.Subset<T, ${self}AggregateData>): ${self}AggregateResult<T>;
   count(coutData: ${self}CountData): number;
   count(): number;
-  groupBy<T extends ${self}GroupByData>(groupByData: T): ${self}GroupByResult<T>[];
+  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData>): ${self}GroupByResult<T>[];
 }
 `;
 };


### PR DESCRIPTION
## 概要

**有効なキーと混ぜた不正なキーが型エラーにならない**問題を修正します。

```ts
gassma.User.findMany({ where: { id: 1 }, typo: true });  // 修正前: 通ってしまう
gassma.User.aggregate({ where: { id: 1 }, typo: true }); // 修正前: 通ってしまう
```

単独の `{ typo: true }` は正しく拒否されるため、**タイプミスが混じった時だけ静かに素通りする**という気づきにくい形で漏れていました。

## 原因

Prisma は**ガジェット型**で捕捉しています:

```ts
type Subset<T, U> = { [K in keyof T]: K extends keyof U ? T[K] : never };
aggregate<T extends UserAggregateArgs>(args: Subset<T, UserAggregateArgs>)
```

余分なキーが `never` に写像されて代入不可になります。一方 gassma-cli は裸のジェネリクス(`aggregate<T extends AggregateData>(data: T)`)で、`T` が推論される経路では excess property check が働きませんでした。

## スコープの実測

全 API を分類し、31個のプローブを gassma(修正前後)と Prisma 7.4.1 に投げ、**TS 5.4.5 / 6.0.3 / 7.0.2** で測りました。

| API | 形 | 修正前 |
|---|---|---|
| create / createManyAndReturn / findFirst / findFirstOrThrow / findMany / update / upsert / delete / aggregate / groupBy | ジェネリック | **バグあり** |
| createMany / updateMany / updateManyAndReturn / deleteMany / count | 非ジェネリック(具象型) | 問題なし |

| ケース | 修正前 | **修正後** | Prisma@TS5 | Prisma@TS6 |
|---|---|---|---|---|
| top-level 単独 `findMany({ typo })` | ⭕ | ⭕ | ⭕ | ⭕ |
| **top-level 混在** `findMany({ where, typo })` 等9種 | **❌** | **⭕** | ⭕ | ⭕ |
| ネスト単独 `where: { typo }` | ⭕ | ⭕ | ⭕ | ⭕ |
| **ネスト混在** `where: { id, typo }` 等9種 | ❌ | ❌ | ⭕ | **❌** |

## 重要: 「Prisma は拒否する」は TS 5.x での話でした

当初「Prisma はネスト混在も拒否する」という前提でしたが、**TS 6.0 では本家 Prisma も素通り**します(TS 6 の推論変更により、5.x にあった制約インスタンス化型への excess property check の精緻化が消えたため)。

したがって**ガジェットで塞げるのは top-level(全 TS バージョン)**で、ネスト混在は現行 TS では本家にも存在する穴です。修正後の gassma は **Prisma@TS6 と同一の拒否範囲**になり、しかも TS 5/6/7 間で挙動が安定します(Prisma のネスト拒否は TS6 で退化)。

## 実装

生成物に `type Subset` を1行追加し、10メソッドの引数を `data: T` → `data: T & Gassma.Subset<T, <制約と同じ型>>` に変更しました。

### Prisma そのままの形ではなく `T &` を付けた理由

**pure な `(args: Subset<T, U>)` は gassma の型設計と噛み合わず、既存コードを壊すことを実測しました**:

1. **`findMany({})` のような空リテラル** — 逆マップ型への推論が候補を生まず `T` が制約へフォールバックします。Prisma は結果型を条件型で引くので無害ですが、**gassma は `FindResult<T["select"], ...>` と位置指定で引くため結果型が壊れます**。しかもコンパイルは通るので**サイレントに壊れる**性質でした
2. **select/omit の XOR union の受け渡し** — 逆マップ推論が union を潰します(Prisma の Args は XOR union を使わないため本家には無い問題)

`T &` でアンカーすると `T` へ常に推論候補が渡るため**推論・結果型が修正前と完全一致**し、`Subset` 側の `never` 写像で拒否は効きます。

## 検証

t-wada 流 TDD。**全体1347件パス**、format / lint / typecheck / test:types / build すべて clean。

独立した検証エージェントによる敵対的レビューを実施し、実装者の主張をすべて実測で裏取りしました:

- **拒否が効くこと** — 全10メソッド × 22ケースを head/base 両方でコンパイル。head は22/22 拒否、base は混在ケースが全て素通りすることを確認。「`T &` で拒否が骨抜きになる」懸念は否定されました
- **既存コードの非破壊** — 正当系プローブ約60ケース(where 演算子 / relation filter / select・include の入れ子 / omit / orderBy / cursor / distinct / nested write / `$extends` / `$transaction` / global omit / strict / `{}` / 引数省略 / 変数渡し)が TS 6.0.3 と 5.4.5 の両方でゼロエラー
- **結果型が厳密に不変** — head/base の d.ts を同一プログラムに import し、26ケースを `Equal` 型で比較して全一致。ハーネスが偽 Equal を検出することも自己検証済み
- **生成 JS がバイト不変** — fixture と gassma-test の実スキーマ2本で `cmp` 一致。d.ts も **Subset の記述を剥がすと base とバイト一致**(= 差分は Subset のみ)
- **gassma-test(実利用者コードの塊)** — コピーで生成物だけ差し替えて `tsc --noEmit` が exit 0(gassma-test 本体は無変更)
- 変異テスト3系統で Red 確認。`@ts-expect-error` の空振りが無いことも、混在系の期待エラーが Subset だけを根拠にしていることまで確認

## 既知の制限

**ジェネリックなラッパー関数の引数パススルー**が型エラーになります:

```ts
const wrap = <T extends GassmaUserFindManyData>(x: T) => gassma.User.findMany(x);  // エラーになる
```

具体型を渡すか、ラッパーを非ジェネリックにすれば回避できます。原因は Subset ガジェットと gassma の XOR union 型の組み合わせで、**pure な Prisma 形を gassma の型で再現しても同様に壊れる**ことを確認済みです(anchored 形固有の問題ではありません)。

## 残る課題(このPRのスコープ外)

- **ネスト混在**の素通り(TS 6 以降は本家 Prisma も同じ。塞ぐには再帰的な Exact 型など本家を超える独自仕様が必要)
- **非ジェネリック5メソッド**は非フレッシュ変数の余分キーを許す(修正前後で同一の既存挙動。Prisma はこれらもジェネリックで拒否)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja