### PR TITLE
fix: 生成型に欠けていたエラークラス2件をミラーする

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -48,6 +48,13 @@ describe("getGassmaErrorClasses", () => {
     expect(result).toContain("constructor(argumentName: string)");
   });
 
+  it("should include GassmaUnknownArgumentError", () => {
+    expect(result).toContain("class GassmaUnknownArgumentError extends Error");
+    expect(result).toContain(
+      "constructor(argumentName: string, availableArguments: string[])",
+    );
+  });
+
   it("should include RelationIgnoredColumnError", () => {
     expect(result).toContain("class RelationIgnoredColumnError extends Error");
     expect(result).toContain(
@@ -100,6 +107,12 @@ describe("getGassmaErrorClasses", () => {
     expect(result).toContain("class GassmaAggregateSumTypeError extends Error");
     expect(result).toContain(
       "class GassmaAggregateAvgTypeError extends GassmaAggregateSumTypeError",
+    );
+  });
+
+  it("should include GassmaAggregateSelectionRequiredError", () => {
+    expect(result).toContain(
+      "class GassmaAggregateSelectionRequiredError extends Error",
     );
   });
 

--- a/packages/cli/src/__test__/types/aggregate/aggregateSelectionRequiredError.test-d.ts
+++ b/packages/cli/src/__test__/types/aggregate/aggregateSelectionRequiredError.test-d.ts
@@ -1,0 +1,22 @@
+import { expectTypeOf } from "vitest";
+import { Gassma } from "../__generated__/client";
+
+// GassmaAggregateSelectionRequiredError は Gassma namespace から利用できる
+{
+  expectTypeOf<Gassma.GassmaAggregateSelectionRequiredError>().toExtend<Error>();
+  expectTypeOf<
+    ConstructorParameters<typeof Gassma.GassmaAggregateSelectionRequiredError>
+  >().toEqualTypeOf<[]>();
+}
+
+// catch した unknown を instanceof で型判別できる
+{
+  const caught: unknown = null;
+  if (caught instanceof Gassma.GassmaAggregateSelectionRequiredError) {
+    expectTypeOf(
+      caught,
+    ).toEqualTypeOf<Gassma.GassmaAggregateSelectionRequiredError>();
+    expectTypeOf(caught.message).toEqualTypeOf<string>();
+    expectTypeOf(caught.name).toEqualTypeOf<string>();
+  }
+}

--- a/packages/cli/src/__test__/types/query/unknownArgumentError.test-d.ts
+++ b/packages/cli/src/__test__/types/query/unknownArgumentError.test-d.ts
@@ -1,0 +1,20 @@
+import { expectTypeOf } from "vitest";
+import { Gassma } from "../__generated__/client";
+
+// GassmaUnknownArgumentError は Gassma namespace から利用できる
+{
+  expectTypeOf<Gassma.GassmaUnknownArgumentError>().toExtend<Error>();
+  expectTypeOf<
+    ConstructorParameters<typeof Gassma.GassmaUnknownArgumentError>
+  >().toEqualTypeOf<[argumentName: string, availableArguments: string[]]>();
+}
+
+// catch した unknown を instanceof で型判別できる
+{
+  const caught: unknown = null;
+  if (caught instanceof Gassma.GassmaUnknownArgumentError) {
+    expectTypeOf(caught).toEqualTypeOf<Gassma.GassmaUnknownArgumentError>();
+    expectTypeOf(caught.message).toEqualTypeOf<string>();
+    expectTypeOf(caught.name).toEqualTypeOf<string>();
+  }
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -45,6 +45,11 @@ const errorClassDefinitions: ErrorClassDef[] = [
     params: "",
   },
   {
+    name: "GassmaAggregateSelectionRequiredError",
+    extends: "Error",
+    params: "",
+  },
+  {
     name: "RelationSheetNotFoundError",
     extends: "Error",
     params: "sheetName: string",
@@ -159,6 +164,11 @@ const errorClassDefinitions: ErrorClassDef[] = [
     name: "GassmaMissingArgumentError",
     extends: "Error",
     params: "argumentName: string",
+  },
+  {
+    name: "GassmaUnknownArgumentError",
+    extends: "Error",
+    params: "argumentName: string, availableArguments: string[]",
   },
   {
     name: "GassmaRelationNotFoundError",


### PR DESCRIPTION
本体 gassma #192 で追加された `GassmaUnknownArgumentError` への追随です。あわせて、**以前から乖離していた1件**も直します。

## 問題

`getGassmaErrorClasses()` は生成型に本体のエラークラス宣言を出力する**手動メンテのミラー**です。ここに無いクラスは、**実行時には投げられるのに TypeScript ユーザーが `catch` で型を絞り込めません**。

欠けていたのは2件でした。

| クラス | 由来 | 用途 |
|---|---|---|
| `GassmaUnknownArgumentError` | 本体 #192(今回) | `deleteMany({ whre: ... })` や `{ age: { gth: 30 } }` のような typo を実行時に拒否する |
| `GassmaAggregateSelectionRequiredError` | 本体 #183 | `aggregate({})` のように集計対象が指定されていない場合 |

後者は**以前から乖離していたもの**です。今回の突き合わせで見つかりました。仕様の追加ではなく**実装との乖離の修正**なので、ミラーを追随させるという本 PR の目的そのものと判断して含めています。

## 修正

本体の宣言を正典として写しました。並びも本体 `index.d.ts` の順に合わせています。

```ts
{ name: "GassmaUnknownArgumentError", extends: "Error",
  params: "argumentName: string, availableArguments: string[]" }

{ name: "GassmaAggregateSelectionRequiredError", extends: "Error", params: "" }
```

正典の確認には `git show origin/main:src/index.d.ts` を使っています。**ローカルの dev が #192 未取り込みだった**ため、作業ディレクトリを見ていたら古い実装を写して食い違いに気づけないところでした。

生成後のフィクスチャに出る宣言が本体 `index.d.ts` と**一字一句一致する**ことも確認しています。

## drift ゼロの確認

本体 `index.d.ts` の全エラークラス(`GassmaController` / `FieldRef` を除く **50件**)と cli ミラーを機械的に diff し、**差分が空**であることを確認しました。

逆方向(本体から消えたのに cli に残存)は0件です。以前記録していた `GassmaTargetSheetNotFoundError` の残存は解消済みで、既存テストが「含まれないこと」を検証しています。

## 検証結果

- `npm test`: 177 files / **1,349 tests** 全 green
- `npm run test:types`: **214 files** / 1,349 tests、**no errors**
- `typecheck` / `lint`(431 files)/ `format:check` / `build` すべて pass

追加テストは、ミラー出力の検証2件と、**型テスト2ファイル**です。後者は `Error` を extend していること、`ConstructorParameters` が一致すること、そして **`catch` した `unknown` を絞り込めること**を確認しています(利用者にとっての実用上の関心はここなので)。

既存テストは1件も変更していません。

## 再発防止について(報告のみ・別途判断)

**本体とミラーを自動で突き合わせるテストは存在しません。** 既存の `gassmaErrorClasses.test.ts` は「ミラーに書いた内容がミラーの出力に出るか」という**自己参照的な検証**なので、本体との乖離は原理的に検出できません。今回の欠落が見逃されていたのはこのためです。**手動メンテを続ける限り同じ drift は必ず再発します。**

作れるかどうかを調べた結果:

- **npm 依存経由は不可**。npm の `gassma` パッケージは **cli 自身**で、本体(GAS ライブラリ)は npm 未公開のため、依存として引く経路がありません
- **ローカルでは容易**。本体は兄弟ディレクトリにあり、環境変数 + フォールバックで `src/index.d.ts` を読み、`describe.skipIf` にすれば手元では常時検証できます。パースは devDependencies にある TypeScript の compiler API が使え、「クラス名が `Error` で終わる」で全50件を正確に切り出せます
- **論点は CI**。現在の `ci-cli.yml` は cli のみ checkout しているため、本体の clone ステップ追加が要ります。その場合「**本体 main にクラスが追加された瞬間、cli 側の変更なしに cli の CI が赤くなる**」= 非密閉な CI になります。まさに欲しいアラートである一方、無関係な PR を巻き込むトレードオフがあります

`skipIf` 方式なら CI では黙ってスキップし、ローカル実行時のみ検証、という緩い運用も選べます。**非密閉 CI を許容するかの判断が要る**ため、本 PR には含めず別途相談とさせてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)