### PR TITLE
feat: groupBy の orderBy を集計ソートに対応させる

### DIFF
--- a/packages/cli/src/__test__/generate/generator.test.ts
+++ b/packages/cli/src/__test__/generate/generator.test.ts
@@ -97,6 +97,8 @@ describe("generater", () => {
   it("should include GroupBy types", () => {
     expect(result).toContain("GassmaUserGroupByData");
     expect(result).toContain("GassmaUserGroupByResult");
+    expect(result).toContain("export type GassmaUserOrderByWithAggregation");
+    expect(result).toContain("export type GassmaPostOrderByWithAggregation");
   });
 
   it("should include Extension types", () => {

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -99,6 +99,24 @@ describe("getGassmaErrorClasses", () => {
     );
   });
 
+  it("should include GassmaGroupByOrderByRequiredError with rest parameters", () => {
+    expect(result).toContain(
+      "class GassmaGroupByOrderByRequiredError extends Error",
+    );
+    expect(result).toContain("constructor(...paginationArguments: string[]);");
+  });
+
+  it("should declare GroupBy errors in the same order as gassma", () => {
+    const having = result.indexOf("class GassmaGroupByHavingDontWriteByError");
+    const orderByRequired = result.indexOf(
+      "class GassmaGroupByOrderByRequiredError",
+    );
+    const aggregateMax = result.indexOf("class GassmaAggregateMaxError");
+
+    expect(having).toBeLessThan(orderByRequired);
+    expect(orderByRequired).toBeLessThan(aggregateMax);
+  });
+
   it("should include aggregate error classes with inheritance", () => {
     expect(result).toContain("class GassmaAggregateMaxError extends Error");
     expect(result).toContain(

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaGroupByData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaGroupByData.test.ts
@@ -2,17 +2,28 @@ import { describe, it, expect } from "vitest";
 import { getOneGassmaGroupByData } from "../../../generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData";
 
 describe("getOneGassmaGroupByData", () => {
-  it("should extend AggregateData without cursor, with by + having", () => {
+  it("should extend AggregateData without cursor and orderBy, with by + having", () => {
     const result = getOneGassmaGroupByData(
       { id: [1], name: ["a"] },
       "",
       "User",
     );
     expect(result).toContain(
-      'export type GassmaUserGroupByData = Omit<GassmaUserAggregateData, "cursor"> & {',
+      'export type GassmaUserGroupByData = Omit<GassmaUserAggregateData, "cursor" | "orderBy"> & {',
     );
     expect(result).toContain("by:");
     expect(result).toContain("having?: GassmaUserHavingUse;");
+  });
+
+  it("should replace orderBy with OrderByWithAggregation", () => {
+    const result = getOneGassmaGroupByData(
+      { id: [1], name: ["a"] },
+      "",
+      "User",
+    );
+    expect(result).toContain(
+      "orderBy?: GassmaUserOrderByWithAggregation | GassmaUserOrderByWithAggregation[];",
+    );
   });
 
   it("should include all column names as by union", () => {
@@ -34,7 +45,10 @@ describe("getOneGassmaGroupByData", () => {
   it("should prepend schemaName", () => {
     const result = getOneGassmaGroupByData({ id: [1] }, "Test", "User");
     expect(result).toContain("export type GassmaTestUserGroupByData");
-    expect(result).toContain('Omit<GassmaTestUserAggregateData, "cursor">');
+    expect(result).toContain(
+      'Omit<GassmaTestUserAggregateData, "cursor" | "orderBy">',
+    );
     expect(result).toContain("GassmaTestUserHavingUse");
+    expect(result).toContain("GassmaTestUserOrderByWithAggregation");
   });
 });

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaOrderByWithAggregation.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaOrderByWithAggregation.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { getGassmaOrderByWithAggregation } from "../../../generate/typeGenerate/gassmaOrderByWithAggregation";
+import { getOneGassmaOrderByWithAggregation } from "../../../generate/typeGenerate/gassmaOrderByWithAggregation/oneGassmaOrderByWithAggregation";
+
+describe("getOneGassmaOrderByWithAggregation", () => {
+  const sheetContent = { id: ["number"], name: ["string"] };
+
+  it("should declare a type per sheet", () => {
+    const result = getOneGassmaOrderByWithAggregation(sheetContent, "", "User");
+    expect(result).toContain(
+      "export type GassmaUserOrderByWithAggregation = {",
+    );
+  });
+
+  it("should allow every scalar column with SortOrderInput", () => {
+    const result = getOneGassmaOrderByWithAggregation(sheetContent, "", "User");
+    expect(result).toContain(
+      '  "id"?: "asc" | "desc" | Gassma.SortOrderInput;\n',
+    );
+    expect(result).toContain(
+      '  "name"?: "asc" | "desc" | Gassma.SortOrderInput;\n',
+    );
+  });
+
+  it("should allow every column in _count / _max / _min", () => {
+    const result = getOneGassmaOrderByWithAggregation(sheetContent, "", "User");
+    expect(result).toContain(
+      '  "_count"?: { "id"?: "asc" | "desc"; "name"?: "asc" | "desc" };\n',
+    );
+    expect(result).toContain(
+      '  "_max"?: { "id"?: "asc" | "desc"; "name"?: "asc" | "desc" };\n',
+    );
+    expect(result).toContain(
+      '  "_min"?: { "id"?: "asc" | "desc"; "name"?: "asc" | "desc" };\n',
+    );
+  });
+
+  it("should limit _avg / _sum to number columns", () => {
+    const result = getOneGassmaOrderByWithAggregation(sheetContent, "", "User");
+    expect(result).toContain('  "_avg"?: { "id"?: "asc" | "desc" };\n');
+    expect(result).toContain('  "_sum"?: { "id"?: "asc" | "desc" };\n');
+  });
+
+  it("should treat an addType column containing number as a number column", () => {
+    const result = getOneGassmaOrderByWithAggregation(
+      { rating: ["number", "string"] },
+      "",
+      "User",
+    );
+    expect(result).toContain('  "_avg"?: { "rating"?: "asc" | "desc" };\n');
+  });
+
+  it("should drop _avg / _sum when the sheet has no number column", () => {
+    const result = getOneGassmaOrderByWithAggregation(
+      { name: ["string"] },
+      "",
+      "User",
+    );
+    expect(result).not.toContain('"_avg"');
+    expect(result).not.toContain('"_sum"');
+    expect(result).toContain('  "_count"?: { "name"?: "asc" | "desc" };\n');
+  });
+
+  it("should not contain relation fields", () => {
+    const result = getOneGassmaOrderByWithAggregation(sheetContent, "", "User");
+    expect(result).not.toContain("posts");
+  });
+
+  it("should strip trailing ? from column names", () => {
+    const result = getOneGassmaOrderByWithAggregation(
+      { "name?": ["string"] },
+      "",
+      "User",
+    );
+    expect(result).toContain(
+      '  "name"?: "asc" | "desc" | Gassma.SortOrderInput;\n',
+    );
+    expect(result).not.toContain('"name?"');
+  });
+
+  it("should prepend schemaName", () => {
+    const result = getOneGassmaOrderByWithAggregation(
+      sheetContent,
+      "Test",
+      "User",
+    );
+    expect(result).toContain(
+      "export type GassmaTestUserOrderByWithAggregation = {",
+    );
+  });
+
+  it("should add SkipValue to every optional property when strict", () => {
+    const result = getOneGassmaOrderByWithAggregation(
+      sheetContent,
+      "",
+      "User",
+      true,
+    );
+    expect(result).toContain(
+      '  "id"?: "asc" | "desc" | Gassma.SortOrderInput | Gassma.SkipValue;\n',
+    );
+    expect(result).toContain(
+      '  "_count"?: { "id"?: "asc" | "desc" | Gassma.SkipValue; "name"?: "asc" | "desc" | Gassma.SkipValue } | Gassma.SkipValue;\n',
+    );
+    expect(result).toContain(
+      '  "_avg"?: { "id"?: "asc" | "desc" | Gassma.SkipValue } | Gassma.SkipValue;\n',
+    );
+  });
+
+  it("should keep non-strict output free of Skip", () => {
+    const result = getOneGassmaOrderByWithAggregation(sheetContent, "", "User");
+    expect(result).not.toContain("Skip");
+  });
+});
+
+describe("getGassmaOrderByWithAggregation", () => {
+  it("should declare a type for every sheet", () => {
+    const result = getGassmaOrderByWithAggregation(
+      { User: { id: ["number"] }, Post: { title: ["string"] } },
+      "",
+    );
+    expect(result).toContain("export type GassmaUserOrderByWithAggregation");
+    expect(result).toContain("export type GassmaPostOrderByWithAggregation");
+  });
+
+  it("should remove characters that cannot be used in a type name", () => {
+    const result = getGassmaOrderByWithAggregation(
+      { "メンバー 一覧": { id: ["number"] } },
+      "",
+    );
+    expect(result).toContain(
+      "export type Gassmaメンバー一覧OrderByWithAggregation",
+    );
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/strictSkip/topLevelData.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/strictSkip/topLevelData.test.ts
@@ -135,6 +135,12 @@ describe("strict GroupByData", () => {
     expect(result).toContain('by: "id" | ("id")[];');
   });
 
+  it("should add SkipValue to orderBy", () => {
+    expect(result).toContain(
+      "orderBy?: GassmaUserOrderByWithAggregation | GassmaUserOrderByWithAggregation[] | Gassma.SkipValue;",
+    );
+  });
+
   it("should keep non-strict output unchanged", () => {
     expect(
       getOneGassmaGroupByData({ id: ["number"] }, "", "User"),

--- a/packages/cli/src/__test__/types/aggregate/groupBy.test-d.ts
+++ b/packages/cli/src/__test__/types/aggregate/groupBy.test-d.ts
@@ -171,3 +171,115 @@ declare const client: GassmaClient;
     "ADMIN" | "USER" | "MODERATOR" | null
   >();
 }
+
+// groupBy: 集計値でソートできる（本体 #226）
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    orderBy: { _count: { id: "desc" } },
+  });
+  client.User.groupBy({
+    by: ["isActive"],
+    _sum: { age: true },
+    orderBy: { _sum: { age: "desc" } },
+  });
+  client.User.groupBy({ by: ["isActive"], orderBy: { _avg: { age: "asc" } } });
+  client.User.groupBy({
+    by: ["isActive"],
+    orderBy: { _max: { email: "asc" } },
+  });
+  client.User.groupBy({
+    by: ["isActive"],
+    orderBy: { _min: { createdAt: "desc" } },
+  });
+}
+
+// groupBy: 集計の中の列は by に含まれていなくてよい（Prisma パリティ）
+{
+  client.User.groupBy({ by: ["isActive"], orderBy: { _sum: { age: "desc" } } });
+}
+
+// groupBy: 集計を結果に選択していなくてもソートできる（Prisma パリティ）
+{
+  const r = client.User.groupBy({
+    by: ["isActive"],
+    orderBy: { _count: { id: "desc" } },
+  });
+  expectTypeOf<(typeof r)[number]>().not.toHaveProperty("_count");
+}
+
+// groupBy: 集計とスカラーの複合ソート
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    orderBy: [{ _count: { id: "desc" } }, { isActive: "asc" }],
+  });
+}
+
+// groupBy: _count の _all はソートに使えない（Prisma パリティ）
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    // @ts-expect-error orderBy の _count に _all は指定できない
+    orderBy: { _count: { _all: "desc" } },
+  });
+}
+
+// groupBy: orderBy の _avg / _sum は数値フィールド限定
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    // @ts-expect-error _avg は数値フィールド限定（email は string）
+    orderBy: { _avg: { email: "asc" } },
+  });
+  client.User.groupBy({
+    by: ["isActive"],
+    // @ts-expect-error _sum は数値フィールド限定（name は string）
+    orderBy: { _sum: { name: "asc" } },
+  });
+}
+
+// groupBy: 存在しない列ではソートできない
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    // @ts-expect-error "nonexistent" は User のフィールドでない
+    orderBy: { nonexistent: "asc" },
+  });
+}
+
+// groupBy: リレーションではソートできない（本体が拒否する）
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    // @ts-expect-error groupBy の orderBy にリレーションは指定できない
+    orderBy: { posts: { _count: "asc" } },
+  });
+}
+
+// groupBy: by に含まれないスカラー列は型では通る（実行時に本体が弾く）
+{
+  client.User.groupBy({ by: ["isActive"], orderBy: { age: "asc" } });
+}
+
+// findMany の orderBy は従来どおり（リレーション件数ソートを含む・回帰ガード）
+{
+  client.User.findMany({ orderBy: { posts: { _count: "asc" } } });
+  client.User.findMany({ orderBy: { name: { sort: "asc", nulls: "last" } } });
+  client.User.findMany({ orderBy: [{ isActive: "desc" }, { age: "asc" }] });
+}
+
+// aggregate の orderBy は従来どおり行に適用（回帰ガード）
+{
+  client.User.aggregate({ _count: { id: true }, orderBy: { name: "asc" } });
+  client.User.aggregate({
+    _count: { id: true },
+    orderBy: { posts: { _count: "asc" } },
+  });
+  const aggregateOrderBy: GassmaUserAggregateData = {
+    orderBy: { createdAt: "desc" },
+    take: 3,
+  };
+  void aggregateOrderBy;
+}

