### PR TITLE
fix: select 分岐を代入可能性でなく型の同一性で判定する

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -100,6 +100,50 @@ jobs:
       - name: Typecheck (cli, tsc --noEmit, includes __test__)
         run: npm run typecheck -w packages/cli
 
+  type-matrix-cli:
+    needs: changes-cli
+    if: needs.changes-cli.outputs.cli == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # peerDependencies の下限(5.2)から最新(7.0)まで。strict の on/off 両方を
+        # scripts/checkTypeMatrix.ts 側で回す。
+        typescript: ['5.2.2', '5.6.3', '5.9.3', '6.0.3', '7.0.2']
+
+    name: Type tests (cli, TypeScript ${{ matrix.typescript }})
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.11.0'
+          cache: 'npm'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-24.11.0-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-24.11.0-
+            ${{ runner.os }}-node-
+
+      - name: Cache TypeScript ${{ matrix.typescript }}
+        uses: actions/cache@v4
+        with:
+          path: packages/cli/.tsmatrix/${{ matrix.typescript }}
+          key: ${{ runner.os }}-tsmatrix-${{ matrix.typescript }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type tests on TypeScript ${{ matrix.typescript }}
+        run: npm run test:types:all -w packages/cli -- ${{ matrix.typescript }}
+
   build-cli:
     needs: changes-cli
     if: needs.changes-cli.outputs.cli == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ gassma/
 # 型テスト用の生成物
 packages/cli/src/__test__/types/__generated__/
 
+# 型テストマトリクス用にバージョンごとに入れた TypeScript
+packages/cli/.tsmatrix/
+
 # npm
 .npmrc

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,8 @@
     "test:watch": "vitest",
     "pretest:types": "tsx scripts/genFixtureTypes.ts",
     "test:types": "vitest --typecheck --run",
+    "pretest:types:all": "tsx scripts/genFixtureTypes.ts",
+    "test:types:all": "tsx scripts/checkTypeMatrix.ts",
     "typecheck": "tsc --noEmit",
     "format": "biome format --write src",
     "format:check": "biome format src",

--- a/packages/cli/scripts/checkTypeMatrix.ts
+++ b/packages/cli/scripts/checkTypeMatrix.ts
@@ -1,0 +1,106 @@
+import { spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+
+// peerDependencies は typescript >=5.2 を宣言している。下限の 5.2、5.6、
+// VS Code 同梱の 5.9、現行の 6.0、最新の 7.0 を対象にする。
+// 同名パッケージのため devDependencies には同居できないので、
+// バージョンごとに別プレフィックスへ install してキャッシュする。
+const DEFAULT_VERSIONS = ["5.2.2", "5.6.3", "5.9.3", "6.0.3", "7.0.2"];
+
+// strictNullChecks が off だと undefined / unknown が任意プロパティのみの型にも
+// object にも代入可能になり、結果型の分岐が変わる。TypeScript 6 以降は strict が
+// 既定で on になったため、off 側を回さないとこの差異を検出できない。
+const PROJECTS = [
+  { label: "on", config: "tsconfig.typetest.json" },
+  { label: "off", config: "tsconfig.typetest.nostrict.json" },
+];
+
+const cliRoot = path.join(__dirname, "..");
+const cacheRoot = path.join(cliRoot, ".tsmatrix");
+
+const versions = process.argv.slice(2).length
+  ? process.argv.slice(2)
+  : DEFAULT_VERSIONS;
+
+const tscPathFor = (version: string) =>
+  path.join(cacheRoot, version, "node_modules", "typescript", "bin", "tsc");
+
+const ensureTypeScript = (version: string) => {
+  const tsc = tscPathFor(version);
+  if (fs.existsSync(tsc)) return tsc;
+
+  const dir = path.join(cacheRoot, version);
+  fs.mkdirSync(dir, { recursive: true });
+  console.log(`installing typescript@${version} -> ${dir}`);
+  const installed = spawnSync(
+    "npm",
+    [
+      "install",
+      "--prefix",
+      dir,
+      `typescript@${version}`,
+      "--no-save",
+      "--no-package-lock",
+      "--no-audit",
+      "--no-fund",
+    ],
+    { encoding: "utf-8", stdio: "inherit" },
+  );
+  if (installed.status !== 0 || !fs.existsSync(tsc)) {
+    throw new Error(`typescript@${version} の取得に失敗しました`);
+  }
+  return tsc;
+};
+
+const versionOf = (tsc: string) => {
+  const out = spawnSync(process.execPath, [tsc, "--version"], {
+    encoding: "utf-8",
+  });
+  return out.stdout.trim().replace(/^Version\s+/, "");
+};
+
+const runOne = (tsc: string, config: string) => {
+  const out = spawnSync(
+    process.execPath,
+    [tsc, "--noEmit", "--pretty", "false", "-p", path.join(cliRoot, config)],
+    { encoding: "utf-8", cwd: cliRoot },
+  );
+  const text = `${out.stdout ?? ""}${out.stderr ?? ""}`;
+  const errors = text.split("\n").filter((line) => /error TS\d+:/.test(line));
+  return { ok: out.status === 0, errors };
+};
+
+const results = versions.flatMap((requested) => {
+  const tsc = ensureTypeScript(requested);
+  const resolved = versionOf(tsc);
+  return PROJECTS.map((project) => {
+    const run = runOne(tsc, project.config);
+    return { requested, resolved, strict: project.label, ...run };
+  });
+});
+
+console.log("\n型テストマトリクス (tsc --noEmit)\n");
+console.log(["TypeScript", "strict", "結果", "エラー数"].join("\t"));
+results.forEach((r) => {
+  const mark = r.ok ? "OK" : "NG";
+  console.log([r.resolved, r.strict, mark, r.errors.length].join("\t"));
+});
+
+const failed = results.filter((r) => !r.ok);
+
+failed.forEach((r) => {
+  console.log(`\n--- TypeScript ${r.resolved} / strict=${r.strict} ---`);
+  r.errors.slice(0, 30).forEach((line) => console.log(line));
+  if (r.errors.length > 30) console.log(`... 他 ${r.errors.length - 30} 件`);
+});
+
+if (failed.length > 0) {
+  const where = failed
+    .map((r) => `TypeScript ${r.resolved} (strict=${r.strict})`)
+    .join(", ");
+  console.error(`\n型チェックに失敗しました: ${where}`);
+  process.exit(1);
+}
+
+console.log("\nすべての組み合わせで型チェックに成功しました。");

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResultSelectBranch.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResultSelectBranch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { RelationsConfig } from "../../../generate/read/extractRelations";
+import { getGassmaCommonTypes } from "../../../generate/typeGenerate/gassmaCommonTypes";
+import { getOneGassmaFindResult } from "../../../generate/typeGenerate/gassmaFindResult/oneGassmaFindResult";
+
+const userRelations: RelationsConfig = {
+  User: {
+    posts: {
+      type: "oneToMany",
+      to: "Post",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+};
+
+// strictNullChecks が off だと undefined / unknown が任意プロパティのみの型にも
+// object にも代入可能になるため、代入可能性で select の有無を判定すると
+// 引数省略時に select 側の分岐へ落ちる。型の同一性で判定する。
+describe("SelectGiven discriminator", () => {
+  it("should treat unknown and undefined as no selection without using assignability", () => {
+    const common = getGassmaCommonTypes();
+    expect(common).toContain("type SelectGiven<S> =");
+    expect(common).toContain("(<T>() => T extends S ? 1 : 2) extends");
+    expect(common).toContain("[S] extends [undefined]");
+  });
+
+  it("should discriminate the FindResult select branch by SelectGiven", () => {
+    const result = getOneGassmaFindResult("", "User", userRelations);
+    expect(result).toContain("Gassma.SelectGiven<S> extends true");
+    expect(result).not.toContain("(S extends GassmaUserFindSelect");
+  });
+
+  it("should keep the FindResult select branch distributive over unions of S", () => {
+    const result = getOneGassmaFindResult("", "User", userRelations);
+    expect(result).toContain("S extends unknown");
+  });
+
+  it("should apply the discriminator to both FindResultBase and FindResultCore", () => {
+    const result = getOneGassmaFindResult("", "User", userRelations);
+    expect(result.split("Gassma.SelectGiven<S> extends true")).toHaveLength(3);
+  });
+
+  it("should discriminate StripComputed and WithComputed by SelectGiven too", () => {
+    const common = getGassmaCommonTypes();
+    expect(common).toContain("type StripComputed<S, C>");
+    expect(common).toContain("type WithComputed<Base, C, S, QO>");
+    expect(common).not.toContain("S extends object");
+  });
+});

--- a/packages/cli/src/__test__/types/nostrict/findResult.test-d.ts
+++ b/packages/cli/src/__test__/types/nostrict/findResult.test-d.ts
@@ -1,0 +1,116 @@
+import { expectTypeOf } from "vitest";
+import { GassmaClient } from "../__generated__/client";
+
+// strictNullChecks の有無に依存しない書き方だけを使う。
+// `| null` は非 strict では潰れるため NonNullable<> 経由で中身を検証する。
+const client = new GassmaClient();
+
+// 引数に select / include / omit を渡さない場合に全スカラーが解決される
+{
+  const u = client.User.findFirst({ where: { id: 1 } });
+  type U = NonNullable<typeof u>;
+  expectTypeOf<U["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<U["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<U["isActive"]>().toEqualTypeOf<boolean>();
+  expectTypeOf<U["createdAt"]>().toEqualTypeOf<Date>();
+
+  const us = client.User.findMany({ where: {} });
+  expectTypeOf<(typeof us)[number]["id"]>().toEqualTypeOf<number>();
+}
+
+// select
+{
+  const u = client.User.findFirstOrThrow({ select: { id: true, email: true } });
+  expectTypeOf<(typeof u)["id"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof u)["email"]>().toEqualTypeOf<string>();
+  expectTypeOf(u).not.toHaveProperty("isActive");
+}
+
+// omit
+{
+  const u = client.User.findFirstOrThrow({ omit: { email: true } });
+  expectTypeOf<(typeof u)["id"]>().toEqualTypeOf<number>();
+  expectTypeOf(u).not.toHaveProperty("email");
+}
+
+// include（リレーションが never にならない）
+{
+  const u = client.User.findFirstOrThrow({ include: { posts: true } });
+  expectTypeOf<(typeof u)["posts"][number]["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<(typeof u)["id"]>().toEqualTypeOf<number>();
+
+  const p = client.Post.findFirstOrThrow({ include: { author: true } });
+  expectTypeOf<
+    NonNullable<(typeof p)["author"]>["email"]
+  >().toEqualTypeOf<string>();
+}
+
+// ネストした include
+{
+  const u = client.User.findFirstOrThrow({
+    include: { posts: { include: { tags: true } } },
+  });
+  type Post = (typeof u)["posts"][number];
+  expectTypeOf<Post["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<Post["tags"][number]["name"]>().toEqualTypeOf<string>();
+}
+
+// include 内の select
+{
+  const u = client.User.findFirstOrThrow({
+    include: { posts: { select: { title: true } } },
+  });
+  type Post = (typeof u)["posts"][number];
+  expectTypeOf<Post["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<Post>().not.toHaveProperty("id");
+}
+
+// _count
+{
+  const u = client.User.findFirstOrThrow({
+    include: { _count: { select: { posts: true } } },
+  });
+  expectTypeOf<(typeof u)["_count"]["posts"]>().toEqualTypeOf<number>();
+  expectTypeOf<(typeof u)["id"]>().toEqualTypeOf<number>();
+}
+
+// 自己参照リレーション
+{
+  const c = client.Category.findFirstOrThrow({
+    include: { children: { include: { children: true } } },
+  });
+  expectTypeOf<(typeof c)["name"]>().toEqualTypeOf<string>();
+  type Child = (typeof c)["children"][number];
+  expectTypeOf<Child["name"]>().toEqualTypeOf<string>();
+  expectTypeOf<Child["children"][number]["name"]>().toEqualTypeOf<string>();
+
+  const p = client.Category.findFirstOrThrow({ include: { parent: true } });
+  expectTypeOf<
+    NonNullable<(typeof p)["parent"]>["name"]
+  >().toEqualTypeOf<string>();
+}
+
+// $extends result: 算出フィールドだけを select した場合はスカラーが付かない
+{
+  const extended = client.$extends({
+    result: {
+      User: {
+        fullName: {
+          needs: { email: true },
+          compute: (user) => `x${user.email}`,
+        },
+      },
+    },
+  });
+
+  const onlyComputed = extended.User.findMany({ select: { fullName: true } });
+  expectTypeOf<
+    (typeof onlyComputed)[number]["fullName"]
+  >().toEqualTypeOf<string>();
+  expectTypeOf(onlyComputed[0]).not.toHaveProperty("id");
+
+  // 引数省略時は算出フィールドとスカラーの両方が付く
+  const all = extended.User.findMany({ where: {} });
+  expectTypeOf<(typeof all)[number]["fullName"]>().toEqualTypeOf<string>();
+  expectTypeOf<(typeof all)[number]["id"]>().toEqualTypeOf<number>();
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -97,12 +97,15 @@ const getGassmaCommonTypes = (strict?: boolean) => {
     [K in keyof C as K extends keyof S ? (S[K] extends true ? K : never) : never]: C[K];
   };
   type ActiveComputed<C, QO> = { [K in keyof C as K extends TrueKeys<QO> ? never : K]: C[K] };
+  type SelectGiven<S> = (<T>() => T extends S ? 1 : 2) extends <T>() => T extends unknown ? 1 : 2
+    ? false
+    : [S] extends [undefined] ? false : true;
   type StripComputed<S, C> = [keyof C] extends [never]
     ? S
-    : S extends object ? { [K in Exclude<keyof S, keyof C>]: S[K] } : S;
+    : SelectGiven<S> extends true ? { [K in Exclude<keyof S, keyof C>]: S[K] } : S;
   type WithComputed<Base, C, S, QO> = [keyof C] extends [never]
     ? Base
-    : S extends object
+    : SelectGiven<S> extends true
       ? Omit<Base, keyof SelectedComputed<C, S>> & SelectedComputed<C, S>
       : Omit<Base, keyof ActiveComputed<C, QO>> & ActiveComputed<C, QO>;
 

--- a/packages/cli/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -58,9 +58,15 @@ ${relationBranch("I", childName, childArgs)}
           K extends "_count" ? Gassma.CountResult<I[K]> :
           never;
       })`;
-    return `(S extends ${self}FindSelect
-  ? ${selectResult}
-  : ${omitResult}) &
+    // strictNullChecks が off だと undefined/unknown が任意プロパティのみの型にも
+    // 代入可能になり、select 省略時にも select 側へ落ちる。SelectGiven は
+    // 代入可能性でなく型の同一性で判定するため strict の有無に依存しない。
+    // 外側の `S extends unknown` は union の S に対する分配を保つためのもの。
+    return `(S extends unknown
+  ? Gassma.SelectGiven<S> extends true
+    ? ${selectResult}
+    : ${omitResult}
+  : never) &
   ${includePart}`;
   };
 

--- a/packages/cli/tsconfig.typetest.json
+++ b/packages/cli/tsconfig.typetest.json
@@ -1,0 +1,15 @@
+{
+  "include": ["src/__test__/types"],
+  "compilerOptions": {
+    "target": "es2016",
+    "lib": ["ES2021"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  }
+}

--- a/packages/cli/tsconfig.typetest.nostrict.json
+++ b/packages/cli/tsconfig.typetest.nostrict.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.typetest.json",
+  "include": ["src/__test__/types/nostrict"],
+  "compilerOptions": {
+    "strict": false
+  }
+}


### PR DESCRIPTION
**`gassma@2.0.0` で、非 strict のプロジェクトはモデルのフィールドが1つも解決できません。**

```
error TS2339: Property 'isActive' does not exist on type
  'GassmaSchemaMemberFindResultCore<unknown, unknown, unknown, {}, {}, {}>'
error TS2339: Property 'name' does not exist on type 'never'      ← include したリレーション
```

## 原因 — バージョンの問題ではありませんでした

**当初「TypeScript 5.x の退行」と診断しましたが、誤りでした。**

```ts
S extends {Model}FindSelect ? <select 分岐> : <omit 分岐>
```

`select` を省略した呼び出しでは `T["select"]` が **`unknown`** になります。**`strictNullChecks: false` では `unknown` が「任意プロパティだけの型」に代入可能**なので、`unknown extends FindSelect` が **true** になって select 分岐に入り、`keyof unknown` = `never` を走査して**全フィールドが消えます**。

**バージョン依存に見えたのは、TypeScript 6.0 が `strict` の既定を off → on に変えたから**です。

```
TS 5.9.3   const x: string = null;  → 通る   （strict 既定 off）
TS 6.0.3   同上                      → エラー （strict 既定 on）
```

**そして `gassma bootstrap` が生成する `tsconfig.json` に `strict` の指定がありません。**

```json
{ "compilerOptions": { "lib": ["esnext"], "types": ["google-apps-script"] } }
```

決定的な確認として、**TS 6.0.3 と 7.0.2 でも `strict: false` にすれば同じ17件が出ます**（下表）。つまり壊れるのは「5.x の利用者」ではなく**「非 strict の利用者」全員**です。

**PR #148（ルックアップマップ型への置換）は無罪でした。** 公開済み 2.0.0 の生成物を #148 以前の条件型チェーンに機械的に戻しても、TS 5.9 の非 strict で**まったく同じ失敗**が出ます。この欠陥は `FindResult` が導入された当初（#80/#81 期）から存在していました。

同じ形が `StripComputed` / `WithComputed` の `S extends object` にもあり、**`$extends` の算出フィールドがネストした `include` の中で消える**という形で出ていました。

## 修正

代入可能性ではなく**型の同一性**で判定します。

```ts
type SelectGiven<S> = (<T>() => T extends S ? 1 : 2) extends <T>() => T extends unknown ? 1 : 2
  ? false
  : [S] extends [undefined] ? false : true;
```

**`[keyof S] extends [never]` という単純な形では駄目でした。** それだと `S = {}` も反転しますが、**`{}` は「算出フィールドだけを select した」ときに `StripComputed` が作る正当な値**で、select 分岐に入る必要があります（既存テスト `resultExtends.test-d.ts:171` が落ちて発覚）。

5バージョン × strict on/off の全10セルで真理値表を実測し、`SelectGiven` が `unknown`/`undefined`/`{}`/`{k:true}` に対して **全セルで F/F/T/T と不変**であることを確認しています。旧判定との差は**壊れていた2セル（unknown・undefined の非 strict）だけ**です。

## 検証結果

**利用者プロジェクトでの実測です（私の側で独立に確認）。**

| TypeScript | 修正前（既定） | 修正前（strict:false） | 修正後（既定 / strict:false） |
|---|---|---|---|
| 5.2.2 | 17件 | 17件 | **0件 / 0件** |
| 5.6.3 | 17件 | 17件 | **0件 / 0件** |
| **5.9.3** | **17件** | 17件 | **0件 / 0件** |
| 6.0.3 | 0件 | **17件** | **0件 / 0件** |
| 7.0.2 | 0件 | **17件** | **0件 / 0件** |

**型テストマトリクス（`packages/cli`）も全10通りで 0件**です。

```
TypeScript  strict  結果  エラー数
5.2.2       on/off   OK     0 / 0
5.6.3       on/off   OK     0 / 0
5.9.3       on/off   OK     0 / 0
6.0.3       on/off   OK     0 / 0
7.0.2       on/off   OK     0 / 0
```

- `npm test` **1,446件 green**、`test:types` も **Type Errors: no errors**
- `typecheck` / `lint` / `format:check` pass

## 型が変わっていないこと

**生成物の差分は判定式だけ**です（私も内訳を確認）。

```
4モデル × 2箇所   S extends {Model}FindSelect  →  SelectGiven<S>
2箇所             S extends object             →  SelectGiven<S>
```

**フィールドの型定義は1行も変わっておらず、ランタイムの `schemaClient.js` は完全一致**です。201モデルの生成物でも変更行は 402行 = 201 × 2（`FindResultBase` + `FindResultCore` の判別条件）のみでした。

## 性能

#148 の改善は維持されています（fan-in 200、TS 6.0.3、best-of-3）。

| variant | 軽 real / check | 重 real / check | 重 instantiations |
|---|---|---|---|
| #148 以前 | 0.66s / 0.30s | 1.11s / 0.77s | 216,622 |
| main | 0.47s / 0.11s | 1.09s / 0.66s | 218,226 |
| **修正後** | **0.47s / 0.10s** | **1.07s / 0.73s** | 235,144 |

コストは instantiations +7.8%、実時間は計測誤差内です。

**注記**: #148 の PR 本文にある 8.10s → 0.26s は今回の合成スキーマでは再現せず、#148 以前の最悪値は 0.66s でした。ベンチの作りが違うためですが、**3種類のワークロードすべてで `修正後 ≈ main < #148以前` の順序は一貫**しています。

## 再発防止

**バージョンマトリクスだけではこの不具合は捕まりません。** strict=on は5バージョンすべて緑だからです。**捕まえるのは strict on/off の次元**で、両方をゲートに入れました。

- `npm run test:types:all`（5バージョン × strict 2通り）／`npm run test:types:all -- 5.9.3`（単体）
- CI ジョブ `type-matrix-cli`（5並列・`fail-fast: false`・ジョブ名にバージョン）

**依存の追加はゼロです。** 各バージョンは `.tsmatrix/<version>` に必要時取得してキャッシュします（gitignore 済み、CI では `actions/cache`）。

npm alias（`typescript-5.2` 等）を devDependencies に入れる案は**撤回**しました。3つとも `tsc` という bin を持つため、npm が `node_modules/.bin/tsc` を 5.2.2 に張り替えて `npm run typecheck` が壊れます。

## 判断が必要で実装しなかった点

**1. 非 strict の型テストは新規 `nostrict/` に限定しました。** 既存233ファイルを非 strict で回すと19件残りますが、**すべて前提の食い違いで不具合ではありません**（13件は `toBeNullable()` — 非 strict では `X|null` ≡ `X` なので vitest の `ExpectNullable<T>` に呼び出しシグネチャが無い、5件は「Unused `@ts-expect-error`」— null 誤用の拒否を検証するもので非 strict では合法）。既存アサーションを両モード可搬に書き換えるのは本 PR の範囲を超えます。

**2. `StrictGlobalOmit` の非 strict 循環参照エラー**（`TS2615`、`NonNullable<O[K]>` 由来）。**別件の既存不具合**で、`$extends` と globalOmit を併用して `GassmaClient<{omit:...}>` を明示指定したときだけ出ます。範囲外としてゲート対象外にしています。

**3. `S = any` の扱いが変わります。** 従来は分配により両分岐の union でしたが、omit 分岐（全スカラー）のみになります。改善だと考えていますが仕様変更なので報告します。

**4. マトリクスのパッチバージョンは固定**（5.2.2/5.6.3/5.9.3/6.0.3/7.0.2）。再現性優先で、更新は手動です。

## 関連

**`gassma@2.0.1` が必要です。** この不具合は公開済みの 2.0.0 に入っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)