### PR TITLE
feat: type the autoincrement counter API per model

### DIFF
--- a/packages/cli/scripts/genFixtureTypes.ts
+++ b/packages/cli/scripts/genFixtureTypes.ts
@@ -39,7 +39,7 @@ const generateFixture = (text: string, fileName: string) => {
     true,
     defaults,
     Object.keys(updatedAt),
-    Object.keys(autoincrement),
+    autoincrement,
     optionalFields,
     strict,
     optionalRelations,

--- a/packages/cli/src/__test__/generate/schemaCollision.test.ts
+++ b/packages/cli/src/__test__/generate/schemaCollision.test.ts
@@ -54,7 +54,7 @@ const generateFromPrisma = (
     true,
     {},
     [],
-    [],
+    {},
     optionalFields,
   );
 };

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerAutoincrement.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerAutoincrement.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { generater } from "../../../generate/generator";
+import { getGassmaController } from "../../../generate/typeGenerate/gassmaController";
+import { getOneGassmaController } from "../../../generate/typeGenerate/gassmaController/oneGassmaController";
+
+describe("getOneGassmaController autoincrement counter", () => {
+  it("should narrow field to the only autoincrement field of the model", () => {
+    const result = getOneGassmaController("", "User", ["id", "name"], ["id"]);
+
+    expect(result).toContain('$getAutoincrement(field: "id"): number;');
+    expect(result).toContain(
+      '$setAutoincrement(field: "id", next: number): void;',
+    );
+    expect(result).toContain('$syncAutoincrement(field: "id"): number;');
+  });
+
+  it("should union every autoincrement field of the model", () => {
+    const result = getOneGassmaController(
+      "",
+      "User",
+      ["id", "seq", "name"],
+      ["id", "seq"],
+    );
+
+    expect(result).toContain('$getAutoincrement(field: "id" | "seq"): number;');
+    expect(result).toContain(
+      '$setAutoincrement(field: "id" | "seq", next: number): void;',
+    );
+    expect(result).toContain(
+      '$syncAutoincrement(field: "id" | "seq"): number;',
+    );
+  });
+
+  it("should type field as never when the model has no autoincrement field", () => {
+    const result = getOneGassmaController(
+      "",
+      "Enrollment",
+      ["studentId", "courseId"],
+      [],
+    );
+
+    expect(result).toContain("$getAutoincrement(field: never): number;");
+    expect(result).toContain(
+      "$setAutoincrement(field: never, next: number): void;",
+    );
+    expect(result).toContain("$syncAutoincrement(field: never): number;");
+  });
+
+  it("should type field as never when no autoincrement fields are given", () => {
+    const result = getOneGassmaController("", "User", ["id"]);
+
+    expect(result).toContain("$getAutoincrement(field: never): number;");
+  });
+
+  it("should not leak another model's autoincrement field", () => {
+    const result = getOneGassmaController("", "User", ["id", "name"], ["id"]);
+
+    expect(result).not.toContain('$getAutoincrement(field: "name")');
+  });
+});
+
+describe("getGassmaController autoincrement counter", () => {
+  const dictYaml = {
+    User: { id: ["number"], name: ["string"] },
+    Enrollment: { studentId: ["number"], courseId: ["number"] },
+  };
+
+  it("should give each model only its own autoincrement fields", () => {
+    const result = getGassmaController(dictYaml, "", { User: ["id"] });
+
+    expect(result).toContain('$getAutoincrement(field: "id"): number;');
+    expect(result).toContain("$getAutoincrement(field: never): number;");
+  });
+
+  it("should type every model as never when nothing is autoincrement", () => {
+    const result = getGassmaController(dictYaml, "");
+
+    expect(result).not.toContain('$getAutoincrement(field: "');
+  });
+});
+
+describe("generater autoincrement counter", () => {
+  const dictYaml = {
+    User: { id: ["number"], name: ["string"] },
+    Enrollment: { studentId: ["number"], courseId: ["number"] },
+  };
+
+  it("should pass the extracted autoincrement config down to the controllers", () => {
+    const result = generater(dictYaml, undefined, "", true, undefined, [], {
+      User: ["id"],
+    });
+
+    expect(result).toContain('$getAutoincrement(field: "id"): number;');
+    expect(result).toContain("$getAutoincrement(field: never): number;");
+  });
+
+  it("should still build the autoincrement client option from the same config", () => {
+    const result = generater(dictYaml, undefined, "", true, undefined, [], {
+      User: ["id"],
+    });
+
+    expect(result).toContain(
+      `export type GassmaAutoincrementConfig = {\n  "User"?: "id" | "name" | ("id" | "name")[];\n};\n`,
+    );
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/autoincrementDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/autoincrementDocs.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { getOneGassmaController } from "../../../../generate/typeGenerate/gassmaController/oneGassmaController";
+import { getModelNaming } from "../../../../generate/typeGenerate/tsdoc/modelNaming";
+import { getAutoincrementDocLines } from "../../../../generate/typeGenerate/tsdoc/operations/autoincrementDocs";
+
+const BASE = "https://gassma.io/en/docs";
+const LINK = `Read more here: ${BASE}/reference/config/autoincrement`;
+const naming = getModelNaming("", "Post", ["id", "title"]);
+const lines = getAutoincrementDocLines(naming, ["id"]);
+
+describe("getAutoincrementDocLines", () => {
+  it("should document $getAutoincrement", () => {
+    expect(lines.getAutoincrement).toEqual([
+      "Get the value the next `create` will issue for an autoincrement field of Post.",
+      "Reading the counter is allowed inside `$transaction`.",
+      "Throws `GassmaAutoincrementNotConfiguredError` when the field is not an autoincrement field.",
+      LINK,
+      "@param {string} field - An autoincrement field of Post.",
+      "@example",
+      "// The id the next Post will get",
+      'const next = gassma.Post.$getAutoincrement("id")',
+    ]);
+  });
+
+  it("should document $setAutoincrement", () => {
+    expect(lines.setAutoincrement).toEqual([
+      "Set the value the next `create` will issue for an autoincrement field of Post.",
+      "`next` is the value that will be issued next, so it must be an integer of 1 or more.",
+      "Throws `GassmaAutoincrementInTransactionError` inside `$transaction`, because the counter is never rolled back.",
+      LINK,
+      "@param {string} field - An autoincrement field of Post.",
+      "@param {number} next - The value the next `create` will issue.",
+      "@example",
+      "// Let the next Post continue from 1000",
+      'gassma.Post.$setAutoincrement("id", 1000)',
+    ]);
+  });
+
+  it("should document $syncAutoincrement", () => {
+    expect(lines.syncAutoincrement).toEqual([
+      "Line the counter of Post up with the rows already in the sheet.",
+      "The counter becomes the largest value in the column plus one, which is also the return value.",
+      "Throws `GassmaAutoincrementInTransactionError` inside `$transaction`, because the counter is never rolled back.",
+      LINK,
+      "@param {string} field - An autoincrement field of Post.",
+      "@example",
+      "// Adopt a sheet that already has rows",
+      'const next = gassma.Post.$syncAutoincrement("id")',
+    ]);
+  });
+
+  it("should use the first autoincrement field in the examples, not the first column", () => {
+    const multi = getAutoincrementDocLines(
+      getModelNaming("", "Post", ["title", "seq"]),
+      ["seq"],
+    );
+
+    expect(multi.getAutoincrement).toContain(
+      'const next = gassma.Post.$getAutoincrement("seq")',
+    );
+  });
+
+  it("should replace the example with a note when the model has no autoincrement field", () => {
+    const none = getAutoincrementDocLines(naming, []);
+    const note = "Post has no autoincrement field, so this cannot be called.";
+
+    expect(none.getAutoincrement).toEqual([
+      "Get the value the next `create` will issue for an autoincrement field of Post.",
+      note,
+      LINK,
+    ]);
+    expect(none.setAutoincrement).toEqual([
+      "Set the value the next `create` will issue for an autoincrement field of Post.",
+      note,
+      LINK,
+    ]);
+    expect(none.syncAutoincrement).toEqual([
+      "Line the counter of Post up with the rows already in the sheet.",
+      note,
+      LINK,
+    ]);
+  });
+});
+
+describe("generated autoincrement counter tsdoc", () => {
+  const result = getOneGassmaController("", "Post", ["id", "title"], ["id"]);
+
+  it.each([
+    "$getAutoincrement(field:",
+    "$setAutoincrement(field:",
+    "$syncAutoincrement(field:",
+  ])("should place a doc block right before %s", (member) => {
+    expect(result).toContain(`   */\n  ${member}`);
+  });
+
+  it("should document the counter methods with the reference link", () => {
+    expect(result).toContain(`   * ${LINK}\n`);
+  });
+});

--- a/packages/cli/src/__test__/generate/typeGenerate/tsdoc/generatedDocs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/tsdoc/generatedDocs.test.ts
@@ -6,7 +6,8 @@ const dictYaml = {
   Post: { id: ["number"], title: ["string"] },
   Users: { id: ["number"], name: ["string"] },
 };
-const generated = `${generater(dictYaml, undefined, "", true)}\n${generateClientDts("", undefined, Object.keys(dictYaml))}`;
+// Post だけ autoincrement を持たせ、持つ側と持たない側の両方の doc を検査対象に入れる
+const generated = `${generater(dictYaml, undefined, "", true, undefined, undefined, { Post: ["id"] })}\n${generateClientDts("", undefined, Object.keys(dictYaml))}`;
 
 const ARGUMENT_LESS_OPERATIONS = [
   "count",
@@ -98,6 +99,16 @@ describe("generated tsdoc", () => {
   it("should warn that deleteMany without arguments deletes everything", () => {
     expect(generated).toContain(
       "   * Calling `deleteMany` without arguments deletes **all** rows in the sheet. This cannot be undone.",
+    );
+  });
+
+  it("should link the autoincrement counter methods to their reference page", () => {
+    expect(generated).toContain("/reference/config/autoincrement");
+  });
+
+  it("should tell a model without autoincrement that the counter cannot be called", () => {
+    expect(generated).toContain(
+      "   * Users has no autoincrement field, so this cannot be called.",
     );
   });
 

--- a/packages/cli/src/__test__/types/config/autoincrementCounter.test-d.ts
+++ b/packages/cli/src/__test__/types/config/autoincrementCounter.test-d.ts
@@ -1,0 +1,75 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+import { GassmaClient as StrictGassmaClient } from "../__generated__/clientStrict";
+
+declare const client: GassmaClient;
+declare const strictClient: StrictGassmaClient;
+declare const anyField: string;
+
+// autoincrement フィールドを渡せる。戻り値は「次に発行される値」
+{
+  expectTypeOf(client.User.$getAutoincrement("id")).toEqualTypeOf<number>();
+  expectTypeOf(client.User.$setAutoincrement("id", 1000)).toEqualTypeOf<void>();
+  expectTypeOf(client.User.$syncAutoincrement("id")).toEqualTypeOf<number>();
+}
+
+// @@map されたモデルでもコード名でアクセスして呼べる
+{
+  expectTypeOf(client.Member.$getAutoincrement("id")).toEqualTypeOf<number>();
+}
+
+// autoincrement ではないフィールド名は弾かれる
+{
+  // @ts-expect-error email は autoincrement ではない
+  client.User.$getAutoincrement("email");
+  // @ts-expect-error name は autoincrement ではない
+  client.User.$setAutoincrement("name", 1000);
+  // @ts-expect-error createdAt は autoincrement ではない
+  client.User.$syncAutoincrement("createdAt");
+}
+
+// typo は黙って通らない
+{
+  // @ts-expect-error "i" というフィールドは存在しない
+  client.User.$getAutoincrement("i");
+  // @ts-expect-error "Id" は大文字違い
+  client.User.$syncAutoincrement("Id");
+}
+
+// 任意の文字列は受け付けない
+{
+  // @ts-expect-error string ではリテラルに絞り込めない
+  client.User.$getAutoincrement(anyField);
+}
+
+// next は number のみ
+{
+  // @ts-expect-error next に文字列は渡せない
+  client.User.$setAutoincrement("id", "1000");
+  // @ts-expect-error next は省略できない
+  client.User.$setAutoincrement("id");
+}
+
+// autoincrement を1つも持たないモデルでは呼べない
+{
+  // @ts-expect-error Enrollment に autoincrement フィールドは無い
+  client.Enrollment.$getAutoincrement("studentId");
+  // @ts-expect-error Enrollment に autoincrement フィールドは無い
+  client.Enrollment.$setAutoincrement("studentId", 1);
+  // @ts-expect-error Enrollment に autoincrement フィールドは無い
+  client.Enrollment.$syncAutoincrement("courseId");
+}
+
+// トランザクション内でも読み取りは型として使える
+{
+  client.$transaction((tx) => tx.User.$getAutoincrement("id"));
+}
+
+// strict fixture でも同じ
+{
+  expectTypeOf(
+    strictClient.Post.$getAutoincrement("id"),
+  ).toEqualTypeOf<number>();
+  // @ts-expect-error title は autoincrement ではない
+  strictClient.Post.$syncAutoincrement("title");
+}

--- a/packages/cli/src/generate/generate.ts
+++ b/packages/cli/src/generate/generate.ts
@@ -119,7 +119,7 @@ function generateFromSchema(
     true,
     defaults,
     Object.keys(updatedAt),
-    Object.keys(autoincrement),
+    autoincrement,
     optionalFields,
     strict,
     optionalRelations,

--- a/packages/cli/src/generate/generator.ts
+++ b/packages/cli/src/generate/generator.ts
@@ -1,3 +1,4 @@
+import type { AutoincrementConfig } from "./read/extractAutoincrement";
 import type { DefaultsConfig } from "./read/extractDefaults";
 import type { OptionalRelationsConfig } from "./read/extractOptionalRelations";
 import type { RelationsConfig } from "./read/extractRelations";
@@ -51,13 +52,14 @@ const generater = (
   includeCommon?: boolean,
   defaults?: DefaultsConfig,
   updatedAtModels?: string[],
-  autoincrementModels?: string[],
+  autoincrement?: AutoincrementConfig,
   optionalFields?: Record<string, string[]>,
   strict?: boolean,
   optionalRelations?: OptionalRelationsConfig,
 ) => {
   const schema = schemaName ?? "";
   const sheetNames = Object.keys(dictYaml);
+  const autoincrementConfig = autoincrement ?? {};
   let result = getGassmaMain(
     sheetNames,
     schema,
@@ -66,13 +68,13 @@ const generater = (
       dictYaml,
       defaults: defaults ?? {},
       updatedAtModels: updatedAtModels ?? [],
-      autoincrementModels: autoincrementModels ?? [],
+      autoincrementModels: Object.keys(autoincrementConfig),
     },
     strict,
   );
 
   result += getGassmaSheet(sheetNames, schema);
-  result += getGassmaController(dictYaml, schema);
+  result += getGassmaController(dictYaml, schema, autoincrementConfig);
   if (includeCommon !== false) {
     result += getGassmaManyCount();
   }

--- a/packages/cli/src/generate/typeGenerate/gassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController.ts
@@ -1,8 +1,10 @@
+import type { AutoincrementConfig } from "../read/extractAutoincrement";
 import { getOneGassmaController } from "./gassmaController/oneGassmaController";
 
 const getGassmaController = (
   dictYaml: Record<string, Record<string, unknown[]>>,
   schemaName: string,
+  autoincrement: AutoincrementConfig = {},
 ) => {
   const controllerTypeDeclare = Object.keys(dictYaml).reduce(
     (pre, currentSheetName) =>
@@ -11,6 +13,7 @@ const getGassmaController = (
         schemaName,
         currentSheetName,
         Object.keys(dictYaml[currentSheetName]),
+        autoincrement[currentSheetName] ?? [],
       ),
     "",
   );

--- a/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -5,8 +5,18 @@ const getOneGassmaController = (
   schemaName: string,
   sheetName: string,
   columnNames: string[],
+  autoincrementFields: string[] = [],
 ) => {
-  const docs = getControllerDocs(schemaName, sheetName, columnNames);
+  const docs = getControllerDocs(
+    schemaName,
+    sheetName,
+    columnNames,
+    autoincrementFields,
+  );
+  const counterField =
+    autoincrementFields.length === 0
+      ? "never"
+      : autoincrementFields.map((name) => `"${name}"`).join(" | ");
   const clean = getRemovedCantUseVarChar(sheetName);
   const self = `Gassma${schemaName}${clean}`;
   const fr = `${self}FindResult`;
@@ -49,6 +59,9 @@ ${docs.aggregate}  aggregate<T extends ${self}AggregateData>(aggregateData: T & 
 ${docs.count}  count<T extends ${self}CountData>(countData: T & Gassma.Subset<T, ${self}CountData>): ${self}CountResult<T>;
 ${docs.countNoArgs}  count(): number;
 ${docs.groupBy}  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData>): ${self}GroupByResult<T>[];
+${docs.getAutoincrement}  $getAutoincrement(field: ${counterField}): number;
+${docs.setAutoincrement}  $setAutoincrement(field: ${counterField}, next: number): void;
+${docs.syncAutoincrement}  $syncAutoincrement(field: ${counterField}): number;
 }
 `;
 };

--- a/packages/cli/src/generate/typeGenerate/tsdoc/docContext.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/docContext.ts
@@ -1,5 +1,6 @@
 import { renderDocBlock } from "./docBlock";
 import { getModelNaming } from "./modelNaming";
+import { getAutoincrementDocLines } from "./operations/autoincrementDocs";
 import { getCreateDocLines } from "./operations/createDocs";
 import { getDeleteDocLines } from "./operations/deleteDocs";
 import {
@@ -19,6 +20,7 @@ const getControllerDocs = (
   schemaName: string,
   sheetName: string,
   columnNames: string[],
+  autoincrementFields: string[] = [],
 ) => {
   const naming = getModelNaming(schemaName, sheetName, columnNames);
   const member = (lines: string[]) => renderDocBlock(MEMBER_INDENT, lines);
@@ -27,6 +29,7 @@ const getControllerDocs = (
   const update = getUpdateDocLines(naming);
   const remove = getDeleteDocLines(naming);
   const statistics = getStatisticsDocLines(naming);
+  const autoincrement = getAutoincrementDocLines(naming, autoincrementFields);
 
   return {
     controllerClass: renderDocBlock("", controllerClassDocLines(naming)),
@@ -52,6 +55,9 @@ const getControllerDocs = (
     count: member(statistics.count),
     countNoArgs: member(statistics.countNoArgs),
     groupBy: member(statistics.groupBy),
+    getAutoincrement: member(autoincrement.getAutoincrement),
+    setAutoincrement: member(autoincrement.setAutoincrement),
+    syncAutoincrement: member(autoincrement.syncAutoincrement),
   };
 };
 

--- a/packages/cli/src/generate/typeGenerate/tsdoc/operations/autoincrementDocs.ts
+++ b/packages/cli/src/generate/typeGenerate/tsdoc/operations/autoincrementDocs.ts
@@ -1,0 +1,71 @@
+import { REFERENCE_BASE_URL } from "../docBlock";
+import type { ModelNaming } from "../modelNaming";
+
+const AUTOINCREMENT_LINK = `Read more here: ${REFERENCE_BASE_URL}/reference/config/autoincrement`;
+
+const ROLLBACK_NOTE =
+  "Throws `GassmaAutoincrementInTransactionError` inside `$transaction`, because the counter is never rolled back.";
+
+const getAutoincrementDocLines = (
+  { accessor, model }: ModelNaming,
+  fields: string[],
+) => {
+  const field = fields[0];
+  const paramField = `@param {string} field - An autoincrement field of ${model}.`;
+  const noFieldNote = `${model} has no autoincrement field, so this cannot be called.`;
+  const body = (usable: string[], example: string[]) =>
+    field === undefined
+      ? [noFieldNote, AUTOINCREMENT_LINK]
+      : [...usable, AUTOINCREMENT_LINK, ...example];
+
+  return {
+    getAutoincrement: [
+      `Get the value the next \`create\` will issue for an autoincrement field of ${model}.`,
+      ...body(
+        [
+          "Reading the counter is allowed inside `$transaction`.",
+          "Throws `GassmaAutoincrementNotConfiguredError` when the field is not an autoincrement field.",
+        ],
+        [
+          paramField,
+          "@example",
+          `// The ${field} the next ${model} will get`,
+          `const next = ${accessor}.$getAutoincrement("${field}")`,
+        ],
+      ),
+    ],
+    setAutoincrement: [
+      `Set the value the next \`create\` will issue for an autoincrement field of ${model}.`,
+      ...body(
+        [
+          "`next` is the value that will be issued next, so it must be an integer of 1 or more.",
+          ROLLBACK_NOTE,
+        ],
+        [
+          paramField,
+          "@param {number} next - The value the next `create` will issue.",
+          "@example",
+          `// Let the next ${model} continue from 1000`,
+          `${accessor}.$setAutoincrement("${field}", 1000)`,
+        ],
+      ),
+    ],
+    syncAutoincrement: [
+      `Line the counter of ${model} up with the rows already in the sheet.`,
+      ...body(
+        [
+          "The counter becomes the largest value in the column plus one, which is also the return value.",
+          ROLLBACK_NOTE,
+        ],
+        [
+          paramField,
+          "@example",
+          "// Adopt a sheet that already has rows",
+          `const next = ${accessor}.$syncAutoincrement("${field}")`,
+        ],
+      ),
+    ],
+  };
+};
+
+export { getAutoincrementDocLines };


### PR DESCRIPTION
## 背景

gassma 本体 #229（マージ済み）で、autoincrement のカウンタを操作する実行時 API を追加した。**途中から GASsma を導入すると、既存 id が 1〜500 まで埋まっているのにカウンタが 0 から始まり、最初の `create` が id: 1 を採番して衝突する**問題への対応。

本 PR はその型付け。

## 変更

生成されるモデル型に3つのメソッドを追加した。

```ts
$getAutoincrement(field: "id"): number;
$setAutoincrement(field: "id", next: number): void;
$syncAutoincrement(field: "id"): number;
```

**`field` はそのモデルの autoincrement フィールドだけに絞られる。** ここが肝で、`string` のままだと typo が黙って通る。autoincrement を持たないモデルでは `never` になり呼び出せない（実行時の `GassmaAutoincrementNotConfiguredError` と整合する）。

```ts
// Enrollment（@@id([studentId, courseId]) で autoincrement なし）
$getAutoincrement(field: never): number;
```

### 抽出経路は増やしていない

`extractAutoincrement` の戻り値 `AutoincrementConfig`（`{ [model]: string[] }`）は、これまで `generate.ts` で `Object.keys()` に潰されてモデル名だけが型生成に渡り、**フィールド名は `generateClientJs` にしか流れていなかった**。`generator` の引数を config そのものに変え、クライアントオプション用のモデル名一覧は内部で `Object.keys` するようにした。**抽出は1回・供給元は1つのまま。**

## 検証

- `npm test` **1521件 pass**（198ファイル、新規テスト3ファイル）／`typecheck`・`test:types`・`lint`・`format:check`・`build` OK
- **`test:types:all` は TS 5.2.2・5.6.3・5.9.3・6.0.3・7.0.2 × strict on/off の10通りすべて 0 エラー**
- **型テストの `@ts-expect-error` が本物であることを変異で確認した。** `"email"` → `"id"` に書き換えると `TS2578: Unused '@ts-expect-error' directive.` が出る（独立に再実行して確認済み）

型テストの項目: autoincrement フィールドを渡せて戻り値の型が合う／`@@map` モデルでもコード名で呼べる／他フィールド・typo（`"i"` / `"Id"`）・`string` 型変数は拒否／`next` に文字列不可・省略不可／autoincrement を持たないモデルでは3つとも呼べない／tx 内で `$getAutoincrement` は型上使える／strict fixture でも同じ。

## 積み残し（この PR では対応していない）

**1. 生成型にエラークラスが登録されていない。** `errorClassDefinitions.ts` に `GassmaAutoincrementNotConfiguredError` / `GassmaAutoincrementInTransactionError` が無く、利用者は `Gassma` 名前空間経由で `instanceof` 判定できない。**`GassmaInvalidLockError` も同様に未登録**で、このリストは以前から本体に遅れている。公開シンボルを増やす話なので別途判断する。

**2. クライアントオプション経由の `autoincrement` はユニオンに入らない。** 実行時は `new GassmaClient({ autoincrement: { User: "seq" } })` でスキーマ外のフィールドも autoincrement にできるが、型はスキーマ由来のみ。この経路を使うと**型で弾かれて実行時には通る**食い違いが残る。

**3. tx クライアント用のモデル型は存在しない。** `GassmaXTransactionClient = GassmaXSheet<O> & { $extends }` で通常クライアントとモデル型を完全に共有している（既存の型テストが `expectTypeOf(tx.User).toEqualTypeOf<typeof client.User>()` で固定）。そのため `$set` / `$sync` は tx でも型上は見える（実行時は `GassmaAutoincrementInTransactionError`）。型体系を増やす判断が要るので新設していない。

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