### PR TITLE
fix: 必須 to-one リレーションを null 許容にしない

### DIFF
--- a/packages/cli/scripts/genFixtureTypes.ts
+++ b/packages/cli/scripts/genFixtureTypes.ts
@@ -8,6 +8,7 @@ import { extractAutoincrement } from "../src/generate/read/extractAutoincrement"
 import { extractDefaults } from "../src/generate/read/extractDefaults";
 import { extractUpdatedAt } from "../src/generate/read/extractUpdatedAt";
 import { extractOptionalFields } from "../src/generate/read/extractOptionalFields";
+import { extractOptionalRelations } from "../src/generate/read/extractOptionalRelations";
 import { extractPreviewFeatures } from "../src/generate/read/extractPreviewFeatures";
 
 const fixturePath = path.join(
@@ -26,6 +27,7 @@ const generateFixture = (text: string, fileName: string) => {
   const defaults = extractDefaults(text);
   const updatedAt = extractUpdatedAt(text);
   const optionalFields = extractOptionalFields(text);
+  const optionalRelations = extractOptionalRelations(text);
   const strict = extractPreviewFeatures(text).includes(
     "strictUndefinedChecks",
   );
@@ -40,6 +42,7 @@ const generateFixture = (text: string, fileName: string) => {
     Object.keys(autoincrement),
     optionalFields,
     strict,
+    optionalRelations,
   );
   const clientDts = generateClientDts("", undefined, Object.keys(parsed));
 

--- a/packages/cli/src/__test__/generate/read/extractOptionalRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractOptionalRelations.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { extractOptionalRelations } from "../../../generate/read/extractOptionalRelations";
+
+describe("extractOptionalRelations", () => {
+  it("should not collect a required fk-side relation", () => {
+    const schema = `
+model User {
+  id    Int    @id
+  posts Post[]
+}
+
+model Post {
+  id       Int  @id
+  authorId Int
+  author   User @relation(fields: [authorId], references: [id])
+}
+`;
+    const result = extractOptionalRelations(schema);
+
+    expect(result.Post).not.toContain("author");
+  });
+
+  it("should collect an optional fk-side relation", () => {
+    const schema = `
+model Theme {
+  id     Int      @id
+  lesson Lesson[]
+}
+
+model Lesson {
+  id      Int    @id
+  themeId Int?
+  theme   Theme? @relation(fields: [themeId], references: [id])
+}
+`;
+    const result = extractOptionalRelations(schema);
+
+    expect(result.Lesson).toContain("theme");
+  });
+
+  it("should collect a self relation that is optional", () => {
+    const schema = `
+model Category {
+  id       Int        @id
+  parentId Int?
+  parent   Category?  @relation("CategoryTree", fields: [parentId], references: [id])
+  children Category[] @relation("CategoryTree")
+}
+`;
+    const result = extractOptionalRelations(schema);
+
+    expect(result.Category).toContain("parent");
+    expect(result.Category).not.toContain("children");
+  });
+
+  it("should not collect the inverse side that holds no fk", () => {
+    const schema = `
+model User {
+  id      Int      @id
+  profile Profile?
+}
+
+model Profile {
+  id     Int  @id
+  userId Int  @unique
+  user   User @relation(fields: [userId], references: [id])
+}
+`;
+    const result = extractOptionalRelations(schema);
+
+    expect(result.User).not.toContain("profile");
+    expect(result.Profile).not.toContain("user");
+  });
+
+  it("should give every model an entry even without relations", () => {
+    const schema = `
+model Tag {
+  id   Int    @id
+  name String
+}
+`;
+    const result = extractOptionalRelations(schema);
+
+    expect(result.Tag).toEqual([]);
+  });
+
+  it("should collect several optional relations on one model", () => {
+    const schema = `
+model Member {
+  id    Int    @id
+  loans Loan[]
+}
+
+model Book {
+  id    Int    @id
+  loans Loan[]
+}
+
+model Loan {
+  id       Int     @id
+  memberId Int
+  bookId   Int?
+  member   Member  @relation(fields: [memberId], references: [id])
+  book     Book?   @relation(fields: [bookId], references: [id])
+}
+`;
+    const result = extractOptionalRelations(schema);
+
+    expect(result.Loan).toEqual(["book"]);
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResult.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResult.test.ts
@@ -62,7 +62,7 @@ describe("getOneGassmaFindResult", () => {
     );
   });
 
-  it("should map manyToOne to computed TargetFindResult | null threading CMap", () => {
+  it("should map optional manyToOne to computed TargetFindResult | null threading CMap", () => {
     const relations: RelationsConfig = {
       Post: {
         author: {
@@ -73,7 +73,9 @@ describe("getOneGassmaFindResult", () => {
         },
       },
     };
-    const result = getOneGassmaFindResult("", "Post", relations);
+    const result = getOneGassmaFindResult("", "Post", relations, {
+      Post: ["author"],
+    });
     expect(result).toContain(
       '"author": GassmaUserFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "User": infer TO } ? TO extends GassmaUserOmit ? TO : {} : {}, O, CMap> | null;',
     );

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResultRelationNullability.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaFindResultRelationNullability.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { RelationsConfig } from "../../../generate/read/extractRelations";
+import { getOneGassmaFindResult } from "../../../generate/typeGenerate/gassmaFindResult/oneGassmaFindResult";
+
+const postRelations: RelationsConfig = {
+  Post: {
+    author: {
+      type: "manyToOne",
+      to: "User",
+      field: "authorId",
+      reference: "id",
+    },
+  },
+};
+
+const countNull = (text: string, relationName: string) =>
+  text.split("\n").filter((line) => line.includes(`"${relationName}": `))
+    .length;
+
+const nullableLines = (text: string, relationName: string) =>
+  text
+    .split("\n")
+    .filter((line) => line.includes(`"${relationName}": `))
+    .filter((line) => line.trimEnd().endsWith("| null;")).length;
+
+describe("getOneGassmaFindResult relation nullability", () => {
+  it("should not add null to a required manyToOne relation", () => {
+    const result = getOneGassmaFindResult("", "Post", postRelations, {
+      Post: [],
+    });
+
+    expect(countNull(result, "author")).toBeGreaterThan(0);
+    expect(nullableLines(result, "author")).toBe(0);
+  });
+
+  it("should add null to an optional manyToOne relation", () => {
+    const result = getOneGassmaFindResult("", "Post", postRelations, {
+      Post: ["author"],
+    });
+
+    expect(nullableLines(result, "author")).toBe(countNull(result, "author"));
+  });
+
+  it("should apply the same rule to the select branch and the include branch", () => {
+    const required = getOneGassmaFindResult("", "Post", postRelations, {
+      Post: [],
+    });
+
+    expect(required).toContain(
+      '"author": GassmaUserFindResult<Gassma.SelectOf<S[K]>, Gassma.IncludeOf<S[K]>, Gassma.OmitOf<S[K]>, O extends { "User": infer TO } ? TO extends GassmaUserOmit ? TO : {} : {}, O, CMap>;',
+    );
+    expect(required).toContain(
+      '"author": GassmaUserFindResult<Gassma.SelectOf<I[K]>, Gassma.IncludeOf<I[K]>, Gassma.OmitOf<I[K]>, O extends { "User": infer TO } ? TO extends GassmaUserOmit ? TO : {} : {}, O, CMap>;',
+    );
+  });
+
+  it("should keep oneToOne on the non fk side nullable", () => {
+    const relations: RelationsConfig = {
+      User: {
+        profile: {
+          type: "oneToOne",
+          to: "Profile",
+          field: "id",
+          reference: "userId",
+        },
+      },
+    };
+    const result = getOneGassmaFindResult("", "User", relations, { User: [] });
+
+    expect(nullableLines(result, "profile")).toBe(countNull(result, "profile"));
+  });
+
+  it("should keep list relations as arrays without null", () => {
+    const relations: RelationsConfig = {
+      User: {
+        posts: {
+          type: "oneToMany",
+          to: "Post",
+          field: "id",
+          reference: "authorId",
+        },
+        tags: {
+          type: "manyToMany",
+          to: "Tag",
+          field: "id",
+          reference: "id",
+        },
+      },
+    };
+    const result = getOneGassmaFindResult("", "User", relations, { User: [] });
+
+    expect(nullableLines(result, "posts")).toBe(0);
+    expect(nullableLines(result, "tags")).toBe(0);
+    expect(result).toContain("CMap>[];");
+  });
+
+  it("should treat a missing optional-relations entry as required", () => {
+    const result = getOneGassmaFindResult("", "Post", postRelations);
+
+    expect(nullableLines(result, "author")).toBe(0);
+  });
+});

--- a/packages/cli/src/__test__/types/read/include.test-d.ts
+++ b/packages/cli/src/__test__/types/read/include.test-d.ts
@@ -25,15 +25,15 @@ declare const client: GassmaClient;
   expectTypeOf<NonNullable<U["profile"]>["bio"]>().toEqualTypeOf<string>();
 }
 
-// Post.author（manyToOne）→ User | null（スプレッドシートは FK 制約を持たないため常に null 許容）
+// Post.author（manyToOne・FK 必須）→ User（Prisma と同じく null を含まない）
 {
   const p = client.Post.findFirst({
     where: { id: 1 },
     include: { author: true },
   });
   type P = NonNullable<typeof p>;
-  expectTypeOf<P["author"]>().toBeNullable();
-  expectTypeOf<NonNullable<P["author"]>["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<P["author"]>().not.toBeNullable();
+  expectTypeOf<P["author"]["email"]>().toEqualTypeOf<string>();
 }
 
 // findMany でも posts は配列で返る
@@ -143,4 +143,50 @@ declare const client: GassmaClient;
     where: { id: 1 },
     include: { posts: { orderBy: [{ published: "desc" }, { title: "asc" }] } },
   });
+}
+
+// to-one の null 許容はリレーションフィールドの `?` に従う（include）
+{
+  const p = client.Post.findFirstOrThrow({ include: { author: true } });
+  // Post.author は必須なのでガードなしでアクセスできる
+  expectTypeOf<(typeof p)["author"]["email"]>().toEqualTypeOf<string>();
+
+  const c = client.Category.findFirstOrThrow({ include: { parent: true } });
+  // Category.parent は `Category?` なので null 許容のまま
+  expectTypeOf<(typeof c)["parent"]>().toBeNullable();
+
+  const u = client.User.findFirstOrThrow({ include: { profile: true } });
+  // FK を持たない側は相手が存在する保証がないので常に null 許容
+  expectTypeOf<(typeof u)["profile"]>().toBeNullable();
+}
+
+// to-one の null 許容はリレーションフィールドの `?` に従う（select）
+{
+  const p = client.Post.findFirstOrThrow({ select: { author: true } });
+  expectTypeOf<(typeof p)["author"]["email"]>().toEqualTypeOf<string>();
+
+  const c = client.Category.findFirstOrThrow({ select: { parent: true } });
+  expectTypeOf<(typeof c)["parent"]>().toBeNullable();
+
+  const u = client.User.findFirstOrThrow({ select: { profile: true } });
+  expectTypeOf<(typeof u)["profile"]>().toBeNullable();
+}
+
+// ネストした include の奥でも必須 to-one は null にならない
+{
+  const u = client.User.findFirstOrThrow({
+    include: { posts: { include: { author: true } } },
+  });
+  expectTypeOf<
+    (typeof u)["posts"][number]["author"]["email"]
+  >().toEqualTypeOf<string>();
+}
+
+// 複合FKの両方が必須: Enrollment.student / Enrollment.course
+{
+  const e = client.Enrollment.findFirstOrThrow({
+    include: { student: true, course: true },
+  });
+  expectTypeOf<(typeof e)["student"]["name"]>().toEqualTypeOf<string>();
+  expectTypeOf<(typeof e)["course"]["title"]>().toEqualTypeOf<string>();
 }

--- a/packages/cli/src/__test__/types/read/relationKinds.test-d.ts
+++ b/packages/cli/src/__test__/types/read/relationKinds.test-d.ts
@@ -26,15 +26,15 @@ declare const clientOmit: GassmaClient<{ Post: { published: true } }>;
   expectTypeOf<T["posts"][number]["title"]>().toEqualTypeOf<string>();
 }
 
-// oneToOne 逆側(FK 保有側): Profile.user → User | null
+// 1:1 の FK 保有側: Profile.user は必須なので User（null を含まない）
 {
   const pr = client.Profile.findFirst({
     where: { id: 1 },
     include: { user: true },
   });
   type Pr = NonNullable<typeof pr>;
-  expectTypeOf<Pr["user"]>().toBeNullable();
-  expectTypeOf<NonNullable<Pr["user"]>["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<Pr["user"]>().not.toBeNullable();
+  expectTypeOf<Pr["user"]["email"]>().toEqualTypeOf<string>();
 }
 
 // 3段以上の深いネスト include: User -> posts -> tags -> posts
@@ -84,7 +84,7 @@ declare const clientOmit: GassmaClient<{ Post: { published: true } }>;
   });
   type P = NonNullable<typeof p>;
   expectTypeOf<P>().not.toHaveProperty("published");
-  expectTypeOf<P["author"]>().toBeNullable();
+  expectTypeOf<P["author"]>().not.toBeNullable();
   expectTypeOf<P["tags"]>().toBeArray();
   expectTypeOf<P["title"]>().toEqualTypeOf<string>();
 }
@@ -97,7 +97,7 @@ declare const clientOmit: GassmaClient<{ Post: { published: true } }>;
   });
   type P = NonNullable<typeof p>;
   expectTypeOf<P>().not.toHaveProperty("published");
-  expectTypeOf<P["author"]>().toBeNullable();
+  expectTypeOf<P["author"]>().not.toBeNullable();
 }
 
 // select と include の役割分担: select 内リレーション + _count

--- a/packages/cli/src/__test__/types/read/select.test-d.ts
+++ b/packages/cli/src/__test__/types/read/select.test-d.ts
@@ -41,15 +41,15 @@ declare const client: GassmaClient;
   expectTypeOf<NonNullable<R["profile"]>["bio"]>().toEqualTypeOf<string>();
 }
 
-// select で manyToOne relation: 単一 | null
+// select で manyToOne relation: FK 必須なので単一（null なし）
 {
   const r = client.Post.findFirstOrThrow({
     where: {},
     select: { id: true, author: true },
   });
   type R = typeof r;
-  expectTypeOf<R["author"]>().toBeNullable();
-  expectTypeOf<NonNullable<R["author"]>["email"]>().toEqualTypeOf<string>();
+  expectTypeOf<R["author"]>().not.toBeNullable();
+  expectTypeOf<R["author"]["email"]>().toEqualTypeOf<string>();
 }
 
 // select 内の relation に select（ネスト）: relation 先も絞られる
@@ -104,7 +104,7 @@ declare const client: GassmaClient;
   expectTypeOf<P["tags"][number]>().not.toHaveProperty("id");
 }
 
