### PR TITLE
feat: fall back to .clasp.json parentId when resolving the studio url

### DIFF
--- a/packages/cli/src/__test__/studio/readClaspParentId.test.ts
+++ b/packages/cli/src/__test__/studio/readClaspParentId.test.ts
@@ -1,0 +1,121 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InvalidClaspJsonError } from "../../error/mainError";
+import { readClaspParentId } from "../../studio/readClaspParentId";
+
+describe("readClaspParentId", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-clasp-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeClaspJson = (content: string) => {
+    fs.writeFileSync(path.join(tmpDir, ".clasp.json"), content);
+  };
+
+  it("should return undefined when .clasp.json does not exist", () => {
+    expect(readClaspParentId(tmpDir)).toBeUndefined();
+  });
+
+  it("should return a string parentId as is", () => {
+    writeClaspJson(
+      JSON.stringify({
+        parentId: "1PGLJxHSvYVNXM2UzcOWb8-yvI_XNoEDvfDY0XOKVWVI",
+      }),
+    );
+
+    expect(readClaspParentId(tmpDir)).toBe(
+      "1PGLJxHSvYVNXM2UzcOWb8-yvI_XNoEDvfDY0XOKVWVI",
+    );
+  });
+
+  it("should return the first element of an array parentId", () => {
+    writeClaspJson(
+      JSON.stringify({
+        parentId: ["14yKHbIKdclxxYKkpvB9V04Ovpe8V7I_nHBnfbPmOqyU"],
+      }),
+    );
+
+    expect(readClaspParentId(tmpDir)).toBe(
+      "14yKHbIKdclxxYKkpvB9V04Ovpe8V7I_nHBnfbPmOqyU",
+    );
+  });
+
+  it("should ignore elements after the first one in an array parentId", () => {
+    writeClaspJson(JSON.stringify({ parentId: ["firstId", "secondId"] }));
+
+    expect(readClaspParentId(tmpDir)).toBe("firstId");
+  });
+
+  it("should return undefined for an empty array parentId", () => {
+    writeClaspJson(JSON.stringify({ parentId: [] }));
+
+    expect(readClaspParentId(tmpDir)).toBeUndefined();
+  });
+
+  it("should return undefined when the first array element is not a string", () => {
+    writeClaspJson(JSON.stringify({ parentId: [123] }));
+
+    expect(readClaspParentId(tmpDir)).toBeUndefined();
+  });
+
+  it("should return undefined when the first array element is an empty string", () => {
+    writeClaspJson(JSON.stringify({ parentId: [""] }));
+
+    expect(readClaspParentId(tmpDir)).toBeUndefined();
+  });
+
+  it("should return undefined for an empty string parentId", () => {
+    writeClaspJson(JSON.stringify({ parentId: "" }));
+
+    expect(readClaspParentId(tmpDir)).toBeUndefined();
+  });
+
+  it("should return undefined when parentId is missing", () => {
+    writeClaspJson(JSON.stringify({ scriptId: "abc", rootDir: "./dist" }));
+
+    expect(readClaspParentId(tmpDir)).toBeUndefined();
+  });
+
+  it("should return undefined when parentId is neither a string nor an array", () => {
+    writeClaspJson(JSON.stringify({ parentId: { id: "abc" } }));
+
+    expect(readClaspParentId(tmpDir)).toBeUndefined();
+  });
+
+  it("should return undefined when parentId is null", () => {
+    writeClaspJson(JSON.stringify({ parentId: null }));
+
+    expect(readClaspParentId(tmpDir)).toBeUndefined();
+  });
+
+  it("should throw InvalidClaspJsonError when .clasp.json is not valid JSON", () => {
+    writeClaspJson("{ not json");
+
+    expect(() => readClaspParentId(tmpDir)).toThrow(InvalidClaspJsonError);
+    expect(() => readClaspParentId(tmpDir)).toThrow(
+      /GASsmaInvalidClaspJsonError/,
+    );
+  });
+
+  it("should throw InvalidClaspJsonError when .clasp.json is not a JSON object", () => {
+    writeClaspJson(JSON.stringify(["not", "an", "object"]));
+
+    expect(() => readClaspParentId(tmpDir)).toThrow(InvalidClaspJsonError);
+  });
+
+  it("should not look at .clasp.json in a parent directory", () => {
+    const child = path.join(tmpDir, "child");
+    fs.mkdirSync(child);
+    writeClaspJson(JSON.stringify({ parentId: "parentDirId" }));
+
+    expect(readClaspParentId(child)).toBeUndefined();
+  });
+});

