### PR TITLE
fix: export the Gassma namespace at runtime and reject @unique

### DIFF
--- a/packages/cli/src/__test__/generate/fixtures/fuga.prisma
+++ b/packages/cli/src/__test__/generate/fixtures/fuga.prisma
@@ -5,7 +5,7 @@ generator client {
 
 model User {
   id        Int      @id @default(autoincrement())
-  username  String   @unique
+  username  String
   age       Int?
   orders    Order[]
 }

--- a/packages/cli/src/__test__/generate/fixtures/hoge.prisma
+++ b/packages/cli/src/__test__/generate/fixtures/hoge.prisma
@@ -5,7 +5,7 @@ generator client {
 
 model User {
   id        Int      @id @default(autoincrement())
-  email     String   @unique
+  email     String
   name      String?
   posts     Post[]
 }

--- a/packages/cli/src/__test__/generate/jsGenerate/gassmaNamespaceExport.test.ts
+++ b/packages/cli/src/__test__/generate/jsGenerate/gassmaNamespaceExport.test.ts
@@ -1,0 +1,83 @@
+import fs from "fs";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { generateClientJs } from "../../../generate/jsGenerate/generateClientJs";
+
+const requireFromHere = createRequire(import.meta.url);
+
+const fakeNamespace = () => ({
+  GassmaClient: class FakeCoreClient {},
+  NotFoundError: class NotFoundError extends Error {},
+});
+
+const writeGeneratedModule = (code: string) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-client-js-"));
+  const filePath = path.join(dir, "schemaClient.js");
+  fs.writeFileSync(filePath, code);
+  return { dir, filePath };
+};
+
+describe("generated schemaClient.js Gassma namespace", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "Gassma");
+  });
+
+  it("should re-export the Gassma namespace the .d.ts declares", () => {
+    const code = generateClientJs({}, "Hoge");
+    const exportsObject: Record<string, unknown> = {};
+    const namespace = fakeNamespace();
+
+    const run = new Function("Gassma", "exports", "LockService", code);
+    run(namespace, exportsObject, { getScriptLock: () => ({}) });
+
+    expect(exportsObject.Gassma).toBe(namespace);
+  });
+
+  it("should let the re-exported namespace be used with instanceof", () => {
+    const code = generateClientJs({}, "Hoge");
+    const exportsObject: {
+      Gassma?: { NotFoundError: new () => Error };
+    } = {};
+    const namespace = fakeNamespace();
+
+    const run = new Function("Gassma", "exports", "LockService", code);
+    run(namespace, exportsObject, { getScriptLock: () => ({}) });
+
+    const NotFoundError = exportsObject.Gassma?.NotFoundError;
+    if (!NotFoundError) throw new Error("Gassma.NotFoundError not exported");
+    expect(new NotFoundError() instanceof NotFoundError).toBe(true);
+    expect(new Error("other") instanceof NotFoundError).toBe(false);
+  });
+
+  it("should not read the Gassma global while the module is evaluated", () => {
+    const code = generateClientJs({}, "Hoge");
+    const exportsObject: Record<string, unknown> = {};
+
+    const run = new Function("exports", "LockService", code);
+    expect(() => run(exportsObject, { getScriptLock: () => ({}) })).not.toThrow(
+      ReferenceError,
+    );
+    expect(() => exportsObject.Gassma).toThrow(ReferenceError);
+  });
+
+  it("should expose Gassma when the generated file is required from node", () => {
+    const { filePath } = writeGeneratedModule(generateClientJs({}, "Hoge"));
+
+    const loaded = requireFromHere(filePath);
+
+    expect(Object.keys(loaded)).toContain("Gassma");
+    expect(Object.keys(loaded)).toContain("GassmaClient");
+  });
+
+  it("should resolve Gassma from the global at access time, not at load time", () => {
+    const { filePath } = writeGeneratedModule(generateClientJs({}, "Hoge"));
+    const loaded = requireFromHere(filePath);
+    const namespace = fakeNamespace();
+
+    Reflect.set(globalThis, "Gassma", namespace);
+
+    expect(loaded.Gassma).toBe(namespace);
+  });
+});

