### PR TITLE
fix: make the type test fixture a schema the CLI actually accepts

### DIFF
--- a/packages/cli/scripts/genFixtureTypes.ts
+++ b/packages/cli/scripts/genFixtureTypes.ts
@@ -10,6 +10,7 @@ import { extractUpdatedAt } from "../src/generate/read/extractUpdatedAt";
 import { extractOptionalFields } from "../src/generate/read/extractOptionalFields";
 import { extractOptionalRelations } from "../src/generate/read/extractOptionalRelations";
 import { extractPreviewFeatures } from "../src/generate/read/extractPreviewFeatures";
+import { validateSchema } from "../src/validate/validate";
 
 const fixturePath = path.join(
   __dirname,
@@ -21,6 +22,14 @@ const outDir = path.join(__dirname, "../src/__test__/types/__generated__");
 fs.mkdirSync(outDir, { recursive: true });
 
 const generateFixture = (text: string, fileName: string) => {
+  const validated = validateSchema(text);
+  if (!validated.valid)
+    throw new Error(
+      `fixture schema is rejected by the CLI:\n${validated.errors
+        .map((error) => `  - ${error.message}`)
+        .join("\n")}`,
+    );
+
   const parsed = prismaReader(text);
   const relations = extractRelations(text);
   const autoincrement = extractAutoincrement(text);

--- a/packages/cli/src/__test__/types/config/autoincrementCounter.test-d.ts
+++ b/packages/cli/src/__test__/types/config/autoincrementCounter.test-d.ts
@@ -52,12 +52,15 @@ declare const anyField: string;
 
 // autoincrement を1つも持たないモデルでは呼べない
 {
-  // @ts-expect-error Enrollment に autoincrement フィールドは無い
-  client.Enrollment.$getAutoincrement("studentId");
-  // @ts-expect-error Enrollment に autoincrement フィールドは無い
-  client.Enrollment.$setAutoincrement("studentId", 1);
-  // @ts-expect-error Enrollment に autoincrement フィールドは無い
-  client.Enrollment.$syncAutoincrement("courseId");
+  expectTypeOf(client.Setting.$getAutoincrement).parameter(0).toBeNever();
+  expectTypeOf(client.Setting.$setAutoincrement).parameter(0).toBeNever();
+  expectTypeOf(client.Setting.$syncAutoincrement).parameter(0).toBeNever();
+  // @ts-expect-error Setting に autoincrement フィールドは無い
+  client.Setting.$getAutoincrement("key");
+  // @ts-expect-error Setting に autoincrement フィールドは無い
+  client.Setting.$setAutoincrement("key", 1);
+  // @ts-expect-error Setting に autoincrement フィールドは無い
+  client.Setting.$syncAutoincrement("value");
 }
 
 // トランザクション内でも読み取りは型として使える

--- a/packages/cli/src/__test__/types/fixtures/schema.prisma
+++ b/packages/cli/src/__test__/types/fixtures/schema.prisma
@@ -64,12 +64,11 @@ model Course {
 }
 
 model Enrollment {
+  id        Int     @id @default(autoincrement())
   studentId Int
   courseId  Int
   student   Student @relation(fields: [studentId], references: [id])
   course    Course  @relation(fields: [courseId], references: [id])
-
-  @@id([studentId, courseId])
 }
 
 enum Role {
@@ -96,6 +95,12 @@ model Member {
   createdAt DateTime @default(now())
 
   @@map("メンバー一覧")
+}
+
+/// autoincrement を1つも持たないモデルの検証用
+model Setting {
+  key   String @id
+  value String
 }
 
 /// @@ignore の検証用（クライアントから除外される）

--- a/packages/cli/src/__test__/validate/typeFixtureSchema.test.ts
+++ b/packages/cli/src/__test__/validate/typeFixtureSchema.test.ts
@@ -1,0 +1,15 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { validateSchema } from "../../validate/validate";
+
+const fixturePath = path.resolve(__dirname, "../types/fixtures/schema.prisma");
+
+describe("type test fixture schema", () => {
+  it("should pass the same validation as the generate/validate commands", () => {
+    const result = validateSchema(fs.readFileSync(fixturePath, "utf-8"));
+
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## 問題

#164 で `@@id` を含む非対応属性を拒否するようにしたが、**型テスト用 fixture の `Enrollment` が `@@id([studentId, courseId])` を使ったままだった。**

型 fixture は `scripts/genFixtureTypes.ts` が extractor を直接叩くため、`generateFromSchema` の先頭に入った新しいゲートを**迂回する**。そのため `test:types` は緑のまま。

つまり **利用者が `npx gassma generate` では書けないスキーマに対して、型を検証し続けていた。** 「型は通るが実行時に破綻する」の一種で、この一連の作業で潰してきたものと同じ形。

## 修正

```diff
 model Enrollment {
+  id        Int     @id @default(autoincrement())
   studentId Int
   courseId  Int
   student   Student @relation(fields: [studentId], references: [id])
   course    Course  @relation(fields: [courseId], references: [id])
-
-  @@id([studentId, courseId])
 }
```

**`String @id` のような必須 id ではなく autoincrement を選んだ**のは、`multiFkCreate.test-d.ts` の否定ケースを濁らせないため。必須 id にすると `create({ data: { studentId: 1 } })` が「id 欠落」でも落ちるようになり、`@ts-expect-error course も courseId も無い` が**別の理由で満たされてしまう**。autoincrement なら create 時に `id` が任意（実 CLI 出力で `"id"?: number` を確認）なので、検証の意図がそのまま保たれる。

- `multiFkCreate.test-d.ts` — **変更不要でパス。** 期待値が `Omit<GassmaEnrollmentUse, "studentId" | "courseId">` という生成型ベースの式なので、増えた `id?` を自動で吸収する
- `include.test-d.ts` — **変更不要でパス。** 必須 to-one 2本という前提は不変

## 併せて塞いだ空洞化

**指示範囲外だったが、`autoincrementCounter.test-d.ts` が緑のまま意味を失っていた。**

「autoincrement を1つも持たないモデルでは呼べない」ことを検証するブロックが `Enrollment` を使っており、fixture 中で autoincrement を持たない唯一のモデルだった。id を足すと `field: never` → `field: "id"` に変わるが、**`@ts-expect-error` は `"studentId"` が `"id"` に代入不可なので満たされたまま = 緑のまま検証しなくなる。**

対処として fixture に `model Setting { key String @id  value String }` を追加してこのブロックの担い手にし、さらに `expectTypeOf(...).parameter(0).toBeNever()` を追加して**空洞化を型で固定**した。

空洞化は実測で証明済み。一旦 `Enrollment` に対して `toBeNever()` を書いて `TypeCheckError: ExpectNever<"id">` を確認 → `Setting` に付け替えて緑。実 CLI 出力でも `Setting` だけが `$getAutoincrement(field: never)` になる。

## 再発防止（発生源で塞いだ）

1. **`src/__test__/validate/typeFixtureSchema.test.ts`（新規）** — fixture を `validateSchema`（= `gassma validate` の実体）に通す。`npm test` で回るので CI 信号になる
2. **`scripts/genFixtureTypes.ts` に同じ検査を追加** — **今回の穴（スクリプトがゲートを迂回していた）を発生源で塞ぐ**。`pretest:types` が落ちる。strict 版 fixture も同じ関数を通るので両方カバー

実バイナリを叩く CI ジョブも検討したが、`validateSchema` が `gassma validate` そのものなので上記で等価かつ依存ゼロと判断した。

## 検証

- `npm test` **1578件 pass**（204ファイル）／`typecheck`・`test:types`・`lint`・`format:check`・`build` OK
- **`test:types:all` は TS 5.2.2・5.6.3・5.9.3・6.0.3・7.0.2 × strict on/off の10通りすべて 0 エラー**
- **実 CLI で fixture が通ることを実測。** 修正後は `validate` → `is valid 🚀`、`generate` → 成功。対照として `origin/main` の fixture では `@@id` で拒否されることも確認（計測が空振りでない裏取り）
- **再発防止テストが本物であることを独立に確認した。** fixture に `@@id` を戻すと `typeFixtureSchema.test.ts` が確実に落ち（`@@id` on Enrollment ... is not supported）、戻すと通る
- fixture に残っていた他の非対応属性は**無し**（`@@id` 1件のみ）。`generate/fixtures/{hoge,fuga}.prisma` と `templates/` もクリーン

## 未対応（仕様判断が要る）

**gassma の `validate` / `generate` は「モデルに `@id` が無い」ことを検査していない。** 検証中に `id` 行だけを消した状態でも `validate` が通ることを実測で確認した。

#164 で `@unique` / `@@unique` / `@@id` を塞いだ結果、**Prisma 的に有効な一意識別子は `@id` だけ**になっている。にもかかわらず**その `@id` の不在は検査されない**ので、`prisma validate` では落ちるスキーマが `gassma validate` を通る。

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