### PR TITLE
chore: gassma 2.0.0 をリリースする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6086,7 +6086,7 @@
     },
     "packages/cli": {
       "name": "gassma",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gassma",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "GASsma is Google Apps Script(GAS) of SpreadSheet library that can be used like prisma.",
   "types": "index.d.ts",
   "bin": {


### PR DESCRIPTION
**npm への公開は完了しています。** このバージョン変更を main に反映するための PR です。

```
gassma                       1.1.0 → 2.0.0
@gassma/gas-esbuild-plugin           0.1.0   （初回公開・変更なし）
```

## なぜメジャーか

**今まで通っていた入力がエラーになる変更が20件以上**入っています。うち **9本は「黙って全件が消える／全件が書き換わる」経路**でした。

| 入力 | 2.0.0 より前 |
|---|---|
| `deleteMany({ where: null })` | **全件削除** |
| `deleteMany({ limit: null })` / `updateMany({ limit: null })` | **全件削除 / 全件更新** |
| `update` / `delete({ where: {} })` / `{ id: Gassma.skip }` | **先頭行を書き換え** |
| `updateMany({ data: { col: undefined } })` | **セルの値が消える** |
| `updateMany({ data: { col: { divide: 0 } } })` | **セルの値が消える** |
| `findMany({ take: NaN })` | ページングが消えて全件 |
| `where: { col: undefined }` | **0件**（Prisma は全件） |

これらが `GassmaInvalidValueError` などで**実行前に止まる**ようになりました。**利用者のコードは「今まで動いていたつもりだったものが落ちる」形で影響を受けます**が、落ちる箇所はいずれも意図しない結果を返していた場所です。

型生成側も **`Subset` による余剰キーの拒否**が入っており、これまで通っていた typo を含む引数がコンパイルエラーになります。

あわせて **生成クライアントに TSDoc が出る**ようになりました（#153）。ホバーで説明と使用例が読めます。

## 検証

公開前に実行したものです。

- `npm test` **1,441件 green**、`test:types` も **Type Errors: no errors**
- `@gassma/gas-esbuild-plugin` **15件 green**
- 両パッケージのビルド、`npm publish --dry-run` で内容確認
- `dist/command.js` のリンクが `gassma.io` を指し、**旧 URL は0件**

```
gassma@2.0.0                       60.1 kB / 26ファイル
@gassma/gas-esbuild-plugin@0.1.0    3.9 kB /  7ファイル
```

## 公開時に踏んだこと（記録として）

**`gassma-cli/.npmrc` に失効したトークンが残っていました。** npm はプロジェクト側の `.npmrc` をユーザー側より優先するため、`npm login` を繰り返しても更新されず、`@gassma` スコープへの publish が **404** で落ち続けていました（npm はスコープ付きパッケージの権限不足を 403 でなく 404 で返します）。

このファイルは **gitignore 対象で履歴にも一度も入っていない**ため、トークンの漏洩はありません。削除後は 2FA の 403 になり、`--otp` で通りました。

## 未対応

**`@gassma/gas-esbuild-plugin` の `publishConfig: { access: "public" }` は入れていません。** 今回は `--access public` フラグで公開できたためです。次回以降フラグを忘れると `402` で落ちるので、**入れておくかは別途判断をお願いします**（3行）。

## マージ後

```bash
git tag v2.0.0 && git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)