--- a/packages/cli/src/__test__/generate/read/assertNoUniqueAttributes.test.ts
+++ b/packages/cli/src/__test__/generate/read/assertNoUniqueAttributes.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { UnsupportedAttributeError } from "../../../error/mainError";
+import { assertNoUniqueAttributes } from "../../../generate/read/assertNoUniqueAttributes";
+
+describe("assertNoUniqueAttributes", () => {
+  it("should reject a field marked @unique", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String @unique
+}
+`;
+    expect(() => assertNoUniqueAttributes(schema)).toThrow(
+      UnsupportedAttributeError,
+    );
+  });
+
+  it("should name the model and the field", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String @unique
+}
+`;
+    expect(() => assertNoUniqueAttributes(schema)).toThrow(
+      "GASsmaUnsupportedAttributeError: `@unique` on Staff.email is not supported.\n" +
+        "GASsma cannot enforce uniqueness on a spreadsheet.\n" +
+        "Remove it, or check uniqueness in your code.",
+    );
+  });
+
+  it("should report every violating field at once", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String @unique
+  code  String @unique
+}
+
+model Shift {
+  id   Int    @id
+  slug String @unique
+}
+`;
+    expect(() => assertNoUniqueAttributes(schema)).toThrow(/Staff\.email/);
+    expect(() => assertNoUniqueAttributes(schema)).toThrow(/Staff\.code/);
+    expect(() => assertNoUniqueAttributes(schema)).toThrow(/Shift\.slug/);
+  });
+
+  it("should carry the violating fields on the error", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String @unique
+  code  String @unique
+}
+`;
+    try {
+      assertNoUniqueAttributes(schema);
+      expect.unreachable("assertNoUniqueAttributes did not throw");
+    } catch (e) {
+      if (!(e instanceof UnsupportedAttributeError)) throw e;
+      expect(e.fields).toEqual(["Staff.email", "Staff.code"]);
+    }
+  });
+
+  it("should reject @unique combined with other attributes", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String @unique @map("Email Address")
+}
+`;
+    expect(() => assertNoUniqueAttributes(schema)).toThrow(/Staff\.email/);
+  });
+
+  it("should accept a schema without @unique", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String
+}
+`;
+    expect(() => assertNoUniqueAttributes(schema)).not.toThrow();
+  });
+
+  it("should leave @@unique alone", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String
+
+  @@unique([email])
+}
+`;
+    expect(() => assertNoUniqueAttributes(schema)).not.toThrow();
+  });
+
+  it("should not be fooled by a field named unique", () => {
+    const schema = `
+model Staff {
+  id     Int    @id
+  unique String
+}
+`;
+    expect(() => assertNoUniqueAttributes(schema)).not.toThrow();
+  });
+});

--- a/packages/cli/src/__test__/generate/read/extractOptionalRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractOptionalRelations.test.ts
@@ -62,7 +62,7 @@ model User {
 
 model Profile {
   id     Int  @id
-  userId Int  @unique
+  userId Int
   user   User @relation(fields: [userId], references: [id])
 }
 `;

--- a/packages/cli/src/__test__/generate/read/extractRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/extractRelations.test.ts
@@ -50,7 +50,7 @@ model User {
 model Profile {
   id     Int  @id
   user   User @relation(fields: [userId], references: [id])
-  userId Int  @unique
+  userId Int
 }
 `;
     const result = extractRelations(schema);
@@ -1056,7 +1056,7 @@ model User {
 
 model Post {
   id       Int    @id
-  authorId Int    @unique
+  authorId Int
   author   User   @relation(fields: [authorId], references: [id])
   pinnedBy User[] @relation("Pinned")
 }
@@ -1070,7 +1070,7 @@ model User {
 
 model Post {
   id       Int    @id
-  authorId Int    @unique
+  authorId Int
   author   User   @relation(fields: [authorId], references: [id])
   pinnedBy User[] @relation("Pinned")
 }

--- a/packages/cli/src/__test__/generate/read/ignoredRelationColumns.test.ts
+++ b/packages/cli/src/__test__/generate/read/ignoredRelationColumns.test.ts
@@ -52,7 +52,7 @@ model User {
 model Profile {
   id     Int  @id
   user   User @relation(fields: [userId], references: [id])
-  userId Int  @unique @ignore
+  userId Int  @ignore
 }
 `;
     expect(() => extractRelations(schema)).toThrow(IgnoredRelationColumnError);

--- a/packages/cli/src/__test__/generate/read/prismaReader.test.ts
+++ b/packages/cli/src/__test__/generate/read/prismaReader.test.ts
@@ -111,11 +111,11 @@ model User {
     expect(result.User.name).toEqual(["string"]);
   });
 