-// ネスト select 内の relation true: 対象の全スカラー（manyToOne は | null）
+// ネスト select 内の relation true: 対象の全スカラー（FK 必須なので null なし）
 {
   const r = client.User.findFirstOrThrow({
     where: {},
@@ -112,8 +112,8 @@ declare const client: GassmaClient;
   });
   type P = (typeof r)["posts"][number];
   expectTypeOf<P>().not.toHaveProperty("title");
-  expectTypeOf<P["author"]>().toBeNullable();
-  type A = NonNullable<P["author"]>;
+  expectTypeOf<P["author"]>().not.toBeNullable();
+  type A = P["author"];
   expectTypeOf<keyof A>().toEqualTypeOf<
     | "id"
     | "email"

--- a/packages/cli/src/generate/generate.ts
+++ b/packages/cli/src/generate/generate.ts
@@ -9,6 +9,7 @@ import { extractDefaults } from "./read/extractDefaults";
 import { extractRelations } from "./read/extractRelations";
 import { extractUpdatedAt } from "./read/extractUpdatedAt";
 import { extractOptionalFields } from "./read/extractOptionalFields";
+import { extractOptionalRelations } from "./read/extractOptionalRelations";
 import { extractIgnore } from "./read/extractIgnore";
 import { extractIgnoreSheets } from "./read/extractIgnoreSheets";
 import { extractMap } from "./read/extractMap";
@@ -101,6 +102,7 @@ function generateFromSchema(
   const defaults = extractDefaults(schemaText);
   const updatedAt = extractUpdatedAt(schemaText);
   const optionalFields = extractOptionalFields(schemaText);
+  const optionalRelations = extractOptionalRelations(schemaText);
   const ignore = extractIgnore(schemaText);
   const ignoreSheets = extractIgnoreSheets(schemaText);
   const map = extractMap(schemaText);
@@ -120,6 +122,7 @@ function generateFromSchema(
     Object.keys(autoincrement),
     optionalFields,
     strict,
+    optionalRelations,
   );
   const clientDts = generateClientDts(schemaName, enums, Object.keys(parsed));
   const mergedDts = resultString + "\n" + clientDts;

--- a/packages/cli/src/generate/generator.ts
+++ b/packages/cli/src/generate/generator.ts
@@ -1,4 +1,5 @@
 import type { DefaultsConfig } from "./read/extractDefaults";
+import type { OptionalRelationsConfig } from "./read/extractOptionalRelations";
 import type { RelationsConfig } from "./read/extractRelations";
 import { getGassmaAggregateBaseReturn } from "./typeGenerate/gassmaAggregateBaseReturn";
 import { getGassmaAggregateData } from "./typeGenerate/gassmaAggregateData";
@@ -52,6 +53,7 @@ const generater = (
   autoincrementModels?: string[],
   optionalFields?: Record<string, string[]>,
   strict?: boolean,
+  optionalRelations?: OptionalRelationsConfig,
 ) => {
   const schema = schemaName ?? "";
   const sheetNames = Object.keys(dictYaml);
@@ -101,7 +103,12 @@ const generater = (
   result += getGassmaCountResult(sheetNames, schema);
   result += getGassmaCreateReturn(dictYaml, schema);
   result += getGassmaDefaultFindResult(sheetNames, schema);
-  result += getGassmaFindResult(sheetNames, schema, relations);
+  result += getGassmaFindResult(
+    sheetNames,
+    schema,
+    relations,
+    optionalRelations,
+  );
   result += getGassmaAggregateBaseReturn(dictYaml, schema);
   result += getGassmaAggregateField(sheetNames, schema);
   result += getGassmaAggregateResult(sheetNames, schema);

--- a/packages/cli/src/generate/read/extractOptionalRelations.ts
+++ b/packages/cli/src/generate/read/extractOptionalRelations.ts
@@ -1,0 +1,44 @@
+import {
+  parsePrismaSchema,
+  findFirstAttribute,
+} from "@loancrate/prisma-schema-parser";
+import type { ModelDeclaration } from "@loancrate/prisma-schema-parser";
+import { getFieldReferences } from "./relationHelpers";
+
+type OptionalRelationsConfig = Record<string, string[]>;
+
+const collectOptionalRelationFields = (model: ModelDeclaration): string[] => {
+  const fieldNames: string[] = [];
+
+  model.members.forEach((member) => {
+    if (member.kind !== "field") return;
+    if (member.type.kind !== "optional") return;
+    if (member.type.type.kind !== "typeId") return;
+
+    const attr = findFirstAttribute(member.attributes, "relation");
+    if (!attr) return;
+    if (!getFieldReferences(attr.args, "fields")) return;
+    if (!getFieldReferences(attr.args, "references")) return;
+
+    fieldNames.push(member.name.value);
+  });
+
+  return fieldNames;
+};
+
+const extractOptionalRelations = (
+  schemaText: string,
+): OptionalRelationsConfig => {
+  const ast = parsePrismaSchema(schemaText);
+  const result: OptionalRelationsConfig = {};
+
+  ast.declarations.forEach((decl) => {
+    if (decl.kind !== "model") return;
+    result[decl.name.value] = collectOptionalRelationFields(decl);
+  });
+
+  return result;
+};
+
+export { extractOptionalRelations };
+export type { OptionalRelationsConfig };

--- a/packages/cli/src/generate/typeGenerate/gassmaFindResult.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaFindResult.ts
@@ -1,11 +1,13 @@
 import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
 import { getOneGassmaFindResult } from "./gassmaFindResult/oneGassmaFindResult";
+import type { OptionalRelationsConfig } from "../read/extractOptionalRelations";
 import type { RelationsConfig } from "../read/extractRelations";
 
 const getGassmaFindResult = (
   sheetNames: string[],
   schemaName: string,
   relations?: RelationsConfig,
+  optionalRelations?: OptionalRelationsConfig,
 ) => {
   const findResult = sheetNames.reduce((pre, currentSheetName) => {
     const removedSpaceCurrentSheetName =
@@ -17,6 +19,7 @@ const getGassmaFindResult = (
         schemaName,
         removedSpaceCurrentSheetName,
         relations,
+        optionalRelations,
       )
     );
   }, "");

--- a/packages/cli/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaFindResult/oneGassmaFindResult.ts
@@ -1,14 +1,28 @@
-import type { RelationsConfig } from "../../read/extractRelations";
+import type { OptionalRelationsConfig } from "../../read/extractOptionalRelations";
+import type {
+  RelationDefinition,
+  RelationsConfig,
+} from "../../read/extractRelations";
 
 const getOneGassmaFindResult = (
   schemaName: string,
   sheetName: string,
   relations?: RelationsConfig,
+  optionalRelations?: OptionalRelationsConfig,
 ) => {
   const prefix = `Gassma${schemaName}`;
   const self = `${prefix}${sheetName}`;
   const modelRelations = relations?.[sheetName] ?? {};
   const relNames = Object.keys(modelRelations);
+  const optionalRelNames = optionalRelations?.[sheetName] ?? [];
+
+  // to-many は配列。to-one は Prisma と同じくリレーションフィールドの `?` に従い、
+  // FK を持たない oneToOne は相手が存在する保証がないため常に null 許容。
+  const relationSuffix = (def: RelationDefinition, relationName: string) => {
+    if (def.type === "oneToMany" || def.type === "manyToMany") return "[]";
+    if (def.type === "oneToOne") return " | null";
+    return optionalRelNames.includes(relationName) ? " | null" : "";
+  };
 
   const relUnion = relNames.map((r) => `"${r}"`).join(" | ");
   const relKeyUnion =
@@ -26,9 +40,7 @@ const getOneGassmaFindResult = (
         const targetFR = `${prefix}${def.to}${childName}`;
         const targetGO = `O extends { "${def.to}": infer TO } ? TO extends ${prefix}${def.to}Omit ? TO : {} : {}`;
         const inner = `${targetFR}<Gassma.SelectOf<${source}[K]>, Gassma.IncludeOf<${source}[K]>, Gassma.OmitOf<${source}[K]>, ${targetGO}, O${childArgs}>`;
-        const isList = def.type === "oneToMany" || def.type === "manyToMany";
-        const result = isList ? `${inner}[]` : `${inner} | null`;
-        return `            "${relationName}": ${result};`;
+        return `            "${relationName}": ${inner}${relationSuffix(def, relationName)};`;
       })
       .join("\n");
     return `          K extends ${relUnion} ? {


### PR DESCRIPTION
**FK が必須なリレーションを `include` しても、結果型が `| null` になっていました。**

```ts
const loans = g.Loan.findMany({ include: { member: true } });
const check: typeof loans[0].member = null;   // ← 型エラーにならなかった
```

`Loan.member` は `Member @relation(fields: [memberId], references: [id])` で **`memberId Int`（必須）** です。存在しないことはあり得ないのに、**利用者は書かなくていいガードを書かされます。**

gassma を知らないエージェントにドキュメントだけで実装させたところ、実際に `if (!loan.member) return []` を書く羽目になりました。**Prisma では不要なコードです。**

## Prisma の実物（`prisma-test` の生成物で確認）

**同じ `author` でも2種類あります。**

```
8134:  author: Prisma.$AuthorPayload<ExtArgs> | null    ← Post.author（authorId Int?）
9234:  author: Prisma.$AuthorPayload<ExtArgs>           ← Profile.author（authorId Int @unique）
```

| パターン | Prisma |
|---|---|
| 必須 to-one（FK が `Int`） | **null なし** |
| 任意 to-one（FK が `Int?`） | `\| null` |
| 1:1 の FK 非保有側 | `\| null` |
| to-many | `[]`（null なし） |

## 原因

```ts
const isList = def.type === "oneToMany" || def.type === "manyToMany";
const result = isList ? `${inner}[]` : `${inner} | null`;
```

**リレーションの種別だけを見て、to-one なら無条件に `| null`** を付けていました。この関数は `select` 分岐からも呼ばれるため、**`select` にも同じ不具合がありました**（実測確認済み）。

**情報は既に揃っていました。** `extractRelations.ts:66` が `isOptional` を計算しているのに、`buildRelationsConfig` が読まずに捨てていて**完全なデッドデータ**でした。

## 実装

`RelationsConfig` にキーを足す案は**採っていません**。`generateClientJs.ts` が `JSON.stringify(relations)` で生成 JS に埋め込み、**本体の `src/index.d.ts` の `RelationDefinition` と対応している**ためです。`optionalFields` と同じ「別経路で渡す」方式にしました。

**結果、生成される `.js` の差分はゼロ**です（利用者プロジェクトで実測確認）。

| パターン | 変更前 | 変更後 |
|---|---|---|
| `manyToOne`・FK 必須 | `X \| null` | **`X`** |
| `manyToOne`・FK 任意 | `X \| null` | 不変 |
| `oneToOne`（FK 非保有側） | `X \| null` | 不変 |
| `oneToMany` / `manyToMany` | `X[]` | 不変 |

## 検証結果

**利用者プロジェクトでの実証（私の側で独立に確認）:**

```ts
const bad: null = loans[0].member;   // ← エラーになるようになった
const ok = loans[0].member.name;     // ← ガード無しで通る
const ok3 = sel[0].member.name;      // ← select 側も同じ
const n: Date | null = loans[0].returnedAt;   // ← 任意列は null 許容のまま
```

生成物の差分は **`Loan.member` と `Loan.book`（どちらも必須 FK）だけ**に集中しており、to-many や任意 FK には触れていません。**ランタイム JS は完全一致**です。

- `npm test`: **1,458件 全 green**（1,446 → +12）
- **`test:types:all` 全10セル green**（5.2/5.6/5.9/6.0/7.0 × strict on/off）
- `tsc --noEmit` / lint / format pass

**#156 の `SelectGiven<S>` には一切触れていません。**

## 変更した既存テスト（7件）

**すべて旧仕様を明文化していた箇所**で、期待値を通すためのいじりではありません。

| テスト | 変更 |
|---|---|
| `include.test-d.ts:28-37` | コメント「スプレッドシートは FK 制約を持たないため常に null 許容」ごと書き換え。**本 PR が覆す対象そのもの** |
| `relationKinds.test-d.ts:29-38` | `Profile.user`。コメントの「oneToOne 逆側」も誤記だったので修正（`extractRelations` は `manyToOne` として出す） |
| 同 `:87` / `:100` | omit・グローバル omit 併用。主題は omit なので副次的 |
| `select.test-d.ts:44-52` / `:107-116` | **select 側にもバグがあった証拠**。`NonNullable<P["author"]>` が不要に |
| `gassmaFindResult.test.ts:65` | 主題は CMap の配線なので、`{ Post: ["author"] }` を渡して**任意 FK のケース**として意図を保存。テスト名も変更 |

## 判断が必要で実装しなかった点

**1. `oneToOne`（FK 非保有側）は常に `| null` のままです。**

Prisma は厳密には相手側フィールドの `?` に従うので、`profile Profile`（`?` なし）と書けた場合は非 null になります。ただし**スプレッドシートには FK 制約が無く実在が保証されない**ため、常に null 許容が安全だと判断しました。**Prisma 完全準拠に寄せるかは要判断**です（現フィクスチャでは差が出ません）。

**2. `RelationsConfig` に `isOptional` を持たせる案は見送りました。** DRY にはなりますが、**本体の公開 `.d.ts` と生成 JS の契約が変わる**ので別リポジトリの同時変更が必要になります。

## 関連

`gassma@2.0.1` に含めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)