--- a/packages/cli/src/__test__/types/strict/skip.test-d.ts
+++ b/packages/cli/src/__test__/types/strict/skip.test-d.ts
@@ -193,6 +193,9 @@ declare const client: GassmaClient;
   client.User.count({ where: Gassma.skip, take: Gassma.skip });
   client.User.groupBy({ by: "id", having: Gassma.skip });
   client.User.groupBy({ by: "id", having: { score: Gassma.skip } });
+  client.User.groupBy({ by: "id", orderBy: Gassma.skip });
+  client.User.groupBy({ by: "id", orderBy: { _count: Gassma.skip } });
+  client.User.groupBy({ by: "id", orderBy: { _count: { id: Gassma.skip } } });
   // @ts-expect-error by は必須引数なので skip 不可
   client.User.groupBy({ by: Gassma.skip });
 }

--- a/packages/cli/src/generate/generator.ts
+++ b/packages/cli/src/generate/generator.ts
@@ -35,6 +35,7 @@ import { getGassmaMain } from "./typeGenerate/gassmaMain";
 import { getGassmaManyCount } from "./typeGenerate/gassmaManyCount";
 import { getGassmaOmit } from "./typeGenerate/gassmaOmit";
 import { getGassmaOrderBy } from "./typeGenerate/gassmaOrderBy";
