### PR TITLE
feat: 生成クライアントに TSDoc を出力する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,6 +1193,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pluralize": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
+      "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -6087,7 +6094,8 @@
         "@prisma/internals": "^7.5.0",
         "commander": "^12.1.0",
         "jiti": "^2.6.1",
-        "open": "^11.0.0"
+        "open": "^11.0.0",
+        "pluralize": "^8.0.0"
       },
       "bin": {
         "gassma": "bin/index.js"
@@ -6095,6 +6103,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.3.2",
         "@types/node": "^22.10.2",
+        "@types/pluralize": "^0.0.33",
         "ci-info": "^4.4.0",
         "globals": "^15.13.0",
         "package-manager-detector": "^1.8.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,8 @@
     "@prisma/internals": "^7.5.0",
     "commander": "^12.1.0",
     "jiti": "^2.6.1",
-    "open": "^11.0.0"
+    "open": "^11.0.0",
+    "pluralize": "^8.0.0"
   },
   "keywords": [
     "Google Apps Script",
@@ -79,6 +80,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.2",
     "@types/node": "^22.10.2",
+    "@types/pluralize": "^0.0.33",
     "ci-info": "^4.4.0",
     "globals": "^15.13.0",
     "package-manager-detector": "^1.8.0",

--- a/packages/cli/scripts/genFixtureTypes.ts
+++ b/packages/cli/scripts/genFixtureTypes.ts
@@ -41,7 +41,7 @@ const generateFixture = (text: string, fileName: string) => {
     optionalFields,
     strict,
   );
-  const clientDts = generateClientDts("");
+  const clientDts = generateClientDts("", undefined, Object.keys(parsed));
 
   fs.writeFileSync(path.join(outDir, fileName), `${generated}\n${clientDts}`);
   console.log(`generated fixture types -> ${path.join(outDir, fileName)}`);

--- a/packages/cli/src/__test__/generate/jsGenerate/generateClientDts.test.ts
+++ b/packages/cli/src/__test__/generate/jsGenerate/generateClientDts.test.ts
@@ -48,10 +48,18 @@ describe("generateClientDts", () => {
   it("should export a TransactionClient type without $transaction", () => {
     const result = generateClientDts("Hoge");
 
-    expect(result).toContain(
-      `export type GassmaHogeTransactionClient<O extends Gassma.StrictGlobalOmit<O, GassmaHogeGlobalOmitConfig> = {}> = GassmaHogeSheet<O> & {
-  $extends: GassmaHogeExtendsFn<O, {}>;
-};`,
+    const declaration = result.slice(
+      result.indexOf("export type GassmaHogeTransactionClient"),
+    );
+
+    expect(declaration).toContain(
+      "export type GassmaHogeTransactionClient<O extends Gassma.StrictGlobalOmit<O, GassmaHogeGlobalOmitConfig> = {}> = GassmaHogeSheet<O> & {\n",
+    );
+    expect(declaration.slice(0, declaration.indexOf("};"))).toContain(
+      "  $extends: GassmaHogeExtendsFn<O, {}>;\n",
+    );
+    expect(declaration.slice(0, declaration.indexOf("};"))).not.toContain(
+      "$transaction",
     );
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaController/oneGassmaController";
 
 describe("getOneGassmaController", () => {
-  const result = getOneGassmaController("", "User");
+  const result = getOneGassmaController("", "User", ["id"]);
   const res = `GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O, CMap>`;
   const sub = (dataType: string) => `T & Gassma.Subset<T, ${dataType}>`;
   const withComputed = (dataType: string) =>

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -103,7 +103,7 @@ describe("getOneGassmaController", () => {
       `aggregate<T extends GassmaUserAggregateData>(aggregateData: ${sub("GassmaUserAggregateData")}): GassmaUserAggregateResult<T>`,
     );
     expect(result).toContain(
-      `count<T extends GassmaUserCountData>(coutData: ${sub("GassmaUserCountData")}): GassmaUserCountResult<T>`,
+      `count<T extends GassmaUserCountData>(countData: ${sub("GassmaUserCountData")}): GassmaUserCountResult<T>`,
     );
     expect(result).toContain(
       `groupBy<T extends GassmaUserGroupByData>(groupByData: ${sub("GassmaUserGroupByData")}): GassmaUserGroupByResult<T>[]`,

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
@@ -30,7 +30,7 @@ describe("getOneGassmaController no-arg overloads", () => {
       `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T & Gassma.Subset<T, GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>)`,
     );
     expect(result).toContain(
-      "count<T extends GassmaUserCountData>(coutData: T & Gassma.Subset<T, GassmaUserCountData>): GassmaUserCountResult<T>;",
+      "count<T extends GassmaUserCountData>(countData: T & Gassma.Subset<T, GassmaUserCountData>): GassmaUserCountResult<T>;",
     );
     expect(result).toContain(
       "deleteMany(deleteData: GassmaUserDeleteData): DeleteManyReturn;",

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaController/oneGassmaController";
 
 describe("getOneGassmaController no-arg overloads", () => {
-  const result = getOneGassmaController("", "User");
+  const result = getOneGassmaController("", "User", ["id"]);
   const resNoArg = `GassmaUserFindResult<unknown, unknown, unknown, GO, O, CMap>`;
 
   it("should allow findMany without arguments", () => {
@@ -38,7 +38,7 @@ describe("getOneGassmaController no-arg overloads", () => {
   });
 
   it("should prefix schema name in no-arg return types", () => {
-    const prefixed = getOneGassmaController("Hoge", "User");
+    const prefixed = getOneGassmaController("Hoge", "User", ["id"]);
     expect(prefixed).toContain(
       "findMany(): GassmaHogeUserFindResult<unknown, unknown, unknown, GO, O, CMap>[];",
     );

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/clientDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/clientDocs.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { generateClientDts } from "../../../../generate/jsGenerate/generateClientDts";
+
+const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const BLANK = " * ";
+const result = generateClientDts("Hoge", undefined, ["Post", "User"]);
+
+const clientDoc = [
+  "/**",
+  " * ##  GASsma Client",
+  BLANK,
+  " * Type-safe Google Sheets client for TypeScript & Google Apps Script",
+  " * @example",
+  " * ```",
+  " * const gassma = new GassmaClient()",
+  " * // Fetch zero or more Posts",
+  " * const posts = gassma.Post.findMany()",
+  " * ```",
+  BLANK,
+  BLANK,
+  ` * Read more in our [docs](${BASE}/reference/basic).`,
+  " */",
+].join("\n");
+
+describe("generateClientDts tsdoc", () => {
+  it("should document the transaction client type", () => {
+    expect(result).toContain(
+      [
+        "/**",
+        " * `GassmaClient` proxy available in interactive transactions.",
+        " */",
+        "export type GassmaHogeTransactionClient<",
+      ].join("\n"),
+    );
+  });
+
+  it("should document the client interface", () => {
+    expect(result).toContain(`${clientDoc}\nexport interface GassmaClient<`);
+  });
+
+  it("should document the client class", () => {
+    expect(result).toContain(
+      `${clientDoc}\nexport declare class GassmaClient<`,
+    );
+  });
+
+  it("should document the constructor", () => {
+    expect(result).toContain(
+      [
+        "  /**",
+        "   * Creates a GASsma client.",
+        "   * @param {GassmaHogeClientOptions} options - Spreadsheet id and model configuration.",
+        "   * @example",
+        "   * ```",
+        "   * const gassma = new GassmaClient()",
+        "   * ```",
+        "   * ",
+        "   * ```",
+        '   * const gassma = new GassmaClient({ id: "<spreadsheet id>" })',
+        "   * ```",
+        "   */",
+        "  constructor(options?: GassmaHogeClientOptions<O>);",
+      ].join("\n"),
+    );
+  });
+
+  it("should document $transaction", () => {
+    expect(result).toContain(
+      [
+        "  /**",
+        "   * Allows the running of a sequence of read/write operations that are guaranteed to either succeed or fail as a whole.",
+        "   * @example",
+        "   * ```",
+        "   * const [alice, bob] = gassma.$transaction((tx) => {",
+        "   *   const alice = tx.Post.create({ data: { ... } })",
+        "   *   const bob = tx.Post.create({ data: { ... } })",
+        "   *   return [alice, bob]",
+        "   * })",
+        "   * ```",
+        "   */",
+        "  $transaction<T>(",
+      ].join("\n"),
+    );
+  });
+
+  it("should document $extends on both the transaction client and the client interface", () => {
+    const extendsDoc = [
+      "  /**",
+      "   * Creates an extended client with additional behaviour.",
+      "   * @example",
+      "   * ```",
+      "   * const extended = gassma.$extends({",
+      "   *   result: {",
+      "   *     // ... provide result extensions here",
+      "   *   }",
+      "   * })",
+      "   * ```",
+      "   */",
+      "  $extends: GassmaHogeExtendsFn<O, {}>;",
+    ].join("\n");
+
+    expect(result.split(extendsDoc)).toHaveLength(3);
+  });
+
+  it("should not link to pages that are not published", () => {
+    expect(result).not.toContain("/reference/transaction");
+    expect(result).not.toContain("/reference/client-extensions");
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/clientDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/clientDocs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { generateClientDts } from "../../../../generate/jsGenerate/generateClientDts";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
 const BLANK = " * ";
 const result = generateClientDts("Hoge", undefined, ["Post", "User"]);
 
@@ -69,6 +69,7 @@ describe("generateClientDts tsdoc", () => {
       [
         "  /**",
         "   * Allows the running of a sequence of read/write operations that are guaranteed to either succeed or fail as a whole.",
+        `   * Read more here: ${BASE}/reference/transaction`,
         "   * @example",
         "   * ```",
         "   * const [alice, bob] = gassma.$transaction((tx) => {",
@@ -87,6 +88,7 @@ describe("generateClientDts tsdoc", () => {
     const extendsDoc = [
       "  /**",
       "   * Creates an extended client with additional behaviour.",
+      `   * Read more here: ${BASE}/reference/client-extensions/result`,
       "   * @example",
       "   * ```",
       "   * const extended = gassma.$extends({",
@@ -102,8 +104,8 @@ describe("generateClientDts tsdoc", () => {
     expect(result.split(extendsDoc)).toHaveLength(3);
   });
 
-  it("should not link to pages that are not published", () => {
-    expect(result).not.toContain("/reference/transaction");
-    expect(result).not.toContain("/reference/client-extensions");
+  it("should link $transaction and $extends to their reference pages", () => {
+    expect(result).toContain(`${BASE}/reference/transaction`);
+    expect(result).toContain(`${BASE}/reference/client-extensions/result`);
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/controllerDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/controllerDocs.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { getOneGassmaController } from "../../../../generate/typeGenerate/gassmaController/oneGassmaController";
+
+const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+
+describe("getOneGassmaController tsdoc", () => {
+  const result = getOneGassmaController("", "Post", ["id", "title"]);
+
+  it("should document the controller class", () => {
+    expect(result).toContain(
+      `/**
+ * The delegate class that exposes CRUD operations for the **Post** model.
+ */
+export declare class GassmaPostController<`,
+    );
+  });
+
+  it("should document the fields property", () => {
+    expect(result).toContain(
+      `  /**
+   * Fields of the Post model
+   */
+  readonly fields: Record<string, Gassma.FieldRef>;`,
+    );
+  });
+
+  it("should document changeSettings", () => {
+    expect(result).toContain(
+      `  /**
+   * Change the range this model reads and writes on the spreadsheet.
+   * Read more here: ${BASE}/reference/settings/changeSettings
+   * @param {number} startRowNumber - The row number the header row lives on.
+   * @param {number | string} startColumnValue - The first column of the range.
+   * @param {number | string} endColumnValue - The last column of the range.
+   */
+  changeSettings(`,
+    );
+  });
+
+  const members = [
+    "createMany(createdData:",
+    "createManyAndReturn<",
+    "create<",
+    "findFirst<",
+    "findFirst():",
+    "findFirstOrThrow<",
+    "findFirstOrThrow():",
+    "findMany<",
+    "findMany():",
+    "update<",
+    "updateMany(updateData:",
+    "updateManyAndReturn<",
+    "upsert<",
+    "delete<",
+    "deleteMany(deleteData:",
+    "deleteMany():",
+    "aggregate<",
+    "count<",
+    "count():",
+    "groupBy<",
+  ];
+
+  it.each(members)("should place a doc block right before %s", (member) => {
+    expect(result).toContain(`   */\n  ${member}`);
+  });
+
+  it("should give every documented operation an example", () => {
+    expect(result.split("   * @example\n")).toHaveLength(members.length + 1);
+  });
+
+  it("should use the model accessor and the first column in the examples", () => {
+    expect(result).toContain("   * const posts = gassma.Post.findMany()");
+    expect(result).toContain("   *   by: ['id'],");
+  });
+
+  it("should use the bracket accessor for model names that are not identifiers", () => {
+    const bracketed = getOneGassmaController("", "My Sheet", ["name"]);
+
+    expect(bracketed).toContain(
+      '   * const mySheets = gassma["My Sheet"].findMany()',
+    );
+    expect(bracketed).toContain(
+      "   * @param {GassmaMySheetFindManyData} findData - Arguments to filter and select certain fields only.",
+    );
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/controllerDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/controllerDocs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { getOneGassmaController } from "../../../../generate/typeGenerate/gassmaController/oneGassmaController";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
 
 describe("getOneGassmaController tsdoc", () => {
   const result = getOneGassmaController("", "Post", ["id", "title"]);

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/createDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/createDocs.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
+import { getCreateDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/createDocs";
+
+const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const naming = getModelNaming("", "Post", ["title", "body"]);
+const lines = getCreateDocLines(naming);
+
+describe("getCreateDocLines", () => {
+  it("should document createMany", () => {
+    expect(lines.createMany).toEqual([
+      "Create many Posts.",
+      `Read more here: ${BASE}/reference/crud/create/createMany`,
+      "@param {GassmaPostCreateManyData} createdData - Arguments to create many Posts.",
+      "@example",
+      "// Create many Posts",
+      "const post = gassma.Post.createMany({",
+      "  data: [",
+      "    // ... provide data here",
+      "  ]",
+      "})",
+      "",
+    ]);
+  });
+
+  it("should document createManyAndReturn", () => {
+    expect(lines.createManyAndReturn).toEqual([
+      "Create many Posts and returns the data saved in the spreadsheet.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/crud/create/createManyAndReturn`,
+      "@param {GassmaPostCreateManyAndReturnData} createdData - Arguments to create many Posts.",
+      "@example",
+      "// Create many Posts",
+      "const post = gassma.Post.createManyAndReturn({",
+      "  data: [",
+      "    // ... provide data here",
+      "  ]",
+      "})",
+      "",
+      "// Create many Posts and only return the `title`",
+      "const postWithTitleOnly = gassma.Post.createManyAndReturn({",
+      "  select: { title: true },",
+      "  data: [",
+      "    // ... provide data here",
+      "  ]",
+      "})",
+      "",
+    ]);
+  });
+
+  it("should document create", () => {
+    expect(lines.create).toEqual([
+      "Create a Post.",
+      `Read more here: ${BASE}/reference/crud/create/create`,
+      "@param {GassmaPostCreateData} createdData - Arguments to create a Post.",
+      "@example",
+      "// Create one Post",
+      "const Post = gassma.Post.create({",
+      "  data: {",
+      "    // ... data to create a Post",
+      "  }",
+      "})",
+      "",
+    ]);
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/createDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/createDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getCreateDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/createDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getCreateDocLines(naming);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/createReturnDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/createReturnDocs.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getGassmaCreateReturn } from "../../../../generate/typeGenerate/gassmaCreateReturn";
+
+const BLANK_DOC_LINE = " * ";
+
+describe("getGassmaCreateReturn tsdoc", () => {
+  it("should document the row type with the model name", () => {
+    const result = getGassmaCreateReturn({ Post: { title: ["string"] } }, "");
+
+    expect(result).toContain(
+      [
+        "/**",
+        " * Model Post",
+        BLANK_DOC_LINE,
+        " */",
+        "export type GassmaPostCreateReturn = {",
+      ].join("\n"),
+    );
+  });
+
+  it("should keep the original model name for cleaned type names", () => {
+    const result = getGassmaCreateReturn(
+      { "my-sheet": { title: ["string"] } },
+      "",
+    );
+
+    expect(result).toContain(" * Model my-sheet\n");
+    expect(result).toContain("export type GassmamysheetCreateReturn = {");
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/deleteDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/deleteDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getDeleteDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/deleteDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getDeleteDocLines(naming);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/deleteDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/deleteDocs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
+import { getDeleteDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/deleteDocs";
+
+const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const naming = getModelNaming("", "Post", ["title", "body"]);
+const lines = getDeleteDocLines(naming);
+
+describe("getDeleteDocLines", () => {
+  it("should document delete", () => {
+    expect(lines.deleteSingle).toEqual([
+      "Delete a Post.",
+      `Read more here: ${BASE}/reference/crud/delete/delete`,
+      "@param {GassmaPostDeleteSingleData} deleteData - Arguments to delete one Post.",
+      "@example",
+      "// Delete one Post",
+      "const Post = gassma.Post.delete({",
+      "  where: {",
+      "    // ... filter to delete one Post",
+      "  }",
+      "})",
+      "",
+    ]);
+  });
+
+  it("should document deleteMany with arguments", () => {
+    expect(lines.deleteMany).toEqual([
+      "Delete zero or more Posts.",
+      `Read more here: ${BASE}/reference/crud/delete/deleteMany`,
+      "@param {GassmaPostDeleteData} deleteData - Arguments to filter Posts to delete.",
+      "@example",
+      "// Delete a few Posts",
+      "const { count } = gassma.Post.deleteMany({",
+      "  where: {",
+      "    // ... provide filter here",
+      "  }",
+      "})",
+      "",
+    ]);
+  });
+
+  it("should document deleteMany without arguments", () => {
+    expect(lines.deleteManyNoArgs).toEqual([
+      "Delete every Post.",
+      "Calling `deleteMany` without arguments deletes **all** rows in the sheet. This cannot be undone.",
+      `Read more here: ${BASE}/reference/crud/delete/deleteMany`,
+      "@example",
+      "// Delete every Post in the sheet",
+      "const { count } = gassma.Post.deleteMany()",
+    ]);
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/docBlock.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/docBlock.test.ts
@@ -27,7 +27,7 @@ describe("renderDocBlock", () => {
 
   it("should expose the reference site base url", () => {
     expect(REFERENCE_BASE_URL).toBe(
-      "https://akahoshi1421.github.io/gassma-reference/docs",
+      "https://akahoshi1421.github.io/gassma-reference/en/docs",
     );
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/docBlock.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/docBlock.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  REFERENCE_BASE_URL,
+  renderDocBlock,
+} from "../../../../generate/typeGenerate/tsdoc/docBlock";
+
+describe("renderDocBlock", () => {
+  it("should wrap lines in a jsdoc block ending with a newline", () => {
+    expect(renderDocBlock("", ["Hello", "World"])).toBe(
+      "/**\n * Hello\n * World\n */\n",
+    );
+  });
+
+  it("should prefix every line with the given indent", () => {
+    expect(renderDocBlock("  ", ["Hello"])).toBe("  /**\n   * Hello\n   */\n");
+  });
+
+  it("should render an empty line as a star followed by a single space", () => {
+    expect(renderDocBlock("", ["a", "", "b"])).toBe(
+      "/**\n * a\n * \n * b\n */\n",
+    );
+  });
+
+  it("should render an indented empty line with the indent kept", () => {
+    expect(renderDocBlock("  ", [""])).toBe("  /**\n   * \n   */\n");
+  });
+
+  it("should expose the reference site base url", () => {
+    expect(REFERENCE_BASE_URL).toBe(
+      "https://akahoshi1421.github.io/gassma-reference/docs",
+    );
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/generatedDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/generatedDocs.test.ts
@@ -35,12 +35,36 @@ describe("generated tsdoc", () => {
     expect(generated).not.toContain("prisma.");
   });
 
-  it("should only link to published reference pages", () => {
-    expect(generated).not.toContain("/reference/transaction");
-    expect(generated).not.toContain("/reference/client-extensions");
-    expect(generated).not.toContain(
+  it("should link the client-level features to their reference pages", () => {
+    expect(generated).toContain("/reference/transaction");
+    expect(generated).toContain("/reference/client-extensions/result");
+  });
+
+  it("should link Gassma.skip to strictUndefinedChecks when it is declared", () => {
+    const strictGenerated = generater(
+      dictYaml,
+      undefined,
+      "",
+      true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(strictGenerated).toContain(
       "/reference/config/strict-undefined-checks",
     );
+  });
+
+  it("should link to the english reference, matching the language of the docs", () => {
+    const links = generated.match(/https:\/\/[^\s)]+gassma-reference[^\s)]*/g);
+
+    expect(links).not.toBeNull();
+    links?.forEach((link) => {
+      expect(link).toContain("/gassma-reference/en/docs/");
+    });
   });
 
   it("should not document findUnique operations that gassma does not have", () => {

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/generatedDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/generatedDocs.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { generater } from "../../../../generate/generator";
+import { generateClientDts } from "../../../../generate/jsGenerate/generateClientDts";
+
+const dictYaml = {
+  Post: { id: ["number"], title: ["string"] },
+  Users: { id: ["number"], name: ["string"] },
+};
+const generated = `${generater(dictYaml, undefined, "", true)}\n${generateClientDts("", undefined, Object.keys(dictYaml))}`;
+
+const ARGUMENT_LESS_OPERATIONS = [
+  "count",
+  "deleteMany",
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+];
+
+const getDocumentedNoArgCalls = () => {
+  const docLines = generated.split("\n").filter((line) => /^\s*\*/.test(line));
+  const calls = docLines.flatMap(
+    (line) => line.match(/\.[A-Za-z_$][A-Za-z0-9_$]*\(\)/g) ?? [],
+  );
+
+  return [...new Set(calls.map((call) => call.slice(1, -2)))].sort();
+};
+
+describe("generated tsdoc", () => {
+  it("should never emit await because gassma is synchronous", () => {
+    expect(generated).not.toContain("await");
+  });
+
+  it("should never mention the prisma client or its short links", () => {
+    expect(generated).not.toContain("pris.ly");
+    expect(generated).not.toContain("prisma.");
+  });
+
+  it("should only link to published reference pages", () => {
+    expect(generated).not.toContain("/reference/transaction");
+    expect(generated).not.toContain("/reference/client-extensions");
+    expect(generated).not.toContain(
+      "/reference/config/strict-undefined-checks",
+    );
+  });
+
+  it("should not document findUnique operations that gassma does not have", () => {
+    expect(generated).not.toContain("findUnique");
+  });
+
+  it("should never close a doc block from inside a doc line", () => {
+    const contentLines = generated
+      .split("\n")
+      .filter((line) => /^\s*\* /.test(line));
+
+    expect(contentLines.filter((line) => line.includes("*/"))).toEqual([]);
+  });
+
+  it("should document every model", () => {
+    expect(generated).toContain(
+      " * The delegate class that exposes CRUD operations for the **Post** model.",
+    );
+    expect(generated).toContain(
+      " * The delegate class that exposes CRUD operations for the **Users** model.",
+    );
+  });
+
+  it("should only show argument-less calls for the operations that allow them", () => {
+    expect(getDocumentedNoArgCalls()).toEqual(ARGUMENT_LESS_OPERATIONS);
+  });
+
+  it("should warn that deleteMany without arguments deletes everything", () => {
+    expect(generated).toContain(
+      "   * Calling `deleteMany` without arguments deletes **all** rows in the sheet. This cannot be undone.",
+    );
+  });
+
+  it("should not pluralize a model name that already ends with s", () => {
+    expect(generated).toContain("   * // Get all Users");
+    expect(generated).toContain("   * const users = gassma.Users.findMany()");
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/modelNaming.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/modelNaming.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
+
+describe("getModelNaming", () => {
+  it("should pluralize a model name that does not end with s", () => {
+    const naming = getModelNaming("", "Post", ["id", "title"]);
+
+    expect(naming.model).toBe("Post");
+    expect(naming.clean).toBe("Post");
+    expect(naming.plural).toBe("Posts");
+    expect(naming.variable).toBe("post");
+    expect(naming.variablePlural).toBe("posts");
+  });
+
+  it("should keep a model name that is already plural", () => {
+    const naming = getModelNaming("", "Users", ["id"]);
+
+    expect(naming.plural).toBe("Users");
+    expect(naming.variable).toBe("users");
+    expect(naming.variablePlural).toBe("users");
+  });
+
+  it("should pluralize irregular model names", () => {
+    expect(getModelNaming("", "Person", ["id"]).plural).toBe("People");
+    expect(getModelNaming("", "Category", ["id"]).plural).toBe("Categories");
+    expect(getModelNaming("", "Status", ["id"]).plural).toBe("Statuses");
+  });
+
+  it("should pluralize only the last word of a compound model name", () => {
+    const naming = getModelNaming("", "OrderItem", ["id"]);
+
+    expect(naming.plural).toBe("OrderItems");
+    expect(naming.variablePlural).toBe("orderItems");
+  });
+
+  it("should keep an uncountable model name unchanged", () => {
+    expect(getModelNaming("", "NewS", ["id"]).plural).toBe("NewS");
+  });
+
+  it("should build a dotted accessor for identifier-safe model names", () => {
+    expect(getModelNaming("", "Post", ["id"]).accessor).toBe("gassma.Post");
+    expect(getModelNaming("", "_Post$1", ["id"]).accessor).toBe(
+      "gassma._Post$1",
+    );
+  });
+
+  it("should build a bracket accessor for model names that are not identifiers", () => {
+    expect(getModelNaming("", "My Sheet", ["id"]).accessor).toBe(
+      'gassma["My Sheet"]',
+    );
+    expect(getModelNaming("", "1st", ["id"]).accessor).toBe('gassma["1st"]');
+  });
+
+  it("should build the generated type prefix from the schema name and the cleaned model name", () => {
+    const naming = getModelNaming("Hoge", "My Sheet", ["id"]);
+
+    expect(naming.clean).toBe("MySheet");
+    expect(naming.prefix).toBe("GassmaHogeMySheet");
+    expect(naming.variable).toBe("mySheet");
+    expect(naming.variablePlural).toBe("mySheets");
+  });
+
+  it("should use the first column as the sample field", () => {
+    const naming = getModelNaming("", "Post", ["title", "body"]);
+
+    expect(naming.field).toBe("title");
+    expect(naming.fieldCapital).toBe("Title");
+  });
+
+  it("should strip the optional marker from the first column", () => {
+    const naming = getModelNaming("", "Post", ["title?", "body"]);
+
+    expect(naming.field).toBe("title");
+  });
+
+  it("should fall back to id when the model has no column", () => {
+    const naming = getModelNaming("", "Post", []);
+
+    expect(naming.field).toBe("id");
+    expect(naming.fieldCapital).toBe("Id");
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/readDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/readDocs.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
+import { getReadDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/readDocs";
+
+const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const naming = getModelNaming("", "Post", ["title", "body"]);
+const lines = getReadDocLines(naming);
+
+describe("getReadDocLines", () => {
+  it("should document findFirst with arguments", () => {
+    expect(lines.findFirst).toEqual([
+      "Find the first Post that matches the filter.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/crud/read/findFirst`,
+      "@param {GassmaPostFindFirstData} findData - Arguments to find a Post",
+      "@example",
+      "// Get one Post",
+      "const post = gassma.Post.findFirst({",
+      "  where: {",
+      "    // ... provide filter here",
+      "  }",
+      "})",
+    ]);
+  });
+
+  it("should document findFirst without arguments", () => {
+    expect(lines.findFirstNoArgs).toEqual([
+      "Find the first Post.",
+      `Read more here: ${BASE}/reference/crud/read/findFirst`,
+      "@example",
+      "// Get the first Post",
+      "const post = gassma.Post.findFirst()",
+    ]);
+  });
+
+  it("should document findFirstOrThrow with arguments", () => {
+    expect(lines.findFirstOrThrow).toEqual([
+      "Find the first Post that matches the filter or",
+      "throw `NotFoundError` if no matches were found.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/crud/read/findFirstOrThrow`,
+      "@param {GassmaPostFindFirstData} findData - Arguments to find a Post",
+      "@example",
+      "// Get one Post",
+      "const post = gassma.Post.findFirstOrThrow({",
+      "  where: {",
+      "    // ... provide filter here",
+      "  }",
+      "})",
+    ]);
+  });
+
+  it("should document findFirstOrThrow without arguments", () => {
+    expect(lines.findFirstOrThrowNoArgs).toEqual([
+      "Find the first Post or throw `NotFoundError` if no Posts exist.",
+      `Read more here: ${BASE}/reference/crud/read/findFirstOrThrow`,
+      "@example",
+      "// Get the first Post",
+      "const post = gassma.Post.findFirstOrThrow()",
+    ]);
+  });
+
+  it("should document findMany with arguments", () => {
+    expect(lines.findMany).toEqual([
+      "Find zero or more Posts that matches the filter.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/crud/read/findMany`,
+      "@param {GassmaPostFindManyData} findData - Arguments to filter and select certain fields only.",
+      "@example",
+      "// Get all Posts",
+      "const posts = gassma.Post.findMany()",
+      "",
+      "// Get first 10 Posts",
+      "const posts = gassma.Post.findMany({ take: 10 })",
+      "",
+      "// Only select the `title`",
+      "const postWithTitleOnly = gassma.Post.findMany({ select: { title: true } })",
+      "",
+    ]);
+  });
+
+  it("should document findMany without arguments", () => {
+    expect(lines.findManyNoArgs).toEqual([
+      "Find all Posts.",
+      `Read more here: ${BASE}/reference/crud/read/findMany`,
+      "@example",
+      "// Get all Posts",
+      "const posts = gassma.Post.findMany()",
+    ]);
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/readDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/readDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getReadDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/readDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getReadDocLines(naming);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/sheetDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/sheetDocs.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getGassmaSheet } from "../../../../generate/typeGenerate/gassmaSheet";
+
+describe("getGassmaSheet tsdoc", () => {
+  it("should document each model property", () => {
+    const result = getGassmaSheet(["Post"], "");
+
+    expect(result).toContain(
+      `  /**
+   * \`gassma.Post\`: Exposes CRUD operations for the **Post** model.
+   * Example usage:
+   * \`\`\`ts
+   * // Fetch zero or more Posts
+   * const posts = gassma.Post.findMany()
+   * \`\`\`
+   */
+  "Post": GassmaPostController<`,
+    );
+  });
+
+  it("should use the bracket accessor for model names that are not identifiers", () => {
+    const result = getGassmaSheet(["my-sheet"], "");
+
+    expect(result).toContain(
+      '   * `gassma["my-sheet"]`: Exposes CRUD operations for the **my-sheet** model.',
+    );
+    expect(result).toContain(
+      '   * const mysheets = gassma["my-sheet"].findMany()',
+    );
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/statisticsDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/statisticsDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getStatisticsDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/statisticsDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getStatisticsDocLines(naming);
 
@@ -30,7 +30,7 @@ describe("getStatisticsDocLines", () => {
       "Count the number of Posts.",
       "Note, that providing `undefined` is treated as the value not being there.",
       `Read more here: ${BASE}/reference/statistics/count`,
-      "@param {GassmaPostCountData} coutData - Arguments to filter Posts to count.",
+      "@param {GassmaPostCountData} countData - Arguments to filter Posts to count.",
       "@example",
       "// Count the number of Posts",
       "const count = gassma.Post.count({",

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/statisticsDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/statisticsDocs.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
+import { getStatisticsDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/statisticsDocs";
+
+const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const naming = getModelNaming("", "Post", ["title", "body"]);
+const lines = getStatisticsDocLines(naming);
+
+describe("getStatisticsDocLines", () => {
+  it("should document aggregate", () => {
+    expect(lines.aggregate).toEqual([
+      "Allows you to perform aggregations operations on a Post.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/statistics/aggregate`,
+      "@param {GassmaPostAggregateData} aggregateData - Select which aggregations you would like to apply and on what fields.",
+      "@example",
+      "// Count the Posts that match the filter",
+      "const aggregations = gassma.Post.aggregate({",
+      "  _count: true,",
+      "  where: {",
+      "    // ... provide filter here",
+      "  },",
+      "  take: 10,",
+      "})",
+    ]);
+  });
+
+  it("should document count with arguments", () => {
+    expect(lines.count).toEqual([
+      "Count the number of Posts.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/statistics/count`,
+      "@param {GassmaPostCountData} coutData - Arguments to filter Posts to count.",
+      "@example",
+      "// Count the number of Posts",
+      "const count = gassma.Post.count({",
+      "  where: {",
+      "    // ... the filter for the Posts we want to count",
+      "  }",
+      "})",
+    ]);
+  });
+
+  it("should document count without arguments", () => {
+    expect(lines.countNoArgs).toEqual([
+      "Count every Post.",
+      `Read more here: ${BASE}/reference/statistics/count`,
+      "@example",
+      "// Count every Post",
+      "const count = gassma.Post.count()",
+    ]);
+  });
+
+  it("should document groupBy", () => {
+    expect(lines.groupBy).toEqual([
+      "Group by Post.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/statistics/groupBy`,
+      "@param {GassmaPostGroupByData} groupByData - Group by arguments.",
+      "@example",
+      "// Group by title, get count",
+      "const result = gassma.Post.groupBy({",
+      "  by: ['title'],",
+      "  _count: true,",
+      "})",
+      "",
+    ]);
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/updateDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/updateDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getUpdateDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/updateDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getUpdateDocLines(naming);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/updateDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/updateDocs.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
+import { getUpdateDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/updateDocs";
+
+const BASE = "https://akahoshi1421.github.io/gassma-reference/docs";
+const naming = getModelNaming("", "Post", ["title", "body"]);
+const lines = getUpdateDocLines(naming);
+
+describe("getUpdateDocLines", () => {
+  it("should document update", () => {
+    expect(lines.update).toEqual([
+      "Update one Post.",
+      `Read more here: ${BASE}/reference/crud/update/update`,
+      "@param {GassmaPostUpdateSingleData} updateData - Arguments to update one Post.",
+      "@example",
+      "// Update one Post",
+      "const post = gassma.Post.update({",
+      "  where: {",
+      "    // ... provide filter here",
+      "  },",
+      "  data: {",
+      "    // ... provide data here",
+      "  }",
+      "})",
+      "",
+    ]);
+  });
+
+  it("should document updateMany", () => {
+    expect(lines.updateMany).toEqual([
+      "Update zero or more Posts.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/crud/update/updateMany`,
+      "@param {GassmaPostUpdateData} updateData - Arguments to update one or more rows.",
+      "@example",
+      "// Update many Posts",
+      "const { count } = gassma.Post.updateMany({",
+      "  where: {",
+      "    // ... provide filter here",
+      "  },",
+      "  data: {",
+      "    // ... provide data here",
+      "  }",
+      "})",
+      "",
+    ]);
+  });
+
+  it("should document updateManyAndReturn", () => {
+    expect(lines.updateManyAndReturn).toEqual([
+      "Update zero or more Posts and returns the data updated in the spreadsheet.",
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${BASE}/reference/crud/update/updateManyAndReturn`,
+      "@param {GassmaPostUpdateManyAndReturnData} updateData - Arguments to update many Posts.",
+      "@example",
+      "// Update many Posts",
+      "const posts = gassma.Post.updateManyAndReturn({",
+      "  where: {",
+      "    // ... provide filter here",
+      "  },",
+      "  data: {",
+      "    // ... provide data here",
+      "  }",
+      "})",
+      "",
+      "// Update zero or more Posts and only return the `title`",
+      "const postWithTitleOnly = gassma.Post.updateManyAndReturn({",
+      "  select: { title: true },",
+      "  where: {",
+      "    // ... provide filter here",
+      "  },",
+      "  data: {",
+      "    // ... provide data here",
+      "  }",
+      "})",
+      "",
+    ]);
+  });
+
+  it("should document upsert", () => {
+    expect(lines.upsert).toEqual([
+      "Create or update one Post.",
+      `Read more here: ${BASE}/reference/crud/update/upsert`,
+      "@param {GassmaPostUpsertSingleData} upsertData - Arguments to update or create a Post.",
+      "@example",
+      "// Update or create a Post",
+      "const post = gassma.Post.upsert({",
+      "  create: {",
+      "    // ... data to create a Post",
+      "  },",
+      "  update: {",
+      "    // ... in case it already exists, update",
+      "  },",
+      "  where: {",
+      "    // ... the filter for the Post we want to update",
+      "  }",
+      "})",
+    ]);
+  });
+});

--- a/packages/cli/src/generate/generate.ts
+++ b/packages/cli/src/generate/generate.ts
@@ -121,7 +121,7 @@ function generateFromSchema(
     optionalFields,
     strict,
   );
-  const clientDts = generateClientDts(schemaName, enums);
+  const clientDts = generateClientDts(schemaName, enums, Object.keys(parsed));
   const mergedDts = resultString + "\n" + clientDts;
   writer(mergedDts, `${baseName}Client`, outputPath);
 

--- a/packages/cli/src/generate/generator.ts
+++ b/packages/cli/src/generate/generator.ts
@@ -69,7 +69,7 @@ const generater = (
   );
 
   result += getGassmaSheet(sheetNames, schema);
-  result += getGassmaController(sheetNames, schema);
+  result += getGassmaController(dictYaml, schema);
   if (includeCommon !== false) {
     result += getGassmaManyCount();
   }

--- a/packages/cli/src/generate/jsGenerate/generateClientDts.ts
+++ b/packages/cli/src/generate/jsGenerate/generateClientDts.ts
@@ -1,15 +1,22 @@
 import type { EnumsConfig } from "../read/extractEnums";
+import { getClientDocs } from "../typeGenerate/tsdoc/clientDocs";
 
-const generateClientDts = (schemaName: string, enums?: EnumsConfig): string => {
-  let result = `export type Gassma${schemaName}TransactionClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> = Gassma${schemaName}Sheet<O> & {
-  $extends: Gassma${schemaName}ExtendsFn<O, {}>;
+const generateClientDts = (
+  schemaName: string,
+  enums?: EnumsConfig,
+  sheetNames?: string[],
+): string => {
+  const docs = getClientDocs(schemaName, sheetNames ?? []);
+
+  let result = `${docs.transactionClient}export type Gassma${schemaName}TransactionClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> = Gassma${schemaName}Sheet<O> & {
+${docs.extends}  $extends: Gassma${schemaName}ExtendsFn<O, {}>;
 };
-export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> extends Gassma${schemaName}Sheet<O> {
-  $extends: Gassma${schemaName}ExtendsFn<O, {}>;
-  $transaction<T>(fn: (tx: Gassma${schemaName}TransactionClient<O>) => T, options?: Gassma.GassmaTransactionOptions): T;
+${docs.client}export interface GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> extends Gassma${schemaName}Sheet<O> {
+${docs.extends}  $extends: Gassma${schemaName}ExtendsFn<O, {}>;
+${docs.transaction}  $transaction<T>(fn: (tx: Gassma${schemaName}TransactionClient<O>) => T, options?: Gassma.GassmaTransactionOptions): T;
 }
-export declare class GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> {
-  constructor(options?: Gassma${schemaName}ClientOptions<O>);
+${docs.client}export declare class GassmaClient<O extends Gassma.StrictGlobalOmit<O, Gassma${schemaName}GlobalOmitConfig> = {}> {
+${docs.constructor}  constructor(options?: Gassma${schemaName}ClientOptions<O>);
 }
 `;
 

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -1,5 +1,20 @@
+import { REFERENCE_BASE_URL } from "./tsdoc/docBlock";
+
 const getSkipDeclarations = () => {
-  return `  const skip: unique symbol;
+  return `  /**
+   * Omits the field it is passed to, as if it had not been written at all.
+   * Unlike \`undefined\`, it is accepted while \`strictUndefinedChecks\` is on.
+   *
+   * Read more here: ${REFERENCE_BASE_URL}/reference/config/strict-undefined-checks
+   *
+   * @example
+   * \`\`\`
+   * gassma.User.findMany({
+   *   where: { name: search ?? Gassma.skip },
+   * });
+   * \`\`\`
+   */
+  const skip: unique symbol;
   type SkipValue = typeof skip;
   type SkipOptional<T> = { [K in keyof T]: {} extends Pick<T, K> ? T[K] | SkipValue : T[K] };
 

--- a/packages/cli/src/generate/typeGenerate/gassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController.ts
@@ -1,15 +1,19 @@
-import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaController } from "./gassmaController/oneGassmaController";
 
-const getGassmaController = (sheetNames: string[], schemaName: string) => {
-  const controllerTypeDeclare = sheetNames.reduce((pre, currentSheetName) => {
-    const removedSpaceCurrentSheetName =
-      getRemovedCantUseVarChar(currentSheetName);
-
-    return (
-      pre + getOneGassmaController(schemaName, removedSpaceCurrentSheetName)
-    );
-  }, "");
+const getGassmaController = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
+) => {
+  const controllerTypeDeclare = Object.keys(dictYaml).reduce(
+    (pre, currentSheetName) =>
+      pre +
+      getOneGassmaController(
+        schemaName,
+        currentSheetName,
+        Object.keys(dictYaml[currentSheetName]),
+      ),
+    "",
+  );
 
   return controllerTypeDeclare;
 };

--- a/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -46,7 +46,7 @@ ${docs.deleteSingle}  delete<${arg("DeleteSingleData")}>(deleteData: ${sub("Dele
 ${docs.deleteMany}  deleteMany(deleteData: ${self}DeleteData): DeleteManyReturn;
 ${docs.deleteManyNoArgs}  deleteMany(): DeleteManyReturn;
 ${docs.aggregate}  aggregate<T extends ${self}AggregateData>(aggregateData: T & Gassma.Subset<T, ${self}AggregateData>): ${self}AggregateResult<T>;
-${docs.count}  count<T extends ${self}CountData>(coutData: T & Gassma.Subset<T, ${self}CountData>): ${self}CountResult<T>;
+${docs.count}  count<T extends ${self}CountData>(countData: T & Gassma.Subset<T, ${self}CountData>): ${self}CountResult<T>;
 ${docs.countNoArgs}  count(): number;
 ${docs.groupBy}  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData>): ${self}GroupByResult<T>[];
 }

--- a/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -1,7 +1,16 @@
-const getOneGassmaController = (schemaName: string, sheetName: string) => {
-  const self = `Gassma${schemaName}${sheetName}`;
+import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+import { getControllerDocs } from "../tsdoc/docContext";
+
+const getOneGassmaController = (
+  schemaName: string,
+  sheetName: string,
+  columnNames: string[],
+) => {
+  const docs = getControllerDocs(schemaName, sheetName, columnNames);
+  const clean = getRemovedCantUseVarChar(sheetName);
+  const self = `Gassma${schemaName}${clean}`;
   const fr = `${self}FindResult`;
-  const c = `Gassma.At<CMap, "${sheetName}">`;
+  const c = `Gassma.At<CMap, "${clean}">`;
   const res = `${fr}<T["select"], T["include"], T["omit"], GO, O, CMap>`;
   const resNoArg = `${fr}<unknown, unknown, unknown, GO, O, CMap>`;
   const withComputed = (dataSuffix: string) =>
@@ -11,35 +20,35 @@ const getOneGassmaController = (schemaName: string, sheetName: string) => {
     `T & Gassma.Subset<T, ${withComputed(dataSuffix)}>`;
 
   return `
-export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, CMap = {}> {
+${docs.controllerClass}export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, CMap = {}> {
   constructor(sheetName: string, id?: string);
 
-  readonly fields: Record<string, Gassma.FieldRef>;
-  changeSettings(
+${docs.fields}  readonly fields: Record<string, Gassma.FieldRef>;
+${docs.changeSettings}  changeSettings(
     startRowNumber: number,
     startColumnValue: number | string,
     endColumnValue: number | string
   ): void;
-  createMany(createdData: ${self}CreateManyData): CreateManyReturn;
-  createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: ${sub("CreateManyAndReturnData")}): ${res}[];
-  create<${arg("CreateData")}>(createdData: ${sub("CreateData")}): ${res};
-  findFirst<${arg("FindFirstData")}>(findData: ${sub("FindFirstData")}): ${res} | null;
-  findFirst(): ${resNoArg} | null;
-  findFirstOrThrow<${arg("FindFirstData")}>(findData: ${sub("FindFirstData")}): ${res};
-  findFirstOrThrow(): ${resNoArg};
-  findMany<${arg("FindManyData")}>(findData: ${sub("FindManyData")}): ${res}[];
-  findMany(): ${resNoArg}[];
-  update<${arg("UpdateSingleData")}>(updateData: ${sub("UpdateSingleData")}): ${res} | null;
-  updateMany(updateData: ${self}UpdateData): UpdateManyReturn;
-  updateManyAndReturn<${arg("UpdateManyAndReturnData")}>(updateData: ${sub("UpdateManyAndReturnData")}): ${res}[];
-  upsert<${arg("UpsertSingleData")}>(upsertData: ${sub("UpsertSingleData")}): ${res};
-  delete<${arg("DeleteSingleData")}>(deleteData: ${sub("DeleteSingleData")}): ${res} | null;
-  deleteMany(deleteData: ${self}DeleteData): DeleteManyReturn;
-  deleteMany(): DeleteManyReturn;
-  aggregate<T extends ${self}AggregateData>(aggregateData: T & Gassma.Subset<T, ${self}AggregateData>): ${self}AggregateResult<T>;
-  count<T extends ${self}CountData>(coutData: T & Gassma.Subset<T, ${self}CountData>): ${self}CountResult<T>;
-  count(): number;
-  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData>): ${self}GroupByResult<T>[];
+${docs.createMany}  createMany(createdData: ${self}CreateManyData): CreateManyReturn;
+${docs.createManyAndReturn}  createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: ${sub("CreateManyAndReturnData")}): ${res}[];
+${docs.create}  create<${arg("CreateData")}>(createdData: ${sub("CreateData")}): ${res};
+${docs.findFirst}  findFirst<${arg("FindFirstData")}>(findData: ${sub("FindFirstData")}): ${res} | null;
+${docs.findFirstNoArgs}  findFirst(): ${resNoArg} | null;
+${docs.findFirstOrThrow}  findFirstOrThrow<${arg("FindFirstData")}>(findData: ${sub("FindFirstData")}): ${res};
+${docs.findFirstOrThrowNoArgs}  findFirstOrThrow(): ${resNoArg};
+${docs.findMany}  findMany<${arg("FindManyData")}>(findData: ${sub("FindManyData")}): ${res}[];
+${docs.findManyNoArgs}  findMany(): ${resNoArg}[];
+${docs.update}  update<${arg("UpdateSingleData")}>(updateData: ${sub("UpdateSingleData")}): ${res} | null;
+${docs.updateMany}  updateMany(updateData: ${self}UpdateData): UpdateManyReturn;
+${docs.updateManyAndReturn}  updateManyAndReturn<${arg("UpdateManyAndReturnData")}>(updateData: ${sub("UpdateManyAndReturnData")}): ${res}[];
+${docs.upsert}  upsert<${arg("UpsertSingleData")}>(upsertData: ${sub("UpsertSingleData")}): ${res};
+${docs.deleteSingle}  delete<${arg("DeleteSingleData")}>(deleteData: ${sub("DeleteSingleData")}): ${res} | null;
+${docs.deleteMany}  deleteMany(deleteData: ${self}DeleteData): DeleteManyReturn;
+${docs.deleteManyNoArgs}  deleteMany(): DeleteManyReturn;
+${docs.aggregate}  aggregate<T extends ${self}AggregateData>(aggregateData: T & Gassma.Subset<T, ${self}AggregateData>): ${self}AggregateResult<T>;
+${docs.count}  count<T extends ${self}CountData>(coutData: T & Gassma.Subset<T, ${self}CountData>): ${self}CountResult<T>;
+${docs.countNoArgs}  count(): number;
+${docs.groupBy}  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData>): ${self}GroupByResult<T>[];
 }
 `;
 };

--- a/packages/cli/src/generate/typeGenerate/gassmaCreateReturn.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCreateReturn.ts
@@ -1,4 +1,3 @@
-import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaCreateReturn } from "./gassmaCreateReturn/oneGassmaCreateReturn";
 
 const getGassmaCreateReturn = (
@@ -6,20 +5,13 @@ const getGassmaCreateReturn = (
   schemaName: string,
 ) => {
   const createReturnTypeDeclare = Object.keys(dictYaml).reduce(
-    (pre, currentSheetName) => {
-      const sheetContent = dictYaml[currentSheetName];
-      const removedSpaceCurrentSheetName =
-        getRemovedCantUseVarChar(currentSheetName);
-
-      return (
-        pre +
-        getOneGassmaCreateReturn(
-          sheetContent,
-          schemaName,
-          removedSpaceCurrentSheetName,
-        )
-      );
-    },
+    (pre, currentSheetName) =>
+      pre +
+      getOneGassmaCreateReturn(
+        dictYaml[currentSheetName],
+        schemaName,
+        currentSheetName,
+      ),
     "",
   );
 

--- a/packages/cli/src/generate/typeGenerate/gassmaCreateReturn/oneGassmaCreateReturn.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCreateReturn/oneGassmaCreateReturn.ts
@@ -1,10 +1,15 @@
 import { getColumnType } from "../../util/getColumnType";
+import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+import { getRowTypeDoc } from "../tsdoc/docContext";
 
 const getOneGassmaCreateReturn = (
   sheetContent: Record<string, unknown[]>,
   schemaName: string,
   sheetName: string,
 ) => {
+  const clean = getRemovedCantUseVarChar(sheetName);
+  const doc = getRowTypeDoc(schemaName, sheetName);
+
   const oneCreateReturn = Object.keys(sheetContent).reduce(
     (pre, columnName) => {
       const columnTypes = sheetContent[columnName];
@@ -18,7 +23,7 @@ const getOneGassmaCreateReturn = (
 
       return `${pre} "${removedQuestionMark}": ${now}${isQuestionMark ? " | null" : ""};\n`;
     },
-    `\nexport type Gassma${schemaName}${sheetName}CreateReturn = {\n`,
+    `\n${doc}export type Gassma${schemaName}${clean}CreateReturn = {\n`,
   );
 
   return `${oneCreateReturn}};\n`;

--- a/packages/cli/src/generate/typeGenerate/gassmaSheet.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaSheet.ts
@@ -1,10 +1,12 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getSheetPropertyDoc } from "./tsdoc/docContext";
 
 const getGassmaSheet = (sheetNames: string[], schemaName: string) => {
   const sheetTypeDeclare = sheetNames.reduce((pre, current) => {
     const clean = getRemovedCantUseVarChar(current);
+    const doc = getSheetPropertyDoc(schemaName, current);
 
-    return `${pre}  "${current}": Gassma${schemaName}${clean}Controller<O extends { "${current}": infer UO } ? UO extends Gassma${schemaName}${clean}Omit ? UO : {} : {}, O>;\n`;
+    return `${pre}${doc}  "${current}": Gassma${schemaName}${clean}Controller<O extends { "${current}": infer UO } ? UO extends Gassma${schemaName}${clean}Omit ? UO : {} : {}, O>;\n`;
   }, `export type Gassma${schemaName}Sheet<O extends Gassma${schemaName}GlobalOmitConfig = {}> = {\n`);
 
   return sheetTypeDeclare + "};\n";

--- a/packages/cli/src/generate/typeGenerate/tsdoc/clientDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/clientDocs.ts
@@ -1,0 +1,88 @@
+import { REFERENCE_BASE_URL, renderDocBlock } from "./docBlock";
+import { getModelNaming } from "./modelNaming";
+
+const FENCE = "```";
+const MEMBER_INDENT = "  ";
+const FALLBACK_MODEL = "Model";
+
+const clientDocLines = (
+  plural: string,
+  variablePlural: string,
+  accessor: string,
+) => [
+  "##  GASsma Client",
+  "",
+  "Type-safe Google Sheets client for TypeScript & Google Apps Script",
+  "@example",
+  FENCE,
+  "const gassma = new GassmaClient()",
+  `// Fetch zero or more ${plural}`,
+  `const ${variablePlural} = ${accessor}.findMany()`,
+  FENCE,
+  "",
+  "",
+  `Read more in our [docs](${REFERENCE_BASE_URL}/reference/basic).`,
+];
+
+const constructorDocLines = (schemaName: string) => [
+  "Creates a GASsma client.",
+  `@param {Gassma${schemaName}ClientOptions} options - Spreadsheet id and model configuration.`,
+  "@example",
+  FENCE,
+  "const gassma = new GassmaClient()",
+  FENCE,
+  "",
+  FENCE,
+  'const gassma = new GassmaClient({ id: "<spreadsheet id>" })',
+  FENCE,
+];
+
+const transactionDocLines = (model: string) => [
+  "Allows the running of a sequence of read/write operations that are guaranteed to either succeed or fail as a whole.",
+  "@example",
+  FENCE,
+  "const [alice, bob] = gassma.$transaction((tx) => {",
+  `  const alice = tx.${model}.create({ data: { ... } })`,
+  `  const bob = tx.${model}.create({ data: { ... } })`,
+  "  return [alice, bob]",
+  "})",
+  FENCE,
+];
+
+const EXTENDS_DOC_LINES = [
+  "Creates an extended client with additional behaviour.",
+  "@example",
+  FENCE,
+  "const extended = gassma.$extends({",
+  "  result: {",
+  "    // ... provide result extensions here",
+  "  }",
+  "})",
+  FENCE,
+];
+
+const TRANSACTION_CLIENT_DOC_LINES = [
+  "`GassmaClient` proxy available in interactive transactions.",
+];
+
+const getClientDocs = (schemaName: string, sheetNames: string[]) => {
+  const naming = getModelNaming(
+    schemaName,
+    sheetNames[0] ?? FALLBACK_MODEL,
+    [],
+  );
+  const member = (lines: string[]) => renderDocBlock(MEMBER_INDENT, lines);
+
+  return {
+    transactionClient: renderDocBlock("", TRANSACTION_CLIENT_DOC_LINES),
+    client: renderDocBlock(
+      "",
+      clientDocLines(naming.plural, naming.variablePlural, naming.accessor),
+    ),
+    constructor: member(constructorDocLines(schemaName)),
+    transaction: member(transactionDocLines(naming.model)),
+    extends: member(EXTENDS_DOC_LINES),
+  };
+};
+
+export { getClientDocs };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/clientDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/clientDocs.ts
@@ -39,6 +39,7 @@ const constructorDocLines = (schemaName: string) => [
 
 const transactionDocLines = (model: string) => [
   "Allows the running of a sequence of read/write operations that are guaranteed to either succeed or fail as a whole.",
+  `Read more here: ${REFERENCE_BASE_URL}/reference/transaction`,
   "@example",
   FENCE,
   "const [alice, bob] = gassma.$transaction((tx) => {",
@@ -51,6 +52,7 @@ const transactionDocLines = (model: string) => [
 
 const EXTENDS_DOC_LINES = [
   "Creates an extended client with additional behaviour.",
+  `Read more here: ${REFERENCE_BASE_URL}/reference/client-extensions/result`,
   "@example",
   FENCE,
   "const extended = gassma.$extends({",

--- a/packages/cli/src/generate/typeGenerate/tsdoc/docBlock.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/docBlock.ts
@@ -1,0 +1,10 @@
+const REFERENCE_BASE_URL =
+  "https://akahoshi1421.github.io/gassma-reference/docs";
+
+const renderDocBlock = (indent: string, lines: string[]) => {
+  const body = lines.map((line) => `${indent} * ${line}\n`).join("");
+
+  return `${indent}/**\n${body}${indent} */\n`;
+};
+
+export { REFERENCE_BASE_URL, renderDocBlock };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/docBlock.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/docBlock.ts
@@ -1,5 +1,6 @@
+// TSDoc の本文が英語なので英語版を指す。defaultLocale が ja なので en は /en/ 配下
 const REFERENCE_BASE_URL =
-  "https://akahoshi1421.github.io/gassma-reference/docs";
+  "https://akahoshi1421.github.io/gassma-reference/en/docs";
 
 const renderDocBlock = (indent: string, lines: string[]) => {
   const body = lines.map((line) => `${indent} * ${line}\n`).join("");

--- a/packages/cli/src/generate/typeGenerate/tsdoc/docContext.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/docContext.ts
@@ -1,0 +1,70 @@
+import { renderDocBlock } from "./docBlock";
+import { getModelNaming } from "./modelNaming";
+import { getCreateDocLines } from "./operations/createDocs";
+import { getDeleteDocLines } from "./operations/deleteDocs";
+import {
+  changeSettingsDocLines,
+  controllerClassDocLines,
+  fieldsDocLines,
+  rowTypeDocLines,
+  sheetPropertyDocLines,
+} from "./operations/modelDocs";
+import { getReadDocLines } from "./operations/readDocs";
+import { getStatisticsDocLines } from "./operations/statisticsDocs";
+import { getUpdateDocLines } from "./operations/updateDocs";
+
+const MEMBER_INDENT = "  ";
+
+const getControllerDocs = (
+  schemaName: string,
+  sheetName: string,
+  columnNames: string[],
+) => {
+  const naming = getModelNaming(schemaName, sheetName, columnNames);
+  const member = (lines: string[]) => renderDocBlock(MEMBER_INDENT, lines);
+  const create = getCreateDocLines(naming);
+  const read = getReadDocLines(naming);
+  const update = getUpdateDocLines(naming);
+  const remove = getDeleteDocLines(naming);
+  const statistics = getStatisticsDocLines(naming);
+
+  return {
+    controllerClass: renderDocBlock("", controllerClassDocLines(naming)),
+    fields: member(fieldsDocLines(naming)),
+    changeSettings: member(changeSettingsDocLines()),
+    createMany: member(create.createMany),
+    createManyAndReturn: member(create.createManyAndReturn),
+    create: member(create.create),
+    findFirst: member(read.findFirst),
+    findFirstNoArgs: member(read.findFirstNoArgs),
+    findFirstOrThrow: member(read.findFirstOrThrow),
+    findFirstOrThrowNoArgs: member(read.findFirstOrThrowNoArgs),
+    findMany: member(read.findMany),
+    findManyNoArgs: member(read.findManyNoArgs),
+    update: member(update.update),
+    updateMany: member(update.updateMany),
+    updateManyAndReturn: member(update.updateManyAndReturn),
+    upsert: member(update.upsert),
+    deleteSingle: member(remove.deleteSingle),
+    deleteMany: member(remove.deleteMany),
+    deleteManyNoArgs: member(remove.deleteManyNoArgs),
+    aggregate: member(statistics.aggregate),
+    count: member(statistics.count),
+    countNoArgs: member(statistics.countNoArgs),
+    groupBy: member(statistics.groupBy),
+  };
+};
+
+const getSheetPropertyDoc = (schemaName: string, sheetName: string) =>
+  renderDocBlock(
+    MEMBER_INDENT,
+    sheetPropertyDocLines(getModelNaming(schemaName, sheetName, [])),
+  );
+
+const getRowTypeDoc = (schemaName: string, sheetName: string) =>
+  renderDocBlock(
+    "",
+    rowTypeDocLines(getModelNaming(schemaName, sheetName, [])),
+  );
+
+export { getControllerDocs, getRowTypeDoc, getSheetPropertyDoc };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/modelNaming.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/modelNaming.ts
@@ -1,0 +1,59 @@
+import pluralize from "pluralize";
+import { getRemovedCantUseVarChar } from "../../util/getRemovedCantUseVarChar";
+
+type ModelNaming = {
+  model: string;
+  clean: string;
+  plural: string;
+  variable: string;
+  variablePlural: string;
+  accessor: string;
+  prefix: string;
+  field: string;
+  fieldCapital: string;
+};
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+const toLowerHead = (word: string) =>
+  word.charAt(0).toLowerCase() + word.slice(1);
+
+const toUpperHead = (word: string) =>
+  word.charAt(0).toUpperCase() + word.slice(1);
+
+const toAccessor = (model: string) =>
+  IDENTIFIER_PATTERN.test(model)
+    ? `gassma.${model}`
+    : `gassma[${JSON.stringify(model)}]`;
+
+const toSampleField = (columnNames: string[]) => {
+  const first = columnNames[0];
+  if (first === undefined) return "id";
+
+  return first.at(-1) === "?" ? first.slice(0, -1) : first;
+};
+
+const getModelNaming = (
+  schemaName: string,
+  model: string,
+  columnNames: string[],
+): ModelNaming => {
+  const clean = getRemovedCantUseVarChar(model);
+  const variable = toLowerHead(clean);
+  const field = toSampleField(columnNames);
+
+  return {
+    model,
+    clean,
+    plural: pluralize(model),
+    variable,
+    variablePlural: pluralize(variable),
+    accessor: toAccessor(model),
+    prefix: `Gassma${schemaName}${clean}`,
+    field,
+    fieldCapital: toUpperHead(field),
+  };
+};
+
+export { getModelNaming };
+export type { ModelNaming };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/operations/createDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/operations/createDocs.ts
@@ -1,0 +1,58 @@
+import { REFERENCE_BASE_URL } from "../docBlock";
+import type { ModelNaming } from "../modelNaming";
+
+const CREATE_BASE = `${REFERENCE_BASE_URL}/reference/crud/create`;
+
+const dataArrayLines = ["  data: [", "    // ... provide data here", "  ]"];
+
+const getCreateDocLines = (naming: ModelNaming) => {
+  const { accessor, clean, field, fieldCapital, model, plural, variable } =
+    naming;
+
+  return {
+    createMany: [
+      `Create many ${plural}.`,
+      `Read more here: ${CREATE_BASE}/createMany`,
+      `@param {${naming.prefix}CreateManyData} createdData - Arguments to create many ${plural}.`,
+      "@example",
+      `// Create many ${plural}`,
+      `const ${variable} = ${accessor}.createMany({`,
+      ...dataArrayLines,
+      "})",
+      "",
+    ],
+    createManyAndReturn: [
+      `Create many ${plural} and returns the data saved in the spreadsheet.`,
+      "Note, that providing `undefined` is treated as the value not being there.",
+      `Read more here: ${CREATE_BASE}/createManyAndReturn`,
+      `@param {${naming.prefix}CreateManyAndReturnData} createdData - Arguments to create many ${plural}.`,
+      "@example",
+      `// Create many ${plural}`,
+      `const ${variable} = ${accessor}.createManyAndReturn({`,
+      ...dataArrayLines,
+      "})",
+      "",
+      `// Create many ${plural} and only return the \`${field}\``,
+      `const ${variable}With${fieldCapital}Only = ${accessor}.createManyAndReturn({`,
+      `  select: { ${field}: true },`,
+      ...dataArrayLines,
+      "})",
+      "",
+    ],
+    create: [
+      `Create a ${model}.`,
+      `Read more here: ${CREATE_BASE}/create`,
+      `@param {${naming.prefix}CreateData} createdData - Arguments to create a ${model}.`,
+      "@example",
+      `// Create one ${model}`,
+      `const ${clean} = ${accessor}.create({`,
+      "  data: {",
+      `    // ... data to create a ${model}`,
+      "  }",
+      "})",
+      "",
+    ],
+  };
+};
+
+export { getCreateDocLines };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/operations/deleteDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/operations/deleteDocs.ts
@@ -1,0 +1,48 @@
+import { REFERENCE_BASE_URL } from "../docBlock";
+import type { ModelNaming } from "../modelNaming";
+import { WHERE_LINES } from "./readDocs";
+
+const DELETE_BASE = `${REFERENCE_BASE_URL}/reference/crud/delete`;
+const DELETE_ALL_WARNING =
+  "Calling `deleteMany` without arguments deletes **all** rows in the sheet. This cannot be undone.";
+
+const getDeleteDocLines = (naming: ModelNaming) => {
+  const { accessor, clean, model, plural, prefix } = naming;
+
+  return {
+    deleteSingle: [
+      `Delete a ${model}.`,
+      `Read more here: ${DELETE_BASE}/delete`,
+      `@param {${prefix}DeleteSingleData} deleteData - Arguments to delete one ${model}.`,
+      "@example",
+      `// Delete one ${model}`,
+      `const ${clean} = ${accessor}.delete({`,
+      "  where: {",
+      `    // ... filter to delete one ${model}`,
+      "  }",
+      "})",
+      "",
+    ],
+    deleteMany: [
+      `Delete zero or more ${plural}.`,
+      `Read more here: ${DELETE_BASE}/deleteMany`,
+      `@param {${prefix}DeleteData} deleteData - Arguments to filter ${plural} to delete.`,
+      "@example",
+      `// Delete a few ${plural}`,
+      `const { count } = ${accessor}.deleteMany({`,
+      ...WHERE_LINES,
+      "})",
+      "",
+    ],
+    deleteManyNoArgs: [
+      `Delete every ${model}.`,
+      DELETE_ALL_WARNING,
+      `Read more here: ${DELETE_BASE}/deleteMany`,
+      "@example",
+      `// Delete every ${model} in the sheet`,
+      `const { count } = ${accessor}.deleteMany()`,
+    ],
+  };
+};
+
+export { getDeleteDocLines };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/operations/modelDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/operations/modelDocs.ts
@@ -1,0 +1,42 @@
+import { REFERENCE_BASE_URL } from "../docBlock";
+import type { ModelNaming } from "../modelNaming";
+
+const controllerClassDocLines = ({ model }: ModelNaming) => [
+  `The delegate class that exposes CRUD operations for the **${model}** model.`,
+];
+
+const fieldsDocLines = ({ model }: ModelNaming) => [
+  `Fields of the ${model} model`,
+];
+
+const changeSettingsDocLines = () => [
+  "Change the range this model reads and writes on the spreadsheet.",
+  `Read more here: ${REFERENCE_BASE_URL}/reference/settings/changeSettings`,
+  "@param {number} startRowNumber - The row number the header row lives on.",
+  "@param {number | string} startColumnValue - The first column of the range.",
+  "@param {number | string} endColumnValue - The last column of the range.",
+];
+
+const sheetPropertyDocLines = ({
+  accessor,
+  model,
+  plural,
+  variablePlural,
+}: ModelNaming) => [
+  `\`${accessor}\`: Exposes CRUD operations for the **${model}** model.`,
+  "Example usage:",
+  "```ts",
+  `// Fetch zero or more ${plural}`,
+  `const ${variablePlural} = ${accessor}.findMany()`,
+  "```",
+];
+
+const rowTypeDocLines = ({ model }: ModelNaming) => [`Model ${model}`, ""];
+
+export {
+  changeSettingsDocLines,
+  controllerClassDocLines,
+  fieldsDocLines,
+  rowTypeDocLines,
+  sheetPropertyDocLines,
+};

--- a/packages/cli/src/generate/typeGenerate/tsdoc/operations/readDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/operations/readDocs.ts
@@ -1,0 +1,72 @@
+import { REFERENCE_BASE_URL } from "../docBlock";
+import type { ModelNaming } from "../modelNaming";
+
+const READ_BASE = `${REFERENCE_BASE_URL}/reference/crud/read`;
+const UNDEFINED_NOTE =
+  "Note, that providing `undefined` is treated as the value not being there.";
+const WHERE_LINES = ["  where: {", "    // ... provide filter here", "  }"];
+
+const getReadDocLines = (naming: ModelNaming) => {
+  const { accessor, field, fieldCapital, model, plural, prefix } = naming;
+  const { variable, variablePlural } = naming;
+
+  const findOne = (operation: string, head: string[]) => [
+    ...head,
+    UNDEFINED_NOTE,
+    `Read more here: ${READ_BASE}/${operation}`,
+    `@param {${prefix}FindFirstData} findData - Arguments to find a ${model}`,
+    "@example",
+    `// Get one ${model}`,
+    `const ${variable} = ${accessor}.${operation}({`,
+    ...WHERE_LINES,
+    "})",
+  ];
+
+  const findOneNoArgs = (operation: string, head: string) => [
+    head,
+    `Read more here: ${READ_BASE}/${operation}`,
+    "@example",
+    `// Get the first ${model}`,
+    `const ${variable} = ${accessor}.${operation}()`,
+  ];
+
+  return {
+    findFirst: findOne("findFirst", [
+      `Find the first ${model} that matches the filter.`,
+    ]),
+    findFirstNoArgs: findOneNoArgs("findFirst", `Find the first ${model}.`),
+    findFirstOrThrow: findOne("findFirstOrThrow", [
+      `Find the first ${model} that matches the filter or`,
+      "throw `NotFoundError` if no matches were found.",
+    ]),
+    findFirstOrThrowNoArgs: findOneNoArgs(
+      "findFirstOrThrow",
+      `Find the first ${model} or throw \`NotFoundError\` if no ${plural} exist.`,
+    ),
+    findMany: [
+      `Find zero or more ${plural} that matches the filter.`,
+      UNDEFINED_NOTE,
+      `Read more here: ${READ_BASE}/findMany`,
+      `@param {${prefix}FindManyData} findData - Arguments to filter and select certain fields only.`,
+      "@example",
+      `// Get all ${plural}`,
+      `const ${variablePlural} = ${accessor}.findMany()`,
+      "",
+      `// Get first 10 ${plural}`,
+      `const ${variablePlural} = ${accessor}.findMany({ take: 10 })`,
+      "",
+      `// Only select the \`${field}\``,
+      `const ${variable}With${fieldCapital}Only = ${accessor}.findMany({ select: { ${field}: true } })`,
+      "",
+    ],
+    findManyNoArgs: [
+      `Find all ${plural}.`,
+      `Read more here: ${READ_BASE}/findMany`,
+      "@example",
+      `// Get all ${plural}`,
+      `const ${variablePlural} = ${accessor}.findMany()`,
+    ],
+  };
+};
+
+export { getReadDocLines, UNDEFINED_NOTE, WHERE_LINES };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/operations/statisticsDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/operations/statisticsDocs.ts
@@ -27,7 +27,7 @@ const getStatisticsDocLines = (naming: ModelNaming) => {
       `Count the number of ${plural}.`,
       UNDEFINED_NOTE,
       `Read more here: ${STATISTICS_BASE}/count`,
-      `@param {${prefix}CountData} coutData - Arguments to filter ${plural} to count.`,
+      `@param {${prefix}CountData} countData - Arguments to filter ${plural} to count.`,
       "@example",
       `// Count the number of ${plural}`,
       `const count = ${accessor}.count({`,

--- a/packages/cli/src/generate/typeGenerate/tsdoc/operations/statisticsDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/operations/statisticsDocs.ts
@@ -1,0 +1,62 @@
+import { REFERENCE_BASE_URL } from "../docBlock";
+import type { ModelNaming } from "../modelNaming";
+import { UNDEFINED_NOTE } from "./readDocs";
+
+const STATISTICS_BASE = `${REFERENCE_BASE_URL}/reference/statistics`;
+
+const getStatisticsDocLines = (naming: ModelNaming) => {
+  const { accessor, field, model, plural, prefix } = naming;
+
+  return {
+    aggregate: [
+      `Allows you to perform aggregations operations on a ${model}.`,
+      UNDEFINED_NOTE,
+      `Read more here: ${STATISTICS_BASE}/aggregate`,
+      `@param {${prefix}AggregateData} aggregateData - Select which aggregations you would like to apply and on what fields.`,
+      "@example",
+      `// Count the ${plural} that match the filter`,
+      `const aggregations = ${accessor}.aggregate({`,
+      "  _count: true,",
+      "  where: {",
+      "    // ... provide filter here",
+      "  },",
+      "  take: 10,",
+      "})",
+    ],
+    count: [
+      `Count the number of ${plural}.`,
+      UNDEFINED_NOTE,
+      `Read more here: ${STATISTICS_BASE}/count`,
+      `@param {${prefix}CountData} coutData - Arguments to filter ${plural} to count.`,
+      "@example",
+      `// Count the number of ${plural}`,
+      `const count = ${accessor}.count({`,
+      "  where: {",
+      `    // ... the filter for the ${plural} we want to count`,
+      "  }",
+      "})",
+    ],
+    countNoArgs: [
+      `Count every ${model}.`,
+      `Read more here: ${STATISTICS_BASE}/count`,
+      "@example",
+      `// Count every ${model}`,
+      `const count = ${accessor}.count()`,
+    ],
+    groupBy: [
+      `Group by ${model}.`,
+      UNDEFINED_NOTE,
+      `Read more here: ${STATISTICS_BASE}/groupBy`,
+      `@param {${prefix}GroupByData} groupByData - Group by arguments.`,
+      "@example",
+      `// Group by ${field}, get count`,
+      `const result = ${accessor}.groupBy({`,
+      `  by: ['${field}'],`,
+      "  _count: true,",
+      "})",
+      "",
+    ],
+  };
+};
+
+export { getStatisticsDocLines };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/operations/updateDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/operations/updateDocs.ts
@@ -1,0 +1,81 @@
+import { REFERENCE_BASE_URL } from "../docBlock";
+import type { ModelNaming } from "../modelNaming";
+import { UNDEFINED_NOTE } from "./readDocs";
+
+const UPDATE_BASE = `${REFERENCE_BASE_URL}/reference/crud/update`;
+const DATA_LINES = ["  data: {", "    // ... provide data here", "  }"];
+const WHERE_THEN_DATA = [
+  "  where: {",
+  "    // ... provide filter here",
+  "  },",
+  ...DATA_LINES,
+];
+
+const getUpdateDocLines = (naming: ModelNaming) => {
+  const { accessor, field, fieldCapital, model, plural, prefix } = naming;
+  const { variable, variablePlural } = naming;
+
+  return {
+    update: [
+      `Update one ${model}.`,
+      `Read more here: ${UPDATE_BASE}/update`,
+      `@param {${prefix}UpdateSingleData} updateData - Arguments to update one ${model}.`,
+      "@example",
+      `// Update one ${model}`,
+      `const ${variable} = ${accessor}.update({`,
+      ...WHERE_THEN_DATA,
+      "})",
+      "",
+    ],
+    updateMany: [
+      `Update zero or more ${plural}.`,
+      UNDEFINED_NOTE,
+      `Read more here: ${UPDATE_BASE}/updateMany`,
+      `@param {${prefix}UpdateData} updateData - Arguments to update one or more rows.`,
+      "@example",
+      `// Update many ${plural}`,
+      `const { count } = ${accessor}.updateMany({`,
+      ...WHERE_THEN_DATA,
+      "})",
+      "",
+    ],
+    updateManyAndReturn: [
+      `Update zero or more ${plural} and returns the data updated in the spreadsheet.`,
+      UNDEFINED_NOTE,
+      `Read more here: ${UPDATE_BASE}/updateManyAndReturn`,
+      `@param {${prefix}UpdateManyAndReturnData} updateData - Arguments to update many ${plural}.`,
+      "@example",
+      `// Update many ${plural}`,
+      `const ${variablePlural} = ${accessor}.updateManyAndReturn({`,
+      ...WHERE_THEN_DATA,
+      "})",
+      "",
+      `// Update zero or more ${plural} and only return the \`${field}\``,
+      `const ${variable}With${fieldCapital}Only = ${accessor}.updateManyAndReturn({`,
+      `  select: { ${field}: true },`,
+      ...WHERE_THEN_DATA,
+      "})",
+      "",
+    ],
+    upsert: [
+      `Create or update one ${model}.`,
+      `Read more here: ${UPDATE_BASE}/upsert`,
+      `@param {${prefix}UpsertSingleData} upsertData - Arguments to update or create a ${model}.`,
+      "@example",
+      `// Update or create a ${model}`,
+      `const ${variable} = ${accessor}.upsert({`,
+      "  create: {",
+      `    // ... data to create a ${model}`,
+      "  },",
+      "  update: {",
+      "    // ... in case it already exists, update",
+      "  },",
+      "  where: {",
+      `    // ... the filter for the ${model} we want to update`,
+      "  }",
+      "})",
+    ],
+  };
+};
+
+export { getUpdateDocLines };


### PR DESCRIPTION
`gassma.Post.findMany` にホバーしても型しか出ませんでした。**Prisma の生成クライアントと同じ TSDoc を出します**（空行の入れ方まで含めて）。

## お手本

`prisma-test/prisma/generated/a/index.d.ts`（12,259行・`/**` が1,032ブロック・`@example` 146箇所・`@param` 168箇所）を全数調査しました。

TSDoc が付いているシンボル、末尾スペースの実態（323行）、`createMany` だけ末尾スペースが5個、`count`/`aggregate`/`groupBy` だけ閉じが `**/` といった**テンプレート由来のブレ**まで洗い出しています。

## gassma 向けに変えた点

| 変更 | 理由 |
|---|---|
| **`await` を全削除** | gassma は同期（GAS 上で動作） |
| `prisma.item` → `gassma.Post` | シート名そのまま。識別子として不正な名前は `gassma["My Sheet"]` にフォールバック |
| `{ItemFindManyArgs}` → `{GassmaGassmaPostFindManyData}` | 実際の生成型名 |
| `@param` の変数名を実引数名に | `findData` / `createdData` / `updateData` など |
| `findUnique` / `findUniqueOrThrow` を出さない | gassma に存在しない |
| "database" → "spreadsheet" | 保存先が実際にスプレッドシート |
| `pris.ly` → **gassma リファレンスの英語版** | TSDoc の本文が英語なので（後述） |
| `NotFoundError` を明記 | `findFirstOrThrow` が実際に投げる例外 |

**引数省略は5操作だけ**という gassma 固有の制約に合わせ、引数なしオーバーロードに doc を付けたのは `findMany` / `findFirst` / `findFirstOrThrow` / `count` / `deleteMany` のみです。**`deleteMany()` は全件削除なので警告文を入れています。** 「引数なしの例がこの5つ以外に現れない」ことを固定する回帰テストも追加しました。

## リンク先は英語版を指します

TSDoc の本文が英語なので、**日本語版に飛ばすのは不整合**でした。`defaultLocale: "ja"` なので、英語版は `/en/` 配下です。

```
.../gassma-reference/docs/reference/crud/read/findMany       ← 日本語版
.../gassma-reference/en/docs/reference/crud/read/findMany    ← こちらを使う
```

**生成物中の全リンクが英語版を指すことを固定する回帰テスト**を追加しています。

## 複数形は `pluralize` を使います

**Prisma 自身がバンドル内で `pluralize` を使っていました**（`plural: capitalize(mapping.plural)`）。機械的な `+ "s"` ではありません。

```
Users → Users        （既に複数形なら変わらない。自前規則だと Userss）
Person → People
Category → Categories （自前規則だと Categorys）
Status → Statuses     （自前規則だと Status のまま）
```

依存ゼロ・28KB で、tsdown が external 扱いにするため **`dist` の増加は +144バイト**です。

## Prisma のバグは直しました

- `aggregate` / `groupBy` の例が `prisma.user` 固定になっている → 実モデルに置換
- `createManyAndReturn` / `updateManyAndReturn` で説明文が例の後ろに来ている → 先頭へ
- `updateManyAndReturn` の `data: [...]`（配列）→ 実型どおり `{...}`
- `**/` 閉じ・末尾5スペースを統一

**Prisma の癖は意図的に残した箇所もあります**（`create` / `delete` の例だけ変数名が PascalCase）。

## 生成物のサンプル

```ts
  /**
   * Find zero or more Posts that matches the filter.
   * Note, that providing `undefined` is treated as the value not being there.
   * Read more here: https://akahoshi1421.github.io/gassma-reference/en/docs/reference/crud/read/findMany
   * @param {GassmaGassmaPostFindManyData} findData - Arguments to filter and select certain fields only.
   * @example
   * // Get all Posts
   * const posts = gassma.Post.findMany()
   * 
   * // Get first 10 Posts
   * const posts = gassma.Post.findMany({ take: 10 })
   * 
   * // Only select the `id`
   * const postWithIdOnly = gassma.Post.findMany({ select: { id: true } })
   * 
   */
```

**`Gassma.skip` の宣言にも TSDoc を新設**しました（`Gassma.raw` に既に TSDoc があるので、その隣に同じ流儀で）。

```ts
  /**
   * Omits the field it is passed to, as if it had not been written at all.
   * Unlike `undefined`, it is accepted while `strictUndefinedChecks` is on.
   *
   * Read more here: .../en/docs/reference/config/strict-undefined-checks
   *
   * @example
   * ```
   * gassma.User.findMany({
   *   where: { name: search ?? Gassma.skip },
   * });
   * ```
   */
  const skip: unique symbol;
```

## 実装

文面は **`packages/cli/src/generate/typeGenerate/tsdoc/` に集約**し、型生成モジュール側には**文面が1文字も残っていません**（grep で確認済み）。差し込み先の4ファイルは `tsdoc/` を呼ぶだけです。

**1ファイルにしなかったのは、文面が合計約450行あり CLAUDE.md の「200行以内」に反するため**です。操作グループで6ファイルに分割しています。「型生成モジュールに散らさない」という意図は満たしています。

（`Gassma.skip` の doc だけは、既存の `Gassma.raw` の doc がある `gassmaCommonTypes.ts` に並べて置き、URL は `tsdoc/docBlock` から import しています。）

## `count` の引数名を `countData` に直しました

`coutData` という既存のタイポが、**TSDoc の `@param` に出るようになって目立つ**ためです。

**破壊的変更ではありません。** TypeScript は引数を**位置で照合**し、引数名は代入互換性に一切関与しません。影響するのはエディタの表示と `Parameters<>` が返すタプルのラベル（これも飾りで互換性に無関係）だけです。しかも**宣言（`.d.ts`）にしか存在せず、実行時の `gassmaClient.js` には出てきません**。本体リポジトリにも `coutData` はありませんでした。

## 型の中身が変わっていないことの検証

新旧それぞれでフィクスチャを生成し、コメントと空行を同条件で除去して比較しました。

```
コメント除去後の行数     5,030 行 = 5,030 行   （完全一致）
diff -w （空白を無視）   差分なし
```

**型の中身は1文字も変わっていません**（`countData` へのリネームを除く）。ただし**空白だけの差分が211行あります** — クライアントクラス内のモデルプロパティのインデントが 2 → 4 スペースになりました（TSDoc を各プロパティの上に置くための構造変更の副産物）。

## リンクの検証

生成物に含まれる **20個の URL のうち17個が 200**（301 → 200 のリダイレクトを追って確認）。

**残り3個は 404 ですが、これはデプロイが止まっているためです。**

```
404 .../en/docs/reference/transaction
404 .../en/docs/reference/client-extensions/result
404 .../en/docs/reference/config/strict-undefined-checks
```

3ページとも **main にマージ済みで slug も確定**しており、ローカルビルドに実体があることを確認しています。

```
build/en/docs/reference/transaction/index.html                    ← 存在
build/en/docs/reference/client-extensions/result/index.html       ← 存在
build/en/docs/reference/config/strict-undefined-checks/index.html ← 存在
```

**gh-pages のデプロイが 7/20 から止まっている**のが原因なので、デプロイすれば 200 になります。

## 検証結果

- `npm test`: **1,441件 全 green**（191ファイル）
- `test:types` / `typecheck` / `lint` / `format:check` すべてエラーなし
- **gassma-test の実スキーマで `npx tsc --noEmit` → exit 0**
- 生成物に `await` 0 / `pris.ly` 0 / `prisma.` 0
- 行数: gassma-test 実スキーマで 9,345 → **13,891行**

**「フィクスチャ全文比較テスト」は存在しませんでした**（生成器テストは `toContain` のみ、スナップショット0件）。更新した既存テストは4件で、3件は引数追加への機械的追随（アサーション無変更）、1件は `$extends` の直前に doc が入ったため型リテラル完全一致を3分割したものです。

## GAS のスクリプトサイズへの影響: ありません

**`gassmaClient.js` は1バイトも変わっていません。** `.d.ts` は型のみで webpack バンドルに入りません。

## 判断が必要で実装しなかった点

**オプトアウト設定は追加していません。** Prisma の generator ブロックにもドキュメント生成のトグルは存在しないためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
