### PR TITLE
chore: リファレンスの参照先を gassma.io にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm test -w packages/gas-esbuild-plugin
 
 ## Detail reference
 
-https://akahoshi1421.github.io/gassma-reference/
+https://gassma.io/
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -181,7 +181,7 @@ npx gassma bootstrap          # ask for a directory first
 npx gassma bootstrap .        # set up in the current directory
 ```
 
-Requires [clasp](https://github.com/google/clasp): `npm install -g @google/clasp`, then `clasp login`. See the [bootstrap reference](https://akahoshi1421.github.io/gassma-reference/en/docs/reference/bootstrap) for details.
+Requires [clasp](https://github.com/google/clasp): `npm install -g @google/clasp`, then `clasp login`. See the [bootstrap reference](https://gassma.io/en/docs/reference/bootstrap) for details.
 
 #### arguments
 
@@ -232,11 +232,11 @@ Display the current version of GASsma CLI.
 
 The config file is searched in the current directory in the order `gassma.config.{js,ts,mjs,cjs,mts,cts}`, then `.config/gassma.{js,ts,mjs,cjs,mts,cts}`. `--config <path>` overrides the search. The `env("NAME")` helper from `gassma/config` reads environment variables in the config file.
 
-The schema also supports `previewFeatures = ["strictUndefinedChecks"]` in the generator block. See the [strictUndefinedChecks reference](https://akahoshi1421.github.io/gassma-reference/en/docs/reference/config/strict-undefined-checks) for details.
+The schema also supports `previewFeatures = ["strictUndefinedChecks"]` in the generator block. See the [strictUndefinedChecks reference](https://gassma.io/en/docs/reference/config/strict-undefined-checks) for details.
 
 ## Detail reference
 
-https://akahoshi1421.github.io/gassma-reference/en/docs/reference/type-generation/
+https://gassma.io/en/docs/reference/type-generation/
 
 ## License
 

--- a/packages/cli/docs/README.ja.md
+++ b/packages/cli/docs/README.ja.md
@@ -181,7 +181,7 @@ npx gassma bootstrap          # 最初にディレクトリを質問
 npx gassma bootstrap .        # カレントディレクトリにセットアップ
 ```
 