+import { getGassmaOrderByWithAggregation } from "./typeGenerate/gassmaOrderByWithAggregation";
 import { getGassmaSelect } from "./typeGenerate/gassmaSelect";
 import { getGassmaSheet } from "./typeGenerate/gassmaSheet";
 import { getGassmaUpdateData } from "./typeGenerate/gassmaUpdateData";
@@ -97,6 +98,7 @@ const generater = (
   result += getGassmaInclude(sheetNames, schema, relations, strict);
   result += getGassmaCountValue(sheetNames, schema, relations, strict);
   result += getGassmaOrderBy(dictYaml, schema, relations, strict);
+  result += getGassmaOrderByWithAggregation(dictYaml, schema, strict);
   result += getGassmaSelect(dictYaml, schema, relations, strict);
   result += getGassmaOmit(dictYaml, schema, strict);
   result += getGassmaCountData(sheetNames, schema, strict);

--- a/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -21,6 +21,11 @@ const errorClassDefinitions: ErrorClassDef[] = [
   { name: "GassmaFindSelectOmitConflictError", extends: "Error", params: "" },
   { name: "GassmaInValidColumnValueError", extends: "Error", params: "" },
   { name: "GassmaGroupByHavingDontWriteByError", extends: "Error", params: "" },
+  {
+    name: "GassmaGroupByOrderByRequiredError",
+    extends: "Error",
+    params: "...paginationArguments: string[]",
+  },
   { name: "GassmaAggregateMaxError", extends: "Error", params: "" },
   {
     name: "GassmaAggregateMinError",

--- a/packages/cli/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaGroupByData/oneGassmaGroupByData.ts
@@ -30,8 +30,11 @@ const getOneGassmaGroupByData = (
 
   const sk = skipUnion(strict);
 
-  return `\nexport type Gassma${schemaName}${sheetName}GroupByData = Omit<Gassma${schemaName}${sheetName}AggregateData, "cursor"> & {
+  const orderBy = `Gassma${schemaName}${sheetName}OrderByWithAggregation`;
+
+  return `\nexport type Gassma${schemaName}${sheetName}GroupByData = Omit<Gassma${schemaName}${sheetName}AggregateData, "cursor" | "orderBy"> & {
   by: ${byData}(${byArrayData})[];
+  orderBy?: ${orderBy} | ${orderBy}[]${sk};
   having?: Gassma${schemaName}${sheetName}HavingUse${sk};
 };
 `;

--- a/packages/cli/src/generate/typeGenerate/gassmaOrderByWithAggregation.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaOrderByWithAggregation.ts
@@ -1,0 +1,31 @@
+import { getRemovedCantUseVarChar } from "../util/getRemovedCantUseVarChar";
+import { getOneGassmaOrderByWithAggregation } from "./gassmaOrderByWithAggregation/oneGassmaOrderByWithAggregation";
+
+const getGassmaOrderByWithAggregation = (
+  dictYaml: Record<string, Record<string, unknown[]>>,
+  schemaName: string,
+  strict?: boolean,
+) => {
+  const orderByWithAggregationDeclare = Object.keys(dictYaml).reduce(
+    (pre, currentSheetName) => {
+      const sheetContent = dictYaml[currentSheetName];
+      const removedSpaceCurrentSheetName =
+        getRemovedCantUseVarChar(currentSheetName);
+
+      return (
+        pre +
+        getOneGassmaOrderByWithAggregation(
+          sheetContent,
+          schemaName,
+          removedSpaceCurrentSheetName,
+          strict,
+        )
+      );
+    },
+    "",
+  );
+
+  return orderByWithAggregationDeclare;
+};
+
+export { getGassmaOrderByWithAggregation };

--- a/packages/cli/src/generate/typeGenerate/gassmaOrderByWithAggregation/oneGassmaOrderByWithAggregation.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaOrderByWithAggregation/oneGassmaOrderByWithAggregation.ts
@@ -1,0 +1,53 @@
+import { isNumberColumn } from "../../util/isNumberColumn";
+import { skipUnion } from "../util/skipUnion";
+
+const getRemovedQuestionMark = (columnName: string) =>
+  columnName.at(-1) === "?"
+    ? columnName.substring(0, columnName.length - 1)
+    : columnName;
+
+const getAggregateObject = (columnNames: string[], sk: string) => {
+  const fields = columnNames
+    .map(
+      (columnName) =>
+        `"${getRemovedQuestionMark(columnName)}"?: "asc" | "desc"${sk}`,
+    )
+    .join("; ");
+
+  return `{ ${fields} }`;
+};
+
+const getOneGassmaOrderByWithAggregation = (
+  sheetContent: Record<string, unknown[]>,
+  schemaName: string,
+  sheetName: string,
+  strict?: boolean,
+) => {
+  const sk = skipUnion(strict);
+  const columnNames = Object.keys(sheetContent);
+  const numberColumnNames = columnNames.filter((columnName) =>
+    isNumberColumn(sheetContent[columnName]),
+  );
+
+  const scalarLines = columnNames.reduce(
+    (pre, columnName) =>
+      `${pre}  "${getRemovedQuestionMark(columnName)}"?: "asc" | "desc" | Gassma.SortOrderInput${sk};\n`,
+    "",
+  );
+
+  const allObject = getAggregateObject(columnNames, sk);
+  const numberObject = getAggregateObject(numberColumnNames, sk);
+  const numberLine = (aggregate: string) =>
+    numberColumnNames.length === 0
+      ? ""
+      : `  "${aggregate}"?: ${numberObject}${sk};\n`;
+
+  const aggregateLines = `${numberLine("_avg")}  "_count"?: ${allObject}${sk};
+  "_max"?: ${allObject}${sk};
+  "_min"?: ${allObject}${sk};
+${numberLine("_sum")}`;
+
+  return `\nexport type Gassma${schemaName}${sheetName}OrderByWithAggregation = {\n${scalarLines}${aggregateLines}};\n`;
+};
+
+export { getOneGassmaOrderByWithAggregation };


### PR DESCRIPTION
本体 **#226**（`groupBy` のパイプライン修正）と **#227**（専用エラークラス）への型追随です。

## 背景

本体 #226 で `groupBy` の `orderBy` / `take` / `skip` が**グループに適用**されるようになり、**集計値でのソートが可能になりました**。

```js
groupBy({ by: ["bookId"], _count: { id: true }, orderBy: { _count: { id: "desc" } }, take: 5 })
```

**ところが型で書けません。** `GroupByData` が `findMany` と同じ `OrderBy` を共有していて、

- `_avg` / `_sum` / `_min` / `_max` キーが**存在しない**
- `_count` は**リレーション件数用**で意味が違う（`{ "member"?: "asc" }` という形）

「件数の多い順に上位N件」という**最も素直なユースケース**が書けない状態でした。

## 追加する型

```ts
export type GassmaUserOrderByWithAggregation = {
  "id"?: "asc" | "desc" | Gassma.SortOrderInput;
  …全スカラー列…
  "_avg"?: { "id"?: "asc"|"desc"; "age"?: "asc"|"desc"; "score"?: …; "rating"?: … };  ← 数値列のみ
  "_count"?: { …全列… };
  "_max"?: { …全列… };
  "_min"?: { …全列… };
  "_sum"?: { …数値列のみ… };
};
```

`GroupByData` を `Omit<…AggregateData, "cursor" | "orderBy">` に変え、`orderBy` をこの型で再宣言しています。

**`_avg` / `_sum` は数値列限定**です（Prisma と同じ）。既存の `isNumberColumn` を流用しているので `@gassma.addType number` の複合型列も数値扱いになります。**数値列が1本も無いシートではキーごと出しません。**

集計の内側は `"asc" | "desc"` のみにしました（Prisma の `XxxAvgOrderByAggregateInput` が `nulls` を取らないため）。**本体の実行時は `{ sort, nulls }` も受け付けるので、型のほうが狭い**差異が1つあります。

## `by` の縛りは型で表現していません

**`by` に含まれる列だけを許す**という制約を素直なジェネリクスで書こうとしても**効きません**。

```ts
groupBy<T>(data: T & Subset<T, GroupByData> & { orderBy?: OrderByWithAggregation<ByKeys<T["by"]>> })
```

**交差型の余剰プロパティ検査は全メンバーの既知プロパティの和を見る**ため、`GroupByData` 側の緩い `orderBy` に `age` が存在する時点で `by: ["name"], orderBy: { age: "asc" }` が通ります（スパイクで実測）。

**Prisma と同じ条件型エラー方式なら動くことは確認済み**です。

```ts
Exclude<OrderByKeys<T["orderBy"]>, ByKeys<T["by"]> | 集計キー> extends never
  ? unknown : { orderBy: "Error: …" }
```

ただし**コントローラのシグネチャ変更＝仕様追加**なので実装していません。**採用するか判断をお願いします**（スパイクは残してあります）。

現状は「**全スカラー列を型で許し、`by` 外は実行時に `GassmaUnknownArgumentError`**」です。リレーションは型でも拒否します。

## エラークラスのミラー（#227 追随）

```ts
class GassmaGroupByOrderByRequiredError extends Error {
  constructor(...paginationArguments: string[]);
}
```

**可変長引数はこのミラーで初のケース**でしたが、生成テンプレートは `params` を `constructor(…)` にそのまま埋めるだけなので**加工不要**でした（実物で確認）。

**本体52クラスとミラー52クラスが完全一致**します（私の側でも名前を全件ソートして diff、差分ゼロ）。並び順も本体の `index.d.ts` と一致（`GroupByHavingDontWriteBy` → `GroupByOrderByRequired` → `AggregateMax`）。

`verify:bundle` が「48件」と出るのは母数の違いです。あちらは `extends Error` を含む行だけを数えるので、**`extends GassmaAggregateMaxError` のような派生4件が別枠**になり 52 − 4 = 48 になります。

## 検証結果

- `npm test`: **1,475件 全 green**（1,458 → +17）
- **`test:types:all` 全10セル green**（5.2/5.6/5.9/6.0/7.0 × strict on/off）
- `tsc --noEmit` / lint / format pass
- **`findMany` の `OrderBy` と `aggregate` の `AggregateData` は1文字も変わっていません**（回帰ガードの型テスト付き）

利用者プロジェクトの schema を複製した環境で、`groupBy({ by:["memberId"], _count:{id:true}, orderBy:{_count:{id:"desc"}}, take:5 })` が書けること、`_avg: { lentAt }`（非数値列）・リレーション・`_all` が落ちることを確認しています。

### 変更した既存テスト3件

| テスト | 変更 |
|---|---|
| `gassmaGroupByData.test.ts` | `Omit<…, "cursor">` → `Omit<…, "cursor" \| "orderBy">`。**orderBy を差し替えるため必然**。テスト名も実態に合わせ変更 |
| `strictSkip/topLevelData.test.ts` | orderBy の `\| Gassma.SkipValue` 検証を**追加**（既存の期待値は不変） |
| `generator.test.ts` | 新型名2件の検証を**追加**（既存行は不変） |

## 判断が必要で実装しなかった点

1. **`by` 制約の条件型エラー方式**（上記）
2. **集計の内側に `Gassma.SortOrderInput` を許すか** — 本体は受け付けるが Prisma に合わせて狭くした
3. **`orderBy: { _count: {} }`（空）** — 本体は throw するが型では通る。**Prisma も型では通る**ので合わせた
4. **リファレンスの更新は未着手**（別リポジトリ）

## マージ順

**本体 #227 を先にマージしてください。** ミラーがそれを前提にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)