-  it("should ignore @id, @default, @unique, @map attributes", () => {
+  it("should ignore @id, @default, @map attributes", () => {
     const schema = `
 model User {
   id    Int    @id @default(autoincrement())
-  email String @unique
+  email String
   name  String @map("user_name")
 }
 `;

--- a/packages/cli/src/__test__/generate/typeGenerate/fixtures/gassmaPublicErrorClasses.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/fixtures/gassmaPublicErrorClasses.ts
@@ -1,0 +1,72 @@
+/**
+ * Snapshot of the error classes exported from gassma's `src/publicApi.ts`.
+ *
+ * The CLI cannot read the gassma repository, so this list is the agreed
+ * contract between the two. Refresh it from a gassma checkout with:
+ *
+ *   grep -oE '^export const [A-Za-z]+' src/publicApi.ts \
+ *     | sed 's/export const //' | grep -E 'Error$' | sort
+ *
+ * `gassmaPublicErrorClasses.test.ts` fails when the generated namespace and
+ * this list drift apart in either direction.
+ */
+const gassmaPublicErrorClasses = [
+  "GassmaAggregateAvgError",
+  "GassmaAggregateAvgTypeError",
+  "GassmaAggregateMaxError",
+  "GassmaAggregateMinError",
+  "GassmaAggregateSelectionRequiredError",
+  "GassmaAggregateSumError",
+  "GassmaAggregateSumTypeError",
+  "GassmaAggregateTypeError",
+  "GassmaAutoincrementInTransactionError",
+  "GassmaAutoincrementNotConfiguredError",
+  "GassmaFindFirstTakeError",
+  "GassmaFindSelectOmitConflictError",
+  "GassmaGroupByHavingDontWriteByError",
+  "GassmaGroupByOrderByRequiredError",
+  "GassmaInValidColumnValueError",
+  "GassmaIncludeSelectConflictError",
+  "GassmaInvalidLockError",
+  "GassmaInvalidValueError",
+  "GassmaLimitNegativeError",
+  "GassmaMissingArgumentError",
+  "GassmaNestedTransactionError",
+  "GassmaRelationDuplicateError",
+  "GassmaRelationNotFoundError",
+  "GassmaSkipInArrayError",
+  "GassmaSkipNegativeError",
+  "GassmaThroughRequiredError",
+  "GassmaTransactionLockRequiredError",
+  "GassmaTransactionLockTimeoutError",
+  "GassmaTransactionRollbackError",
+  "GassmaTransactionTimeoutError",
+  "GassmaUndefinedValueError",
+  "GassmaUnknownArgumentError",
+  "IncludeInvalidOptionTypeError",
+  "IncludeSelectIncludeConflictError",
+  "IncludeSelectOmitConflictError",
+  "IncludeWithoutRelationsError",
+  "NestedWriteConnectNotFoundError",
+  "NestedWriteInvalidOperationError",
+  "NestedWriteRelationNotFoundError",
+  "NestedWriteTargetNotFoundError",
+  "NestedWriteWithoutRelationsError",
+  "NotFoundError",
+  "RelationColumnNotFoundError",
+  "RelationIgnoredColumnError",
+  "RelationInvalidOnDeleteError",
+  "RelationInvalidOnUpdateError",
+  "RelationInvalidPropertyTypeError",
+  "RelationInvalidTypeError",
+  "RelationMissingPropertyError",
+  "RelationOnDeleteRestrictError",
+  "RelationOnUpdateRestrictError",
+  "RelationOrderByCountUnsupportedTypeError",
+  "RelationOrderByUnsupportedTypeError",
+  "RelationSheetNotFoundError",
+  "WhereRelationInvalidFilterError",
+  "WhereRelationWithoutContextError",
+];
+
+export { gassmaPublicErrorClasses };

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaErrorClasses.test.ts
@@ -222,6 +222,26 @@ describe("getGassmaErrorClasses", () => {
     );
   });
 
+  it("should include lock error classes", () => {
+    expect(result).toContain(
+      "class GassmaTransactionLockRequiredError extends Error",
+    );
+    expect(result).toContain("class GassmaInvalidLockError extends Error");
+  });
+
+  it("should include autoincrement error classes", () => {
+    expect(result).toContain(
+      "class GassmaAutoincrementNotConfiguredError extends Error",
+    );
+    expect(result).toContain(
+      "constructor(sheetName: string, field: string, configuredFields: string[])",
+    );
+    expect(result).toContain(
+      "class GassmaAutoincrementInTransactionError extends Error",
+    );
+    expect(result).toContain("constructor(methodName: string)");
+  });
+
   it("should include relation errors from relationError.ts", () => {
     expect(result).toContain("class GassmaRelationNotFoundError extends Error");
     expect(result).toContain("class GassmaThroughRequiredError extends Error");

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaPublicErrorClasses.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaPublicErrorClasses.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getGassmaErrorClasses } from "../../../generate/typeGenerate/gassmaErrorClasses";
+import { gassmaPublicErrorClasses } from "./fixtures/gassmaPublicErrorClasses";
+
+const declaredErrorClasses = (): string[] => {
+  const matches = getGassmaErrorClasses().matchAll(
+    /^ {2}class ([A-Za-z]+) extends/gm,
+  );
+  return [...matches].map((match) => match[1]).sort();
+};
+
+describe("generated Gassma namespace error classes", () => {
+  it("should declare every error class gassma exports", () => {
+    const missing = gassmaPublicErrorClasses.filter(
+      (name) => !declaredErrorClasses().includes(name),
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it("should not declare error classes gassma does not export", () => {
+    const extra = declaredErrorClasses().filter(
+      (name) => !gassmaPublicErrorClasses.includes(name),
+    );
+
+    expect(extra).toEqual([]);
+  });
+
+  it("should match gassma exactly", () => {
+    expect(declaredErrorClasses()).toEqual(
+      [...gassmaPublicErrorClasses].sort(),
+    );
+  });
+});

--- a/packages/cli/src/__test__/generate/uniqueAttribute.test.ts
+++ b/packages/cli/src/__test__/generate/uniqueAttribute.test.ts
@@ -1,0 +1,67 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UnsupportedAttributeError } from "../../error/mainError";
+import { generate } from "../../generate/generate";
+
+const generatorBlock = (outDir: string) => `generator client {
+  provider = "prisma-client-js"
+  output   = "${outDir}"
+}`;
+
+describe("generate with @unique", () => {
+  let tmpDir: string;
+  let schemaDir: string;
+  let outDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-unique-"));
+    schemaDir = path.join(tmpDir, "gassma");
+    outDir = path.join(tmpDir, "generated");
+    fs.mkdirSync(schemaDir);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeSchema = (model: string) => {
+    const schemaPath = path.join(schemaDir, "schema.prisma");
+    fs.writeFileSync(schemaPath, `${generatorBlock(outDir)}\n\n${model}\n`);
+    return schemaPath;
+  };
+
+  it("should throw UnsupportedAttributeError instead of generating", () => {
+    const schemaPath = writeSchema(`model Staff {
+  id    Int    @id
+  email String @unique
+}`);
+
+    expect(() => generate({ schema: schemaPath })).toThrow(
+      UnsupportedAttributeError,
+    );
+    expect(fs.existsSync(outDir)).toBe(false);
+  });
+
+  it("should tell which model and field carries it", () => {
+    const schemaPath = writeSchema(`model Staff {
+  id    Int    @id
+  email String @unique
+}`);
+
+    expect(() => generate({ schema: schemaPath })).toThrow(/Staff\.email/);
+  });
+
+  it("should generate when @unique is removed", () => {
+    const schemaPath = writeSchema(`model Staff {
+  id    Int    @id
+  email String
+}`);
+
+    expect(() => generate({ schema: schemaPath })).not.toThrow();
+    expect(fs.existsSync(path.join(outDir, "schemaClient.js"))).toBe(true);
+  });
+});

--- a/packages/cli/src/__test__/templates.test.ts
+++ b/packages/cli/src/__test__/templates.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { readTemplate } from "../util/readTemplate";
+import { validateSchema } from "../validate/validate";
 
 const GITIGNORE = [
   ".clasp.json",
@@ -123,7 +124,7 @@ const SCHEMA = `generator client {
 const SCHEMA_WITH_MODEL = `${SCHEMA}
 model User {
   id    Int     @id @default(autoincrement())
-  email String  @unique
+  email String
   name  String
 }
 `;
@@ -187,6 +188,15 @@ describe("bundled templates", () => {
     expect(readTemplate("schema.with-model.prisma.template")).toBe(
       SCHEMA_WITH_MODEL,
     );
+  });
+
+  it("should ship a schema.with-model template a fresh project can generate from", () => {
+    const result = validateSchema(
+      readTemplate("schema.with-model.prisma.template"),
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
   });
 
   it("should ship gassma.config.ts.template byte for byte", () => {

--- a/packages/cli/src/__test__/types/fixtures/schema.prisma
+++ b/packages/cli/src/__test__/types/fixtures/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 
 model User {
   id        Int      @id @default(autoincrement())
-  email     String   @unique
+  email     String
   name      String?
   age       Int?
   isActive  Boolean  @default(true)
@@ -32,13 +32,13 @@ model Post {
 model Profile {
   id     Int    @id @default(autoincrement())
   bio    String
-  userId Int    @unique
+  userId Int
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Tag {
   id    Int    @id @default(autoincrement())
-  name  String @unique
+  name  String
   posts Post[]
 }
 

--- a/packages/cli/src/__test__/validate/uniqueAttribute.test.ts
+++ b/packages/cli/src/__test__/validate/uniqueAttribute.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { validateSchema } from "../../validate/validate";
+
+const generatorBlock = `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}`;
+
+describe("validateSchema with @unique", () => {
+  it("should report unsupportedAttribute for a field marked @unique", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id    Int    @id
+  email String @unique
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ type: "unsupportedAttribute" }),
+    );
+    const messages = result.errors.map((error) => error.message).join("\n");
+    expect(messages).toContain("Staff.email");
+    expect(messages).toContain("@unique");
+  });
+
+  it("should report one error per violating field", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id    Int    @id
+  email String @unique
+  code  String @unique
+}
+`;
+    const result = validateSchema(schema);
+
+    const uniqueErrors = result.errors.filter(
+      (error) => error.type === "unsupportedAttribute",
+    );
+    expect(uniqueErrors).toHaveLength(2);
+  });
+
+  it("should stay valid without @unique", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id    Int    @id
+  email String
+}
+`;
+    expect(validateSchema(schema).valid).toBe(true);
+  });
+});

--- a/packages/cli/src/error/mainError.ts
+++ b/packages/cli/src/error/mainError.ts
@@ -90,6 +90,25 @@ class ThroughSheetConflictError extends Error {
   }
 }
 
+const describeUniqueFields = (fields: string[]): string =>
+  fields.length === 1
+    ? `\`@unique\` on ${fields[0]} is not supported.`
+    : "`@unique` is not supported.\n" +
+      fields.map((field) => `  - ${field}`).join("\n");
+
+class UnsupportedAttributeError extends Error {
+  readonly fields: string[];
+
+  constructor(fields: string[]) {
+    super(
+      `GASsmaUnsupportedAttributeError: ${describeUniqueFields(fields)}\n` +
+        "GASsma cannot enforce uniqueness on a spreadsheet.\n" +
+        "Remove it, or check uniqueness in your code.",
+    );
+    this.fields = fields;
+  }
+}
+
 export {
   ArgumentError,
   NoModelsError,
@@ -101,4 +120,5 @@ export {
   MigrateOutputDirError,
   IgnoredRelationColumnError,
   ThroughSheetConflictError,
+  UnsupportedAttributeError,
 };

--- a/packages/cli/src/generate/generate.ts
+++ b/packages/cli/src/generate/generate.ts
@@ -17,6 +17,7 @@ import { extractMapSheets } from "./read/extractMapSheets";
 import { extractEnums } from "./read/extractEnums";
 import { extractDatasourceUrl } from "./read/extractDatasourceUrl";
 import { countModels } from "./read/countModels";
+import { assertNoUniqueAttributes } from "./read/assertNoUniqueAttributes";
 import { prismaReader } from "./read/prismaReader";
 import { NoModelsError } from "../error/mainError";
 import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
@@ -87,6 +88,8 @@ function generateFromSchema(
   schemaName: string,
   datasourceUrl?: string,
 ) {
+  assertNoUniqueAttributes(schemaText);
+
   const outputPath = extractOutputPath(schemaText);
   if (!outputPath) {
     throw new Error(

--- a/packages/cli/src/generate/jsGenerate/generateClientJs.ts
+++ b/packages/cli/src/generate/jsGenerate/generateClientJs.ts
@@ -180,6 +180,13 @@ ${defaultsDecl}${updatedAtDecl}${ignoreDecl}${mapDecl}${ignoreSheetsDecl}${mapSh
 }
 
 exports.GassmaClient = GassmaClient;
+Object.defineProperty(exports, "Gassma", {
+  enumerable: true,
+  configurable: true,
+  get: function () {
+    return Gassma;
+  },
+});
 ${hasEnums ? "\n" + enumDecls : ""}`;
 };
 

--- a/packages/cli/src/generate/read/assertNoUniqueAttributes.ts
+++ b/packages/cli/src/generate/read/assertNoUniqueAttributes.ts
@@ -1,0 +1,28 @@
+import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
+import { UnsupportedAttributeError } from "../../error/mainError";
+
+const collectUniqueFields = (schemaText: string): string[] => {
+  const ast = parsePrismaSchema(schemaText);
+
+  return ast.declarations.flatMap((decl) => {
+    if (decl.kind !== "model") return [];
+    const modelName = decl.name.value;
+
+    return decl.members.flatMap((member) => {
+      if (member.kind !== "field") return [];
+      const hasUnique = (member.attributes ?? []).some(
+        (attr) =>
+          attr.kind === "fieldAttribute" && attr.path.value[0] === "unique",
+      );
+      return hasUnique ? [`${modelName}.${member.name.value}`] : [];
+    });
+  });
+};
+
+const assertNoUniqueAttributes = (schemaText: string): void => {
+  const fields = collectUniqueFields(schemaText);
+  if (fields.length === 0) return;
+  throw new UnsupportedAttributeError(fields);
+};
+
+export { assertNoUniqueAttributes, collectUniqueFields };

--- a/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaErrorClasses/errorClassDefinitions.ts
@@ -213,6 +213,18 @@ const errorClassDefinitions: ErrorClassDef[] = [
     params: "backupSheetNames: string[]",
     members: ["readonly backupSheetNames: string[]"],
   },
+  { name: "GassmaTransactionLockRequiredError", extends: "Error", params: "" },
+  { name: "GassmaInvalidLockError", extends: "Error", params: "" },
+  {
+    name: "GassmaAutoincrementNotConfiguredError",
+    extends: "Error",
+    params: "sheetName: string, field: string, configuredFields: string[]",
+  },
+  {
+    name: "GassmaAutoincrementInTransactionError",
+    extends: "Error",
+    params: "methodName: string",
+  },
 ];
 
 export { errorClassDefinitions };

--- a/packages/cli/src/validate/validate.ts
+++ b/packages/cli/src/validate/validate.ts
@@ -1,6 +1,7 @@
 import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
 import { IgnoredRelationColumnError } from "../error/mainError";
 import { countModelsInAst } from "../generate/read/countModels";
+import { collectUniqueFields } from "../generate/read/assertNoUniqueAttributes";
 import { extractRelations } from "../generate/read/extractRelations";
 
 type ValidationError = {
@@ -9,7 +10,8 @@ type ValidationError = {
     | "missingGenerator"
     | "missingOutput"
     | "noModels"
-    | "ignoredRelationColumn";
+    | "ignoredRelationColumn"
+    | "unsupportedAttribute";
   message: string;
 };
 
@@ -33,6 +35,15 @@ const collectIgnoredRelationColumnErrors = (
   }
   return [];
 };
+
+const collectUniqueAttributeErrors = (schemaText: string): ValidationError[] =>
+  collectUniqueFields(schemaText).map((field) => ({
+    type: "unsupportedAttribute",
+    message:
+      `\`@unique\` on ${field} is not supported. ` +
+      "GASsma cannot enforce uniqueness on a spreadsheet. " +
+      "Remove it, or check uniqueness in your code.",
+  }));
 
 const validateSchema = (schemaText: string): ValidationResult => {
   const errors: ValidationError[] = [];
@@ -75,6 +86,7 @@ const validateSchema = (schemaText: string): ValidationResult => {
     }
 
     errors.push(...collectIgnoredRelationColumnErrors(schemaText));
+    errors.push(...collectUniqueAttributeErrors(schemaText));
   } catch (e) {
     errors.push({
       type: "syntax",

--- a/packages/cli/templates/schema.with-model.prisma.template
+++ b/packages/cli/templates/schema.with-model.prisma.template
@@ -5,6 +5,6 @@ generator client {
 
 model User {
   id    Int     @id @default(autoincrement())
-  email String  @unique
+  email String
   name  String
 }


### PR DESCRIPTION
**gassma を何も知らないエージェントに実装させる DX テスト**（シフト管理システム）で見つかった2件。どちらも私の側で再現を確認済み。

---

# 1. 生成クライアントで `Gassma` が実行時に存在しない

## 現象

```
$ node -e "const m = require('./src/generated/gassma/schemaClient.js'); console.log(Object.keys(m), m.Gassma)"
[ 'GassmaClient' ]  undefined
```

`schemaClient.js` は `exports.GassmaClient` しか出さないのに、`schemaClient.d.ts` には `export namespace Gassma { ... }` があってエラークラスが**型としては**存在していた。その結果:

| 書き方 | 型チェック | 実行時 |
|---|---|---|
| `import { Gassma } from "./generated/..."` | **通る** | **`undefined`。`catch` の中で TypeError** |
| 素の `Gassma.NotFoundError` | **`TS2304` で落ちる** | 動く |

**型チェックと実行時の両方を満たす書き方が存在しなかった。** しかも壊れるのは `catch` の中＝一番エラーを捕まえたい瞬間。リファレンスの「エラー一覧」は `Gassma.XxxError` で `instanceof` できると書いているが、CLI ワークフローでは成立していなかった。

## 修正

生成 JS から `Gassma` を再 export する。**素朴な代入ではなく遅延 getter にした。**

```js
Object.defineProperty(exports, "Gassma", {
  enumerable: true, configurable: true,
  get: function () { return Gassma; },
});
```

`exports.Gassma = Gassma;` だと**モジュール評価時**に GAS グローバルを読むため、ライブラリ未追加の状態では `require`/import 自体が ReferenceError になり、enum だけ import しているコードまで巻き添えで落ちる。getter なら既存の `new Gassma.GassmaClient(...)` と**同じタイミング**で解決され、意味論が変わらない。esbuild の CJS→ESM interop は getter を getter のまま転写するので、バンドル後も遅延性が保たれる。

### エラークラス4件を追加

`errorClassDefinitions.ts` に無く、本体 `publicApi.ts` にはあったもの。

```
GassmaTransactionLockRequiredError
GassmaInvalidLockError
GassmaAutoincrementNotConfiguredError
GassmaAutoincrementInTransactionError
```

これで 52 → **56** となり本体と一致（逆向きのずれはゼロ）。**同じ遅れが再発しないよう、本体の export 一覧との一致テストを追加した。** 比較対象は `errorClassDefinitions` の生データではなく **`getGassmaErrorClasses()` の出力文字列**（実際に生成される表面を検証するため）。不足・過剰・完全一致の3方向。

## 実効性の実測

```
export: [ 'GassmaClient', 'Gassma' ]
instanceof が使えるか: true
```

---

# 2. スキーマの `@unique` が完全に黙殺される

## 現象

- **CLI に `@unique` を処理するコードが1行も無かった**
- 生成物に `unique` の文字列が **0件**
- **`findUnique` も本体に未実装**
- リファレンスの**スキーマページに記載が無い**のに、**クイックスタートの例では使っている**

つまり**「書けるが完全に無意味」**で、クイックスタートがそれを教えていた。

## 修正

`generate` と `validate` で検出し、エラーで落とす。

```
GASsmaUnsupportedAttributeError: `@unique` is not supported.
  - Store.code
  - Staff.email
  - Skill.name
GASsma cannot enforce uniqueness on a spreadsheet.
Remove it, or check uniqueness in your code.
```

既存の `IgnoredRelationColumnError` の作法に合わせ**全件まとめて報告**。

## ⚠️ 併せて直したもの

**`templates/schema.with-model.prisma.template` が `@unique` を使っていた。** 対策なしでは **`npx gassma bootstrap` で作った新規プロジェクトが直後の `generate` で落ちる**。これが最も重大だった。**テンプレートが `validate` を通ることの回帰テストも追加した。**

ほかに fixture 7ファイル（`types/fixtures/schema.prisma`・`generate/fixtures/*.prisma`・`prismaReader` / `extractRelations` / `extractOptionalRelations` / `ignoredRelationColumns` の各テスト）。**これらは大半が `generate()` を通らない経路で、除去前でも緑だった**が、「書けるが無意味」を残さないため全て外した。`Profile.userId` の `@unique` 除去でリレーション種別判定・生成型は不変（型テスト10組合せ緑）。

gassma-test とリファレンスの `@unique` は別途対応する。

---

## 検証

- `npm test` **1552件 pass**／`typecheck`・`test:types`・`lint`・`format:check`・`build` OK
- **`test:types:all` は TS 5.2.2・5.6.3・5.9.3・6.0.3・7.0.2 × strict on/off の10通りすべて 0 エラー**
- **実 CLI で end-to-end 確認**: `@unique` を含むスキーマが上記メッセージで落ち、外すと生成が通り、生成物から `Gassma` を引いて `instanceof` が機能することを実測
- **変異テスト6件すべて検知**（assert 呼び出し削除／validate の push 削除／検出条件の取り違え／テンプレートに `@unique` を戻す／エラークラスの不足・過剰）。加えて `exports.Gassma = Gassma;`（素朴な代入）にすると遅延性のテスト3件が落ちることも実測

## 未対応（要指示）

実測で**他にも黙殺されている属性**が見つかった。**指示が `@unique` のみだったため手を付けていない。**

- **`@@unique`（複合ユニーク）** — `@unique` と全く同じ性質。同じ扱いにすべき
- **`@@id`（複合主キー）** — 黙殺。しかも implicit m2m 検出（`detectImplicitManyToMany.ts:95-96`）は**列名が文字通り `id` であることを決め打ち**していて、`@id` フィールド属性自体どこからも読まれていない
- `@@index` / `@@fulltext` / `@db.VarChar(255)` — 黙殺。ただし制約でなく性能ヒント・ネイティブ型なので優先度は低い

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