### PR TITLE
fix: let user supplied id override schema datasource url

### DIFF
--- a/packages/cli/src/__test__/generate/jsGenerate/generateClientJs.test.ts
+++ b/packages/cli/src/__test__/generate/jsGenerate/generateClientJs.test.ts
@@ -675,6 +675,174 @@ describe("generateClientJs", () => {
     expect(result).not.toContain("id:");
   });
 
+  it("should place id in the defaults argument so user options can override it", () => {
+    const result = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "SCHEMA_SHEET_ID",
+    );
+
+    expect(result).toContain(
+      'Object.assign({ lock: LockService.getScriptLock(), id: "SCHEMA_SHEET_ID" }, options, { relations: testRelations })',
+    );
+  });
+
+  it("should keep the defaults argument free of id when datasource url is undefined", () => {
+    const result = generateClientJs({}, "Test");
+
+    expect(result).toContain(
+      "Object.assign({ lock: LockService.getScriptLock() }, options, { relations: testRelations })",
+    );
+  });
+
+  it("should let user supplied id win over the schema datasource url", () => {
+    const code = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "SCHEMA_SHEET_ID",
+    );
+    const seen: { id?: unknown }[] = [];
+    class FakeCoreClient {
+      constructor(options: { id?: unknown }) {
+        seen.push(options);
+      }
+    }
+    const exportsObject: { GassmaClient?: new (options?: unknown) => object } =
+      {};
+    const run = new Function("Gassma", "exports", "LockService", code);
+    run({ GassmaClient: FakeCoreClient }, exportsObject, {
+      getScriptLock: () => ({}),
+    });
+
+    const GeneratedClient = exportsObject.GassmaClient;
+    if (!GeneratedClient) throw new Error("GassmaClient not exported");
+    new GeneratedClient({ id: "USER_ID" });
+
+    expect(seen[0].id).toBe("USER_ID");
+  });
+
+  it("should fall back to the schema datasource url when no id is supplied", () => {
+    const code = generateClientJs(
+      {},
+      "Test",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "SCHEMA_SHEET_ID",
+    );
+    const seen: { id?: unknown }[] = [];
+    class FakeCoreClient {
+      constructor(options: { id?: unknown }) {
+        seen.push(options);
+      }
+    }
+    const exportsObject: { GassmaClient?: new (options?: unknown) => object } =
+      {};
+    const run = new Function("Gassma", "exports", "LockService", code);
+    run({ GassmaClient: FakeCoreClient }, exportsObject, {
+      getScriptLock: () => ({}),
+    });
+
+    const GeneratedClient = exportsObject.GassmaClient;
+    if (!GeneratedClient) throw new Error("GassmaClient not exported");
+    new GeneratedClient({});
+
+    expect(seen[0].id).toBe("SCHEMA_SHEET_ID");
+  });
+
+  it("should keep schema relations winning over user supplied relations", () => {
+    const relations = {
+      Post: {
+        author: {
+          type: "manyToOne" as const,
+          to: "User",
+          field: "authorId",
+          reference: "id",
+        },
+      },
+    };
+    const code = generateClientJs(relations, "Test");
+    const seen: { relations?: unknown }[] = [];
+    class FakeCoreClient {
+      constructor(options: { relations?: unknown }) {
+        seen.push(options);
+      }
+    }
+    const exportsObject: { GassmaClient?: new (options?: unknown) => object } =
+      {};
+    const run = new Function("Gassma", "exports", "LockService", code);
+    run({ GassmaClient: FakeCoreClient }, exportsObject, {
+      getScriptLock: () => ({}),
+    });
+
+    const GeneratedClient = exportsObject.GassmaClient;
+    if (!GeneratedClient) throw new Error("GassmaClient not exported");
+    new GeneratedClient({ relations: { Ignored: {} } });
+
+    expect(seen[0].relations).toEqual(relations);
+  });
+
+  it("should keep schema defaults and autoincrement winning over user supplied ones", () => {
+    const defaults: DefaultsConfig = {
+      User: { isActive: { kind: "static", value: true } },
+    };
+    const autoincrement: AutoincrementConfig = { User: ["id"] };
+    const code = generateClientJs(
+      {},
+      "Test",
+      defaults,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      autoincrement,
+    );
+    const seen: { defaults?: unknown; autoincrement?: unknown }[] = [];
+    class FakeCoreClient {
+      constructor(options: { defaults?: unknown; autoincrement?: unknown }) {
+        seen.push(options);
+      }
+    }
+    const exportsObject: { GassmaClient?: new (options?: unknown) => object } =
+      {};
+    const run = new Function("Gassma", "exports", "LockService", code);
+    run({ GassmaClient: FakeCoreClient }, exportsObject, {
+      getScriptLock: () => ({}),
+    });
+
+    const GeneratedClient = exportsObject.GassmaClient;
+    if (!GeneratedClient) throw new Error("GassmaClient not exported");
+    new GeneratedClient({
+      defaults: { User: { isActive: { kind: "static", value: false } } },
+      autoincrement: { User: ["ignored"] },
+    });
+
+    expect(seen[0].defaults).toEqual({ User: { isActive: true } });
+    expect(seen[0].autoincrement).toEqual({ User: "id" });
+  });
+
   it("should embed strictUndefinedChecks when enabled", () => {
     const result = generateClientJs(
       {},

--- a/packages/cli/src/generate/jsGenerate/generateClientJs.ts
+++ b/packages/cli/src/generate/jsGenerate/generateClientJs.ts
@@ -150,8 +150,10 @@ const generateClientJs = (
         .join("\n")
     : "";
 
+  const defaultProps = ["lock: LockService.getScriptLock()"];
+  if (datasourceUrl) defaultProps.push(`id: "${datasourceUrl}"`);
+
   const mergeProps: string[] = [];
-  if (datasourceUrl) mergeProps.push(`id: "${datasourceUrl}"`);
   mergeProps.push(`relations: ${lowerName}Relations`);
   if (hasDefaults) mergeProps.push(`defaults: ${lowerName}Defaults`);
   if (hasUpdatedAt) mergeProps.push(`updatedAt: ${lowerName}UpdatedAt`);
@@ -163,7 +165,7 @@ const generateClientJs = (
   if (hasAutoincrement)
     mergeProps.push(`autoincrement: ${lowerName}Autoincrement`);
   if (strictUndefinedChecks) mergeProps.push("strictUndefinedChecks: true");
-  const mergeExpr = `Object.assign({ lock: LockService.getScriptLock() }, options, { ${mergeProps.join(", ")} })`;
+  const mergeExpr = `Object.assign({ ${defaultProps.join(", ")} }, options, { ${mergeProps.join(", ")} })`;
 
   return `const ${lowerName}Relations = ${relationsJson};
 


### PR DESCRIPTION
## 不具合

**`new GassmaClient({ id: "別のID" })` が黙って無視されていた。**

生成クライアントはこう書かれている。

```js
const mergedOptions = Object.assign(
  { lock: LockService.getScriptLock() },
  options,                                  // ← 利用者
  { id: "SHEET_ID", relations, defaults },  // ← こちらが勝つ
);
```

`gassma.config.ts` の `datasource.url`（またはスキーマの `datasource` ブロック）を設定していると、**コンストラクタに渡した `id` がスキーマ由来の値に上書きされる。**

2つの点で問題だった。

1. **リファレンスの「基本」ページには `new GassmaClient({ id: "SPREAD_SHEET_ID" }); // OK` と明記されている。** ドキュメントの約束と実装が食い違っていた
2. **Prisma とは逆。** `new PrismaClient({ datasourceUrl: "..." })` はスキーマの datasource を上書きする

**gassma を何も知らないエージェントに実装させる DX テストで見つかった。** 直接の報告は「リレーション定義が手書き不要だと分かるまで混乱した」という一言で、そこから生成クライアントを読んで判明した。

## 修正

`id` だけを既定側（第1引数）へ移した。

```diff
-Object.assign({ lock: LockService.getScriptLock() }, options, { id: "SHEET_ID", relations: xRelations })
+Object.assign({ lock: LockService.getScriptLock(), id: "SHEET_ID" }, options, { relations: xRelations })
```

`datasourceUrl` が無いときの生成物は**変化なし**（第1引数に余計なキーが増えない）。

### スキーマ優先のままにしたもの

`relations` / `defaults` / `updatedAt` / `ignore` / `ignoreSheets` / `map` / `mapSheets` / `autoincrement` / `strictUndefinedChecks` は**第3引数のまま**で、引き続き利用者の指定を上書きする。これは仕様として維持する判断。

**ただし「渡しても無視される」ことがドキュメントから読み取れなかったのが混乱の元**だったので、リファレンス側で明記する対応を別途進めている。特に **`defaults` はスキーマに `@default` が1つでもあれば利用者が渡した全モデル分が丸ごと消える**。

生成 `.d.ts` は変更不要。`constructor(options?: Gassma<Name>ClientOptions<O>)` は元から `id` を任意で受け付け、TSDoc にも `new GassmaClient({ id: "<spreadsheet id>" })` の例がある。**今回の修正で型と実装がようやく一致した。**

## 検証

- `npm test` **1527件 pass**（198ファイル、新規6件）／`typecheck`・`test:types`・`lint`・`format:check`・`build` OK
- **`test:types:all` は TS 5.2.2・5.6.3・5.9.3・6.0.3・7.0.2 × strict on/off の10通りすべて 0 エラー**
- 新規テストは既存の `new Function` による**挙動テスト**を含む。文字列の一致だけでなく、`new GassmaClient({ id: "USER_ID" })` が core に `id: "USER_ID"` を渡すことを実際に確認している
- **`relations` / `defaults` / `autoincrement` がスキーマ優先のままであることも退行検知として明示的にテストを置いた**

### 変異テスト

- `id` を第3引数に戻す → **新規2件が落ちる**（他は通る = `id` の位置を正確に狙えている）
- スキーマ由来の全プロパティを第1引数へ移す → **6件が落ちる**（退行検知テストを含む）

いずれも独立に再実行して確認済み。

## 補足（この PR では対応していない）

**素の clone で `npm run typecheck` を単体実行すると落ちる。** 型テスト用フィクスチャが未生成のため `upsert.test-d.ts` で `Unused '@ts-expect-error'` が出る（`pretest:types` の `genFixtureTypes.ts` が生成する）。`test:types` を一度走らせれば以降は通る。**本変更とは無関係**だが、CI のジョブ順次第では踏みうる。

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