--- a/packages/cli/src/__test__/studio/resolveStudioUrl.test.ts
+++ b/packages/cli/src/__test__/studio/resolveStudioUrl.test.ts
@@ -2,7 +2,10 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { NoDatasourceUrlError } from "../../error/mainError";
+import {
+  InvalidClaspJsonError,
+  NoDatasourceUrlError,
+} from "../../error/mainError";
 import { resolveStudioUrl } from "../../studio/resolveStudioUrl";
 
 const SCHEMA_WITHOUT_URL = `generator client {
@@ -41,6 +44,10 @@ describe("resolveStudioUrl", () => {
 
   const writeSchema = (content: string) => {
     fs.writeFileSync(path.join(tmpDir, "gassma", "schema.prisma"), content);
+  };
+
+  const writeClaspJson = (content: string) => {
+    fs.writeFileSync(path.join(tmpDir, ".clasp.json"), content);
   };
 
   it("should resolve a full URL from the schema datasource block", () => {
@@ -82,11 +89,66 @@ describe("resolveStudioUrl", () => {
     );
   });
 
+  it("should fall back to a string parentId in .clasp.json", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/claspId123/edit",
+    );
+  });
+
+  it("should fall back to the first element of an array parentId in .clasp.json", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    writeClaspJson(JSON.stringify({ parentId: ["claspId456", "ignored"] }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/claspId456/edit",
+    );
+  });
+
+  it("should prefer the config datasource url over the clasp parentId", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    fs.writeFileSync(
+      path.join(tmpDir, "gassma.config.ts"),
+      `export default { datasource: { url: "configId456" } };`,
+    );
+    writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/configId456/edit",
+    );
+  });
+
+  it("should prefer the schema datasource url over the clasp parentId", () => {
+    writeSchema(schemaWithUrl("schemaId123"));
+    writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/schemaId123/edit",
+    );
+  });
+
+  it("should throw NoDatasourceUrlError when .clasp.json has no usable parentId", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    writeClaspJson(JSON.stringify({ scriptId: "abc", parentId: [] }));
+
+    expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
+  });
+
+  it("should throw InvalidClaspJsonError when .clasp.json is broken", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    writeClaspJson("{ broken");
+
+    expect(() => resolveStudioUrl()).toThrow(InvalidClaspJsonError);
+  });
+
   it("should throw NoDatasourceUrlError when no url is configured", () => {
     writeSchema(SCHEMA_WITHOUT_URL);
 
     expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
     expect(() => resolveStudioUrl()).toThrow(/GASsmaNoDatasourceUrlError/);
+    expect(() => resolveStudioUrl()).toThrow(/\.clasp\.json/);
   });
 
   it("should resolve from a config given by the config option", () => {

--- a/packages/cli/src/error/mainError.ts
+++ b/packages/cli/src/error/mainError.ts
@@ -18,8 +18,18 @@ class NoDatasourceUrlError extends Error {
   constructor() {
     super(
       "GASsmaNoDatasourceUrlError: datasource url is not set.\n" +
+        'Looked at the datasource block in your schema, datasource.url in gassma.config.ts, and "parentId" in .clasp.json, but none of them had one.\n' +
         "Please set datasource.url in gassma.config.ts or add a url to the datasource block in your schema.\n" +
         'Example:\n  datasource db {\n    provider = "gassma"\n    url      = "https://docs.google.com/spreadsheets/d/XXXX/edit"\n  }',
+    );
+  }
+}
+
+class InvalidClaspJsonError extends Error {
+  constructor(claspJsonPath: string) {
+    super(
+      `GASsmaInvalidClaspJsonError: .clasp.json at ${claspJsonPath} is not a valid JSON object.\n` +
+        "Please fix its contents, or remove the file if you are not using clasp.",
     );
   }
 }
@@ -84,6 +94,7 @@ export {
   ArgumentError,
   NoModelsError,
   NoDatasourceUrlError,
+  InvalidClaspJsonError,
   ConfigFileNotFoundError,
   GassmaConfigEnvError,
   GassmaConfigLoadError,

--- a/packages/cli/src/studio/readClaspParentId.ts
+++ b/packages/cli/src/studio/readClaspParentId.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+import { isRecord } from "../bootstrap/util/isRecord";
+import { InvalidClaspJsonError } from "../error/mainError";
+
+const toParentId = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value === "" ? undefined : value;
+  if (!Array.isArray(value)) return undefined;
+
+  const first: unknown = value[0];
+  if (typeof first !== "string" || first === "") return undefined;
+  return first;
+};
+
+const parseClaspJson = (claspJsonPath: string): Record<string, unknown> => {
+  const text = fs.readFileSync(claspJsonPath, "utf-8");
+
+  const parsed: unknown = (() => {
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new InvalidClaspJsonError(claspJsonPath);
+    }
+  })();
+
+  if (!isRecord(parsed)) throw new InvalidClaspJsonError(claspJsonPath);
+  return parsed;
+};
+
+const readClaspParentId = (cwd: string): string | undefined => {
+  const claspJsonPath = path.join(cwd, ".clasp.json");
+  if (!fs.existsSync(claspJsonPath)) return undefined;
+
+  return toParentId(parseClaspJson(claspJsonPath).parentId);
+};
+
+export { readClaspParentId };

--- a/packages/cli/src/studio/resolveStudioUrl.ts
+++ b/packages/cli/src/studio/resolveStudioUrl.ts
@@ -4,6 +4,7 @@ import { NoDatasourceUrlError } from "../error/mainError";
 import { mergeSchemaFiles } from "../generate/mergeSchemaFiles";
 import { extractDatasourceUrl } from "../generate/read/extractDatasourceUrl";
 import { buildSpreadsheetUrl } from "./buildSpreadsheetUrl";
+import { readClaspParentId } from "./readClaspParentId";
 
 type StudioUrlOptions = {
   config?: string;
@@ -14,7 +15,9 @@ const resolveStudioUrl = (options?: StudioUrlOptions): string => {
   const schemaText = mergeSchemaFiles(files.map((f) => f.filePath));
   const loaded = loadConfig(options?.config);
   const urlOrId =
-    extractDatasourceUrl(schemaText) ?? loaded?.config.datasource?.url;
+    extractDatasourceUrl(schemaText) ??
+    loaded?.config.datasource?.url ??
+    readClaspParentId(process.cwd());
 
   if (urlOrId === undefined || urlOrId === null) {
     throw new NoDatasourceUrlError();


### PR DESCRIPTION
## 変更

`npx gassma studio` が開くスプレッドシート URL の解決に、**`.clasp.json` の `parentId` へのフォールバック**を追加した。

**解決順:**

1. スキーマの `datasource` ブロックの url（変更なし）
2. `gassma.config.ts` の `datasource.url`（変更なし）
3. **`.clasp.json` の `parentId`**（新規）
4. どれも無ければ `NoDatasourceUrlError`

`parentId` はコンテナ（スプレッドシート）の Drive ファイル ID なので、そのまま URL を組み立てられる。

**`generate` は変更していない。** スキーマとの連携が目的なので `.clasp.json` は見ない。

### `parentId` の形

**実在するプロジェクトで2つの形が確認できたため、両方に対応した。**

```json
"parentId": ["14yKHbIKdclxxYKkpvB9V04Ovpe8V7I_nHBnfbPmOqyU"]
```
```json
"parentId": "1PGLJxHSvYVNXM2UzcOWb8-yvI_XNoEDvfDY0XOKVWVI"
```

- 文字列 → そのまま使う
- 配列 → 先頭の要素を使う
- 空配列・空文字列・非文字列 → 「記載なし」として次段へ
- 探索は**カレントディレクトリのみ**（親を遡らない。clasp 自身の挙動に合わせた）

### 壊れた `.clasp.json` は黙殺しない

**ファイルが存在しない**場合は「記載なし」として扱うが、**存在するのに JSON として読めない**場合は `InvalidClaspJsonError` で落とす。黙って無視すると「なぜか設定が効かない」になるため。

「パースできるがオブジェクトでない」（`["a","b"]` / `"str"` / `42` 等）も同じ扱いにした。既存の `src/debug/sections/claspSection.ts` が `if (!isRecord(parsed)) return { exists: true, parseError: true }` と同じ判定をしている前例に合わせている。

```
GASsmaInvalidClaspJsonError: .clasp.json at <path> is not a valid JSON object.
Please fix its contents, or remove the file if you are not using clasp.
```

`NoDatasourceUrlError` は2行目を挿入しただけで他は不変。

```diff
 GASsmaNoDatasourceUrlError: datasource url is not set.
+Looked at the datasource block in your schema, datasource.url in gassma.config.ts, and "parentId" in .clasp.json, but none of them had one.
 Please set datasource.url in gassma.config.ts or add a url to the datasource block in your schema.
```

## 実装

`.clasp.json` の読み取りと `parentId` の正規化は `src/studio/readClaspParentId.ts`（37行）に分離した。`resolveStudioUrl.ts` の変更は配線の3行のみでロジックを持ち込んでいない。

`as` は不使用（`unknown` から `isRecord` + `typeof` / `Array.isArray` で絞る）。

## 検証

- `npm test` **1501件 pass**（196ファイル、新規20件）／`typecheck`・`lint`・`format:check`・`build` OK
- **実在の `.clasp.json` 2件で確認済み** — 配列形式・文字列形式とも正しい ID を返し、`parentId` を持たない `.clasp.json` と存在しないディレクトリは `undefined`
- **変異テストを10通り実施し、すべて kill されることを確認した**（フォールバック削除／配列分岐削除／先頭→末尾／空チェック削除2種／壊れた JSON の黙殺2種／親ディレクトリ探索／エラー文面の巻き戻し／`existsSync` ガード削除）

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