### PR TITLE
fix: GassmaInvalidValueError を生成型にミラーする

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -55,6 +55,13 @@ describe("getGassmaErrorClasses", () => {
     );
   });
 
+  it("should include GassmaInvalidValueError", () => {
+    expect(result).toContain("class GassmaInvalidValueError extends Error");
+    expect(result).toContain(
+      "constructor(argumentName: string, expected: string)",
+    );
+  });
+
   it("should include RelationIgnoredColumnError", () => {
     expect(result).toContain("class RelationIgnoredColumnError extends Error");
     expect(result).toContain(

--- a/packages/cli/src/__test__/types/query/invalidValueError.test-d.ts
+++ b/packages/cli/src/__test__/types/query/invalidValueError.test-d.ts
@@ -1,0 +1,20 @@
+import { expectTypeOf } from "vitest";
+import { Gassma } from "../__generated__/client";
+
+// GassmaInvalidValueError は Gassma namespace から利用できる
+{
+  expectTypeOf<Gassma.GassmaInvalidValueError>().toExtend<Error>();
+  expectTypeOf<
+    ConstructorParameters<typeof Gassma.GassmaInvalidValueError>
+  >().toEqualTypeOf<[argumentName: string, expected: string]>();
+}
+
+// catch した unknown を instanceof で型判別できる
+{
+  const caught: unknown = null;
+  if (caught instanceof Gassma.GassmaInvalidValueError) {
+    expectTypeOf(caught).toEqualTypeOf<Gassma.GassmaInvalidValueError>();
+    expectTypeOf(caught.message).toEqualTypeOf<string>();
+    expectTypeOf(caught.name).toEqualTypeOf<string>();
+  }
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -171,6 +171,11 @@ const errorClassDefinitions: ErrorClassDef[] = [
     params: "argumentName: string, availableArguments: string[]",
   },
   {
+    name: "GassmaInvalidValueError",
+    extends: "Error",
+    params: "argumentName: string, expected: string",
+  },
+  {
     name: "GassmaRelationNotFoundError",
     extends: "Error",
     params: "relationName: string, sheetName: string",


### PR DESCRIPTION
本体 gassma #194 で追加された `GassmaInvalidValueError` への追随です。

## 追加するもの

`orderBy` の方向が `"asc"` / `"desc"` のどちらでもない場合など、**引数の値が受け付けられないもの**だったときに投げられるエラーです。ミラーに無いと**実行時には投げられるのに TypeScript ユーザーが `catch` で型を絞り込めません**。

```ts
{
  name: "GassmaInvalidValueError",
  extends: "Error",
  params: "argumentName: string, expected: string",
},
```

正典は `git show origin/main:src/index.d.ts`(#194 = 8233794)で確認し、宣言・メッセージ形式ともに食い違いがないことを確認しています。挿入位置も本体の並び(`GassmaUnknownArgumentError` の直後)に合わせました。

## drift ゼロの確認

本体との突き合わせスクリプトで、作業前後を計測しています。

- **作業前**: drift 1件(`cli に無い: GassmaInvalidValueError`、本体 51 / cli 50)
- **作業後**: **drift なし**(51 / 51)

## 検証結果

- `npm test`: 177 files / **1,350 tests** 全 green
- `npm run test:types`: **215 files** / 1,350 tests、**no errors**
- `typecheck` / `lint`(432 files)/ `format:check` / `build` すべて pass

追加テストはミラー出力の検証1件と、型テスト1ファイルです。後者では `catch` した `unknown` が `instanceof` で正しく絞り込めることを、**fixtures から実生成したクライアント**に対して確認しています。既存テストは1件も変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)