-[clasp](https://github.com/google/clasp) が必要です: `npm install -g @google/clasp` の後、`clasp login` してください。詳細は [bootstrap リファレンス](https://akahoshi1421.github.io/gassma-reference/docs/reference/bootstrap)を参照してください。
+[clasp](https://github.com/google/clasp) が必要です: `npm install -g @google/clasp` の後、`clasp login` してください。詳細は [bootstrap リファレンス](https://gassma.io/docs/reference/bootstrap)を参照してください。
 
 #### 引数
 
@@ -232,11 +232,11 @@ GASsma CLI の現在のバージョンを表示します。
 
 config ファイルはカレントディレクトリから `gassma.config.{js,ts,mjs,cjs,mts,cts}`、次に `.config/gassma.{js,ts,mjs,cjs,mts,cts}` の順で探索されます。`--config <path>` で探索を上書きできます。`gassma/config` の `env("NAME")` ヘルパーで config ファイル内から環境変数を読み取れます。
 
-スキーマの generator ブロックでは `previewFeatures = ["strictUndefinedChecks"]` もサポートしています。詳細は [strictUndefinedChecks リファレンス](https://akahoshi1421.github.io/gassma-reference/docs/reference/config/strict-undefined-checks)を参照してください。
+スキーマの generator ブロックでは `previewFeatures = ["strictUndefinedChecks"]` もサポートしています。詳細は [strictUndefinedChecks リファレンス](https://gassma.io/docs/reference/config/strict-undefined-checks)を参照してください。
 
 ## 詳細リファレンス
 
-https://akahoshi1421.github.io/gassma-reference/docs/reference/type-generation/
+https://gassma.io/docs/reference/type-generation/
 
 ## ライセンス
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "type": "git",
     "url": "https://github.com/akahoshi1421/gassma-cli.git"
   },
-  "homepage": "https://akahoshi1421.github.io/gassma-reference/",
+  "homepage": "https://gassma.io/",
   "bugs": {
     "url": "https://github.com/akahoshi1421/gassma-cli/issues"
   },

--- a/packages/cli/src/__test__/bootstrap/flow/writeSteps.test.ts
+++ b/packages/cli/src/__test__/bootstrap/flow/writeSteps.test.ts
@@ -53,9 +53,7 @@ describe("projectFilesStep", () => {
     expect(content).toContain("src/generated/");
     expect(content).toContain(".clasp.json");
     expect(content).toContain("dist/appsscript.json");
-    expect(content).toContain(
-      "https://akahoshi1421.github.io/gassma-reference/llms.txt",
-    );
+    expect(content).toContain("https://gassma.io/llms.txt");
   });
 
   it("should not overwrite an existing AGENTS.md", async () => {

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/clientDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/clientDocs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { generateClientDts } from "../../../../generate/jsGenerate/generateClientDts";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
+const BASE = "https://gassma.io/en/docs";
 const BLANK = " * ";
 const result = generateClientDts("Hoge", undefined, ["Post", "User"]);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/controllerDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/controllerDocs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { getOneGassmaController } from "../../../../generate/typeGenerate/gassmaController/oneGassmaController";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
+const BASE = "https://gassma.io/en/docs";
 
 describe("getOneGassmaController tsdoc", () => {
   const result = getOneGassmaController("", "Post", ["id", "title"]);

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/createDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/createDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getCreateDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/createDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
+const BASE = "https://gassma.io/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getCreateDocLines(naming);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/deleteDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/deleteDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getDeleteDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/deleteDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
+const BASE = "https://gassma.io/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getDeleteDocLines(naming);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/docBlock.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/docBlock.test.ts
@@ -26,8 +26,6 @@ describe("renderDocBlock", () => {
   });
 
   it("should expose the reference site base url", () => {
-    expect(REFERENCE_BASE_URL).toBe(
-      "https://akahoshi1421.github.io/gassma-reference/en/docs",
-    );
+    expect(REFERENCE_BASE_URL).toBe("https://gassma.io/en/docs");
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/generatedDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/generatedDocs.test.ts
@@ -59,11 +59,11 @@ describe("generated tsdoc", () => {
   });
 
   it("should link to the english reference, matching the language of the docs", () => {
-    const links = generated.match(/https:\/\/[^\s)]+gassma-reference[^\s)]*/g);
+    const links = generated.match(/https:\/\/gassma\.io[^\s)]*/g);
 
     expect(links).not.toBeNull();
     links?.forEach((link) => {
-      expect(link).toContain("/gassma-reference/en/docs/");
+      expect(link).toContain("https://gassma.io/en/docs/");
     });
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/readDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/readDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getReadDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/readDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
+const BASE = "https://gassma.io/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getReadDocLines(naming);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/statisticsDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/statisticsDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getStatisticsDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/statisticsDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
+const BASE = "https://gassma.io/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getStatisticsDocLines(naming);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/updateDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/updateDocs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
 import { getUpdateDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/updateDocs";
 
-const BASE = "https://akahoshi1421.github.io/gassma-reference/en/docs";
+const BASE = "https://gassma.io/en/docs";
 const naming = getModelNaming("", "Post", ["title", "body"]);
 const lines = getUpdateDocLines(naming);
 

--- a/packages/cli/src/generate/typeGenerate/tsdoc/docBlock.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/docBlock.ts
@@ -1,6 +1,5 @@
 // TSDoc の本文が英語なので英語版を指す。defaultLocale が ja なので en は /en/ 配下
-const REFERENCE_BASE_URL =
-  "https://akahoshi1421.github.io/gassma-reference/en/docs";
+const REFERENCE_BASE_URL = "https://gassma.io/en/docs";
 
 const renderDocBlock = (indent: string, lines: string[]) => {
   const body = lines.map((line) => `${indent} * ${line}\n`).join("");

--- a/packages/cli/templates/AGENTS.md.template
+++ b/packages/cli/templates/AGENTS.md.template
@@ -24,4 +24,4 @@ A local development environment for Google Apps Script, powered by Clasp and GAS
 ## About GASsma
 
 GASsma is a GAS library + CLI that lets you work with spreadsheets the way Prisma works with databases. CRUD, aggregation, relations, and transactions are handled with almost the same syntax as Prisma.
-**Before touching anything related to the API, consult https://akahoshi1421.github.io/gassma-reference/llms.txt** (it is a link index — follow the links and read the pages you need).
+**Before touching anything related to the API, consult https://gassma.io/llms.txt** (it is a link index — follow the links and read the pages you need).

--- a/packages/gas-esbuild-plugin/package.json
+++ b/packages/gas-esbuild-plugin/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/akahoshi1421/gassma-cli.git",
     "directory": "packages/gas-esbuild-plugin"
   },
-  "homepage": "https://akahoshi1421.github.io/gassma-reference/",
+  "homepage": "https://gassma.io/",
   "bugs": {
     "url": "https://github.com/akahoshi1421/gassma-cli/issues"
   },


### PR DESCRIPTION
リファレンスサイトが独自ドメイン **`https://gassma.io`** を取得したので、参照先を移します。

```
https://akahoshi1421.github.io/gassma-reference/en/docs/reference/crud/read/findMany
                              ↓
https://gassma.io/en/docs/reference/crud/read/findMany
```

apex 直下に配信するので `baseUrl` が `/` になり、**`/gassma-reference` のパスが丸ごと消えます**。

## 変更したもの

| ファイル | 内容 |
|---|---|
| `packages/cli/src/generate/typeGenerate/tsdoc/docBlock.ts` | `REFERENCE_BASE_URL`（**生成される TSDoc のリンク全部に効きます**） |
| `packages/cli/package.json` / `packages/gas-esbuild-plugin/package.json` | `homepage`（npm のページに出ます） |
| `packages/cli/templates/AGENTS.md.template` | `llms.txt` へのポインタ |
| `README.md` / `packages/cli/README.md` / `packages/cli/docs/README.ja.md` | 本文中のリンク |
| テスト10ファイル | 期待値の URL |

**`akahoshi1421.github.io` と `gassma-reference` の両方で全文検索して、残りがゼロであることを確認しています**（`node_modules` / `dist` / 生成物を除く）。

## 生成物の確認

```
https://gassma.io/en/docs/reference/basic
https://gassma.io/en/docs/reference/crud/read/findMany
https://gassma.io/en/docs/reference/transaction
https://gassma.io/en/docs/reference/client-extensions/result
https://gassma.io/en/docs/reference/config/strict-undefined-checks
…（全20 URL）
```

**すべて英語版（`/en/`）を指したままです。** 「全リンクが英語版を指す」ことを固定する回帰テストも、新ドメインに合わせて更新しました。

## フォーマットの変更について

**URL が短くなった結果、複数行に折られていたテストの記述が1行に収まるようになりました。** `biome format` が2ファイルで整形しています（`writeSteps.test.ts` / `docBlock.test.ts`）。内容の変更ではありません。

## 検証結果

- `npm test`: **1,441件 全 green**
- `tsc --noEmit` / `biome lint` / `biome format` すべてエラーなし
- 生成物の URL がすべて `https://gassma.io/en/docs/...` になっていることを確認

## デプロイ後に 200 になります

**新ドメインは現在 CSS が読めない状態です。** デプロイ済みのビルドが `baseUrl: "/gassma-reference/"` で作られているため、アセット参照が存在しないパスを向いています。

```
https://gassma.io/docs/reference/basic                      200  （HTML は出る）
https://gassma.io/gassma-reference/assets/css/styles.…css   404  ← CSS が当たらない
```

**gassma-reference 側の対応 PR（`chore/gassma-io-domain`）とデプロイで直ります。** 本 PR のリンクが実際に 200 を返すのも、そのデプロイ後です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)