### PR TITLE
fix: accept @unique and @@unique, and reject composite foreign keys

### DIFF
--- a/packages/cli/src/__test__/generate/compositeRelation.test.ts
+++ b/packages/cli/src/__test__/generate/compositeRelation.test.ts
@@ -1,0 +1,95 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CompositeRelationError } from "../../error/mainError";
+import { generate } from "../../generate/generate";
+
+const generatorBlock = (outDir: string) => `generator client {
+  provider = "prisma-client-js"
+  output   = "${outDir}"
+}`;
+
+describe("generate with a composite foreign key", () => {
+  let tmpDir: string;
+  let schemaDir: string;
+  let outDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gassma-composite-"));
+    schemaDir = path.join(tmpDir, "gassma");
+    outDir = path.join(tmpDir, "generated");
+    fs.mkdirSync(schemaDir);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeSchema = (models: string) => {
+    const schemaPath = path.join(schemaDir, "schema.prisma");
+    fs.writeFileSync(schemaPath, `${generatorBlock(outDir)}\n\n${models}\n`);
+    return schemaPath;
+  };
+
+  it("should throw CompositeRelationError instead of generating", () => {
+    const schemaPath = writeSchema(`model Staff {
+  id        Int     @id @default(autoincrement())
+  firstName String
+  lastName  String
+  shifts    Shift[]
+
+  @@unique([firstName, lastName])
+}
+
+model Shift {
+  id             Int   @id @default(autoincrement())
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+}`);
+
+    expect(() => generate({ schema: schemaPath })).toThrow(
+      CompositeRelationError,
+    );
+    expect(fs.existsSync(outDir)).toBe(false);
+  });
+
+  it("should tell which model and field carries it", () => {
+    const schemaPath = writeSchema(`model Staff {
+  id        Int     @id @default(autoincrement())
+  firstName String
+  lastName  String
+  shifts    Shift[]
+
+  @@unique([firstName, lastName])
+}
+
+model Shift {
+  id             Int   @id @default(autoincrement())
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+}`);
+
+    expect(() => generate({ schema: schemaPath })).toThrow(/Shift\.staff/);
+  });
+
+  it("should generate from a single column relation", () => {
+    const schemaPath = writeSchema(`model Staff {
+  id     Int     @id @default(autoincrement())
+  shifts Shift[]
+}
+
+model Shift {
+  id      Int   @id @default(autoincrement())
+  staffId Int
+  staff   Staff @relation(fields: [staffId], references: [id])
+}`);
+
+    expect(() => generate({ schema: schemaPath })).not.toThrow();
+    expect(fs.existsSync(path.join(outDir, "schemaClient.js"))).toBe(true);
+  });
+});

--- a/packages/cli/src/__test__/generate/read/assertNoCompositeRelations.test.ts
+++ b/packages/cli/src/__test__/generate/read/assertNoCompositeRelations.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import { CompositeRelationError } from "../../../error/mainError";
+import { assertNoCompositeRelations } from "../../../generate/read/assertNoCompositeRelations";
+
+const compositeOneToMany = `
+model Staff {
+  id        Int     @id
+  firstName String
+  lastName  String
+  shifts    Shift[]
+
+  @@unique([firstName, lastName])
+}
+
+model Shift {
+  id             Int   @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+}
+`;
+
+describe("assertNoCompositeRelations", () => {
+  it("should reject a relation whose fields span more than one column", () => {
+    expect(() => assertNoCompositeRelations(compositeOneToMany)).toThrow(
+      CompositeRelationError,
+    );
+  });
+
+  it("should name the model and the field that carries it", () => {
+    expect(() => assertNoCompositeRelations(compositeOneToMany)).toThrow(
+      "GASsmaCompositeRelationError: `@relation` over more than one column is not supported yet.\n" +
+        "  - Shift.staff (fields: [staffFirstName, staffLastName], references: [firstName, lastName])\n" +
+        "GASsma matches a relation on a single column for now, so the columns after the first are dropped and rows that agree on the first column alone would match.\n" +
+        "Please narrow the relation to one column until composite keys are supported.",
+    );
+  });
+
+  it("should reject a composite one-to-one", () => {
+    const schema = `
+model Staff {
+  id        Int      @id
+  firstName String
+  lastName  String
+  profile   Profile?
+
+  @@unique([firstName, lastName])
+}
+
+model Profile {
+  id             Int   @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+
+  @@unique([staffFirstName, staffLastName])
+}
+`;
+    expect(() => assertNoCompositeRelations(schema)).toThrow(
+      /Profile\.staff \(fields: \[staffFirstName, staffLastName\]/,
+    );
+  });
+
+  it("should reject a relation whose references alone span more than one column", () => {
+    const schema = `
+model Staff {
+  id     Int     @id
+  code   String
+  shifts Shift[]
+}
+
+model Shift {
+  id      Int   @id
+  staffId Int
+  staff   Staff @relation(fields: [staffId], references: [id, code])
+}
+`;
+    expect(() => assertNoCompositeRelations(schema)).toThrow(
+      /references: \[id, code\]/,
+    );
+  });
+
+  it("should report every composite relation at once", () => {
+    const schema = `
+model Staff {
+  id        Int       @id
+  firstName String
+  lastName  String
+  shifts    Shift[]
+  reviews   Review[]
+}
+
+model Shift {
+  id             Int   @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+}
+
+model Review {
+  id             Int   @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+}
+`;
+    expect(() => assertNoCompositeRelations(schema)).toThrow(/Shift\.staff/);
+    expect(() => assertNoCompositeRelations(schema)).toThrow(/Review\.staff/);
+  });
+
+  it("should carry the violations on the error", () => {
+    try {
+      assertNoCompositeRelations(compositeOneToMany);
+      expect.unreachable("assertNoCompositeRelations did not throw");
+    } catch (e) {
+      if (!(e instanceof CompositeRelationError)) throw e;
+      expect(e.violations.map((violation) => violation.target)).toEqual([
+        "Shift.staff",
+      ]);
+      expect(e.violations.map((violation) => violation.columns)).toEqual([
+        "fields: [staffFirstName, staffLastName], references: [firstName, lastName]",
+      ]);
+    }
+  });
+
+  it("should say the support is still to come rather than impossible", () => {
+    expect(() => assertNoCompositeRelations(compositeOneToMany)).toThrow(
+      /not supported yet/,
+    );
+  });
+
+  it("should accept a single column relation", () => {
+    const schema = `
+model Staff {
+  id     Int     @id
+  shifts Shift[]
+}
+
+model Shift {
+  id      Int   @id
+  staffId Int
+  staff   Staff @relation(fields: [staffId], references: [id])
+}
+`;
+    expect(() => assertNoCompositeRelations(schema)).not.toThrow();
+  });
+
+  it("should accept a single column relation that carries other arguments", () => {
+    const schema = `
+model Staff {
+  id     Int     @id
+  shifts Shift[]
+}
+
+model Shift {
+  id      Int   @id
+  staffId Int
+  staff   Staff @relation("StaffShifts", fields: [staffId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+}
+`;
+    expect(() => assertNoCompositeRelations(schema)).not.toThrow();
+  });
+
+  it("should accept the inverse side that names no fields", () => {
+    const schema = `
+model Staff {
+  id     Int     @id
+  shifts Shift[] @relation("StaffShifts")
+}
+
+model Shift {
+  id      Int   @id
+  staffId Int
+  staff   Staff @relation("StaffShifts", fields: [staffId], references: [id])
+}
+`;
+    expect(() => assertNoCompositeRelations(schema)).not.toThrow();
+  });
+
+  it("should accept an implicit many-to-many", () => {
+    const schema = `
+model Post {
+  id   Int   @id
+  tags Tag[]
+}
+
+model Tag {
+  id    Int    @id
+  posts Post[]
+}
+`;
+    expect(() => assertNoCompositeRelations(schema)).not.toThrow();
+  });
+
+  it("should leave enum declarations alone", () => {
+    const schema = `
+enum Role {
+  ADMIN
+  USER
+}
+
+model Staff {
+  id   Int  @id
+  role Role
+}
+`;
+    expect(() => assertNoCompositeRelations(schema)).not.toThrow();
+  });
+});

--- a/packages/cli/src/__test__/generate/read/assertNoUnsupportedAttributes.test.ts
+++ b/packages/cli/src/__test__/generate/read/assertNoUnsupportedAttributes.test.ts
@@ -3,82 +3,67 @@ import { UnsupportedAttributeError } from "../../../error/mainError";
 import { assertNoUnsupportedAttributes } from "../../../generate/read/assertNoUnsupportedAttributes";
 
 describe("assertNoUnsupportedAttributes with @unique", () => {
-  it("should reject a field marked @unique", () => {
+  it("should accept a field marked @unique", () => {
     const schema = `
 model Staff {
   id    Int    @id
   email String @unique
 }
 `;
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(
-      UnsupportedAttributeError,
-    );
+    expect(() => assertNoUnsupportedAttributes(schema)).not.toThrow();
   });
 
-  it("should name the model and the field", () => {
+  it("should accept the @unique a one-to-one relation needs on its foreign key", () => {
     const schema = `
 model Staff {
-  id    Int    @id
-  email String @unique
+  id      Int      @id
+  profile Profile?
+}
+
+model Profile {
+  id      Int    @id
+  staffId Int    @unique
+  staff   Staff  @relation(fields: [staffId], references: [id])
 }
 `;
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(
-      "GASsmaUnsupportedAttributeError: `@unique` on Staff.email is not supported.\n" +
-        "GASsma cannot enforce uniqueness on a spreadsheet.\n" +
-        "Remove it, or check uniqueness in your code.",
-    );
+    expect(() => assertNoUnsupportedAttributes(schema)).not.toThrow();
   });
 
-  it("should report every violating field at once", () => {
+  it("should accept the @unique a relation needs to reference a field other than the id", () => {
     const schema = `
 model Staff {
-  id    Int    @id
-  email String @unique
-  code  String @unique
+  id     Int     @id
+  email  String  @unique
+  shifts Shift[]
 }
 
 model Shift {
-  id   Int    @id
-  slug String @unique
+  id         Int    @id
+  staffEmail String
+  staff      Staff  @relation(fields: [staffEmail], references: [email])
 }
 `;
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/Staff\.email/);
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/Staff\.code/);
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/Shift\.slug/);
+    expect(() => assertNoUnsupportedAttributes(schema)).not.toThrow();
   });
 
-  it("should carry the violations on the error", () => {
-    const schema = `
-model Staff {
-  id    Int    @id
-  email String @unique
-  code  String @unique
-}
-`;
-    try {
-      assertNoUnsupportedAttributes(schema);
-      expect.unreachable("assertNoUnsupportedAttributes did not throw");
-    } catch (e) {
-      if (!(e instanceof UnsupportedAttributeError)) throw e;
-      expect(e.violations.map((violation) => violation.target)).toEqual([
-        "Staff.email",
-        "Staff.code",
-      ]);
-      expect(e.violations.map((violation) => violation.attribute)).toEqual([
-        "@unique",
-        "@unique",
-      ]);
-    }
-  });
-
-  it("should reject @unique combined with other attributes", () => {
+  it("should accept @unique combined with other attributes", () => {
     const schema = `
 model Staff {
   id    Int    @id
   email String @unique @map("Email Address")
 }
 `;
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/Staff\.email/);
+    expect(() => assertNoUnsupportedAttributes(schema)).not.toThrow();
+  });
+
+  it("should still reject a native type declared next to @unique", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String @unique @db.VarChar(255)
+}
+`;
+    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/@db\.VarChar/);
   });
 
   it("should not be fooled by a field named unique", () => {
@@ -93,7 +78,7 @@ model Staff {
 });
 
 describe("assertNoUnsupportedAttributes with @@unique", () => {
-  it("should reject a model marked @@unique", () => {
+  it("should accept a model marked @@unique", () => {
     const schema = `
 model Staff {
   id    Int    @id
@@ -102,29 +87,54 @@ model Staff {
   @@unique([email])
 }
 `;
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(
-      "GASsmaUnsupportedAttributeError: `@@unique` on Staff (email) is not supported.\n" +
-        "GASsma cannot enforce uniqueness on a spreadsheet.\n" +
-        "Remove it, or check uniqueness in your code.",
-    );
+    expect(() => assertNoUnsupportedAttributes(schema)).not.toThrow();
   });
 
-  it("should list every field of the composite key", () => {
+  it("should accept the @@unique a composite one-to-many references", () => {
     const schema = `
 model Staff {
-  id    Int    @id
-  email String
-  code  String
+  id        Int     @id
+  firstName String
+  lastName  String
+  shifts    Shift[]
 
-  @@unique([email, code])
+  @@unique([firstName, lastName])
+}
+
+model Shift {
+  id             Int    @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff  @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
 }
 `;
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(
-      /Staff \(email, code\)/,
-    );
+    expect(() => assertNoUnsupportedAttributes(schema)).not.toThrow();
   });
 
-  it("should read the fields argument when it is named", () => {
+  it("should accept the @@unique a composite one-to-one needs on the defining side", () => {
+    const schema = `
+model Staff {
+  id        Int      @id
+  firstName String
+  lastName  String
+  profile   Profile?
+
+  @@unique([firstName, lastName])
+}
+
+model Profile {
+  id             Int    @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff  @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+
+  @@unique([staffFirstName, staffLastName])
+}
+`;
+    expect(() => assertNoUnsupportedAttributes(schema)).not.toThrow();
+  });
+
+  it("should accept the named fields argument", () => {
     const schema = `
 model Staff {
   id    Int    @id
@@ -133,9 +143,7 @@ model Staff {
   @@unique(fields: [email], name: "staffEmail")
 }
 `;
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(
-      /Staff \(email\)/,
-    );
+    expect(() => assertNoUnsupportedAttributes(schema)).not.toThrow();
   });
 });
 
@@ -259,7 +267,7 @@ describe("assertNoUnsupportedAttributes with @ignore", () => {
     const schema = `
 model Staff {
   id    Int    @id
-  email String @unique @ignore
+  email String @db.VarChar(255) @ignore
 }
 `;
     expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/Staff\.email/);
@@ -271,7 +279,7 @@ model Staff {
   id    Int    @id
   email String
 
-  @@unique([email])
+  @@index([email])
   @@ignore
 }
 `;
@@ -286,11 +294,12 @@ describe("assertNoUnsupportedAttributes with supported schemas", () => {
     const schema = `
 model Staff {
   id        Int      @id @default(autoincrement())
-  email     String   @map("Email Address")
+  email     String   @unique @map("Email Address")
   memo      String   @ignore
   updatedAt DateTime @updatedAt
   shifts    Shift[]
 
+  @@unique([email, memo])
   @@map("staff sheet")
 }
 
@@ -326,26 +335,49 @@ describe("assertNoUnsupportedAttributes with several attributes", () => {
   it("should report all of them in one error", () => {
     const schema = `
 model Staff {
-  id    Int    @id
-  email String @unique
-  name  String @db.VarChar(255)
+  id   Int    @id
+  name String @db.VarChar(255)
+  bio  String
 
   @@index([name])
-  @@unique([email])
+  @@fulltext([bio])
 }
 `;
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/@unique/);
     expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/@db\.VarChar/);
     expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/@@index/);
-    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/@@unique/);
+    expect(() => assertNoUnsupportedAttributes(schema)).toThrow(/@@fulltext/);
+  });
+
+  it("should carry the violations on the error", () => {
+    const schema = `
+model Staff {
+  id    Int    @id
+  email String @db.VarChar(255)
+  code  String @db.Text
+}
+`;
+    try {
+      assertNoUnsupportedAttributes(schema);
+      expect.unreachable("assertNoUnsupportedAttributes did not throw");
+    } catch (e) {
+      if (!(e instanceof UnsupportedAttributeError)) throw e;
+      expect(e.violations.map((violation) => violation.target)).toEqual([
+        "Staff.email",
+        "Staff.code",
+      ]);
+      expect(e.violations.map((violation) => violation.attribute)).toEqual([
+        "@db.VarChar",
+        "@db.Text",
+      ]);
+    }
   });
 
   it("should group the targets that share an attribute", () => {
     const schema = `
 model Staff {
   id    Int    @id
-  email String @unique
-  code  String @unique
+  email String @db.VarChar(255)
+  code  String @db.VarChar(255)
 
   @@index([email])
 }
@@ -356,11 +388,11 @@ model Staff {
     } catch (e) {
       if (!(e instanceof UnsupportedAttributeError)) throw e;
       expect(e.message).toBe(
-        "GASsmaUnsupportedAttributeError: `@unique` is not supported.\n" +
+        "GASsmaUnsupportedAttributeError: `@db.VarChar` is not supported.\n" +
           "  - Staff.email\n" +
           "  - Staff.code\n" +
-          "GASsma cannot enforce uniqueness on a spreadsheet.\n" +
-          "Remove it, or check uniqueness in your code.\n" +
+          "GASsma cannot control how a spreadsheet stores a value, so the native type has no effect.\n" +
+          "Remove it.\n" +
           "\n" +
           "`@@index` on Staff (email) is not supported.\n" +
           "GASsma cannot create an index on a spreadsheet.\n" +

--- a/packages/cli/src/__test__/generate/unsupportedAttribute.test.ts
+++ b/packages/cli/src/__test__/generate/unsupportedAttribute.test.ts
@@ -34,39 +34,43 @@ describe("generate with unsupported attributes", () => {
     return schemaPath;
   };
 
-  it("should throw UnsupportedAttributeError instead of generating", () => {
+  it("should generate from a schema that marks a field @unique", () => {
     const schemaPath = writeSchema(`model Staff {
-  id    Int    @id
+  id    Int    @id @default(autoincrement())
   email String @unique
 }`);
 
-    expect(() => generate({ schema: schemaPath })).toThrow(
-      UnsupportedAttributeError,
-    );
-    expect(fs.existsSync(outDir)).toBe(false);
+    expect(() => generate({ schema: schemaPath })).not.toThrow();
+    expect(fs.existsSync(path.join(outDir, "schemaClient.js"))).toBe(true);
   });
 
-  it("should tell which model and field carries it", () => {
+  it("should generate from the one-to-one shape Prisma requires @unique for", () => {
     const schemaPath = writeSchema(`model Staff {
-  id    Int    @id
-  email String @unique
+  id      Int      @id @default(autoincrement())
+  profile Profile?
+}
+
+model Profile {
+  id      Int   @id @default(autoincrement())
+  staffId Int   @unique
+  staff   Staff @relation(fields: [staffId], references: [id])
 }`);
 
-    expect(() => generate({ schema: schemaPath })).toThrow(/Staff\.email/);
+    expect(() => generate({ schema: schemaPath })).not.toThrow();
+    expect(fs.existsSync(path.join(outDir, "schemaClient.js"))).toBe(true);
   });
 
-  it("should reject @@unique", () => {
+  it("should generate from a schema that declares @@unique", () => {
     const schemaPath = writeSchema(`model Staff {
-  id    Int    @id
-  email String
+  id        Int    @id @default(autoincrement())
+  firstName String
+  lastName  String
 
-  @@unique([email])
+  @@unique([firstName, lastName])
 }`);
 
-    expect(() => generate({ schema: schemaPath })).toThrow(
-      UnsupportedAttributeError,
-    );
-    expect(fs.existsSync(outDir)).toBe(false);
+    expect(() => generate({ schema: schemaPath })).not.toThrow();
+    expect(fs.existsSync(path.join(outDir, "schemaClient.js"))).toBe(true);
   });
 
   it("should reject @@id", () => {

--- a/packages/cli/src/__test__/migrate/resolveOutputDir.test.ts
+++ b/packages/cli/src/__test__/migrate/resolveOutputDir.test.ts
@@ -35,6 +35,12 @@ describe("resolveOutputDir", () => {
     expect(() => resolveOutputDir(undefined, tmpDir)).toThrow("--output");
   });
 
+  it("should show the example on a subcommand that exists", () => {
+    expect(() => resolveOutputDir(undefined, tmpDir)).toThrow(
+      "npx gassma migrate dev --output ./dist",
+    );
+  });
+
   it("should throw when .clasp.json has no rootDir", () => {
     fs.writeFileSync(
       path.join(tmpDir, ".clasp.json"),

--- a/packages/cli/src/__test__/types/fixtures/schema.prisma
+++ b/packages/cli/src/__test__/types/fixtures/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 
 model User {
   id        Int      @id @default(autoincrement())
-  email     String
+  email     String   @unique
   name      String?
   age       Int?
   isActive  Boolean  @default(true)
@@ -32,7 +32,7 @@ model Post {
 model Profile {
   id     Int    @id @default(autoincrement())
   bio    String
-  userId Int
+  userId Int    @unique
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 

--- a/packages/cli/src/__test__/validate/compositeRelation.test.ts
+++ b/packages/cli/src/__test__/validate/compositeRelation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { validateSchema } from "../../validate/validate";
+
+const generatorBlock = `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated/gassma"
+}`;
+
+const messagesOf = (schema: string) =>
+  validateSchema(schema)
+    .errors.map((error) => error.message)
+    .join("\n");
+
+describe("validateSchema with a composite foreign key", () => {
+  it("should report compositeRelation", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id        Int     @id
+  firstName String
+  lastName  String
+  shifts    Shift[]
+
+  @@unique([firstName, lastName])
+}
+
+model Shift {
+  id             Int   @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+}
+`;
+    const result = validateSchema(schema);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual({
+      type: "compositeRelation",
+      message:
+        "`@relation` on Shift.staff spans more than one column " +
+        "(fields: [staffFirstName, staffLastName], references: [firstName, lastName]), " +
+        "which is not supported yet. " +
+        "GASsma matches a relation on a single column for now, so the columns after the first are dropped " +
+        "and rows that agree on the first column alone would match. " +
+        "Please narrow the relation to one column until composite keys are supported.",
+    });
+  });
+
+  it("should report one error per composite relation", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id        Int       @id
+  firstName String
+  lastName  String
+  shifts    Shift[]
+  reviews   Review[]
+}
+
+model Shift {
+  id             Int   @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+}
+
+model Review {
+  id             Int   @id
+  staffFirstName String
+  staffLastName  String
+  staff          Staff @relation(fields: [staffFirstName, staffLastName], references: [firstName, lastName])
+}
+`;
+    const compositeErrors = validateSchema(schema).errors.filter(
+      (error) => error.type === "compositeRelation",
+    );
+
+    expect(compositeErrors).toHaveLength(2);
+    expect(messagesOf(schema)).toContain("Shift.staff");
+    expect(messagesOf(schema)).toContain("Review.staff");
+  });
+
+  it("should stay valid for a single column relation", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id     Int     @id
+  shifts Shift[]
+}
+
+model Shift {
+  id      Int   @id
+  staffId Int
+  staff   Staff @relation(fields: [staffId], references: [id])
+}
+`;
+    expect(validateSchema(schema)).toEqual({ valid: true, errors: [] });
+  });
+
+  it("should stay valid for a one-to-one whose foreign key is a single @unique column", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id      Int      @id
+  profile Profile?
+}
+
+model Profile {
+  id      Int   @id
+  staffId Int   @unique
+  staff   Staff @relation(fields: [staffId], references: [id])
+}
+`;
+    expect(validateSchema(schema)).toEqual({ valid: true, errors: [] });
+  });
+});

--- a/packages/cli/src/__test__/validate/unsupportedAttribute.test.ts
+++ b/packages/cli/src/__test__/validate/unsupportedAttribute.test.ts
@@ -12,7 +12,7 @@ const messagesOf = (schema: string) =>
     .join("\n");
 
 describe("validateSchema with unsupported attributes", () => {
-  it("should report unsupportedAttribute for a field marked @unique", () => {
+  it("should stay valid for a field marked @unique", () => {
     const schema = `${generatorBlock}
 
 model Staff {
@@ -20,15 +20,38 @@ model Staff {
   email String @unique
 }
 `;
-    const result = validateSchema(schema);
+    expect(validateSchema(schema)).toEqual({ valid: true, errors: [] });
+  });
 
-    expect(result.valid).toBe(false);
-    expect(result.errors).toContainEqual(
-      expect.objectContaining({ type: "unsupportedAttribute" }),
-    );
-    const messages = result.errors.map((error) => error.message).join("\n");
-    expect(messages).toContain("Staff.email");
-    expect(messages).toContain("@unique");
+  it("should stay valid for the one-to-one shape Prisma requires @unique for", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id      Int      @id
+  profile Profile?
+}
+
+model Profile {
+  id      Int   @id
+  staffId Int   @unique
+  staff   Staff @relation(fields: [staffId], references: [id])
+}
+`;
+    expect(validateSchema(schema)).toEqual({ valid: true, errors: [] });
+  });
+
+  it("should stay valid for a model that declares @@unique", () => {
+    const schema = `${generatorBlock}
+
+model Staff {
+  id        Int    @id
+  firstName String
+  lastName  String
+
+  @@unique([firstName, lastName])
+}
+`;
+    expect(validateSchema(schema)).toEqual({ valid: true, errors: [] });
   });
 
   it("should report one error per violating target", () => {
@@ -36,33 +59,16 @@ model Staff {
 
 model Staff {
   id    Int    @id
-  email String @unique
-  code  String @unique
+  email String @db.VarChar(255)
+  code  String @db.Text
 }
 `;
     const result = validateSchema(schema);
 
-    const uniqueErrors = result.errors.filter(
+    const nativeTypeErrors = result.errors.filter(
       (error) => error.type === "unsupportedAttribute",
     );
-    expect(uniqueErrors).toHaveLength(2);
-  });
-
-  it("should report @@unique with the model and its fields", () => {
-    const schema = `${generatorBlock}
-
-model Staff {
-  id    Int    @id
-  email String
-
-  @@unique([email])
-}
-`;
-    expect(messagesOf(schema)).toContain(
-      "`@@unique` on Staff (email) is not supported. " +
-        "GASsma cannot enforce uniqueness on a spreadsheet. " +
-        "Remove it, or check uniqueness in your code.",
-    );
+    expect(nativeTypeErrors).toHaveLength(2);
   });
 
   it("should report @@id", () => {

--- a/packages/cli/src/error/mainError.ts
+++ b/packages/cli/src/error/mainError.ts
@@ -62,7 +62,7 @@ class MigrateOutputDirError extends Error {
   constructor() {
     super(
       "GASsmaMigrateOutputDirError: could not determine where to write gassma-migration.js.\n" +
-        "Pass --output <dir> (e.g. npx gassma migrate --output ./dist), " +
+        "Pass --output <dir> (e.g. npx gassma migrate dev --output ./dist), " +
         'or run in a project whose .clasp.json has "rootDir".',
     );
   }
@@ -107,6 +107,27 @@ class ThroughSheetConflictError extends Error {
         "An implicit many-to-many relation needs a through sheet of its own, so the two pairs would overwrite each other.\n" +
         'Please give one of them a different relation name, e.g. @relation("OtherName") on both sides.',
     );
+  }
+}
+
+type CompositeRelationViolation = {
+  target: string;
+  columns: string;
+  reason: string;
+};
+
+class CompositeRelationError extends Error {
+  readonly violations: CompositeRelationViolation[];
+
+  constructor(violations: CompositeRelationViolation[]) {
+    super(
+      "GASsmaCompositeRelationError: `@relation` over more than one column is not supported yet.\n" +
+        violations
+          .map((violation) => `  - ${violation.target} (${violation.columns})`)
+          .join("\n") +
+        `\n${violations[0].reason}`,
+    );
+    this.violations = violations;
   }
 }
 
@@ -164,5 +185,6 @@ export {
   IgnoredRelationColumnError,
   ThroughSheetConflictError,
   UnsupportedAttributeError,
+  CompositeRelationError,
 };
-export type { UnsupportedAttributeViolation };
+export type { UnsupportedAttributeViolation, CompositeRelationViolation };

--- a/packages/cli/src/generate/generate.ts
+++ b/packages/cli/src/generate/generate.ts
@@ -18,6 +18,7 @@ import { extractEnums } from "./read/extractEnums";
 import { extractDatasourceUrl } from "./read/extractDatasourceUrl";
 import { countModels } from "./read/countModels";
 import { assertNoUnsupportedAttributes } from "./read/assertNoUnsupportedAttributes";
+import { assertNoCompositeRelations } from "./read/assertNoCompositeRelations";
 import { prismaReader } from "./read/prismaReader";
 import { NoModelsError } from "../error/mainError";
 import { resolveSchemaFiles } from "../config/resolveSchemaFiles";
@@ -89,6 +90,7 @@ function generateFromSchema(
   datasourceUrl?: string,
 ) {
   assertNoUnsupportedAttributes(schemaText);
+  assertNoCompositeRelations(schemaText);
 
   const outputPath = extractOutputPath(schemaText);
   if (!outputPath) {

--- a/packages/cli/src/generate/read/assertNoCompositeRelations.ts
+++ b/packages/cli/src/generate/read/assertNoCompositeRelations.ts
@@ -1,0 +1,83 @@
+import {
+  findArgument,
+  findFirstAttribute,
+  type FieldDeclaration,
+  type ModelDeclaration,
+  parsePrismaSchema,
+  type SchemaArgument,
+  type SchemaExpression,
+} from "@loancrate/prisma-schema-parser";
+import {
+  CompositeRelationError,
+  type CompositeRelationViolation,
+} from "../../error/mainError";
+
+const COMPOSITE_RELATION_REASON =
+  "GASsma matches a relation on a single column for now, so the columns after the first are dropped and rows that agree on the first column alone would match.\n" +
+  "Please narrow the relation to one column until composite keys are supported.";
+
+const argumentItems = (
+  args: readonly SchemaArgument[] | undefined,
+  name: string,
+): SchemaExpression[] => {
+  const arg = findArgument(args, name);
+  if (!arg) return [];
+  return arg.expression.kind === "array" ? arg.expression.items : [];
+};
+
+const columnNameOf = (item: SchemaExpression): string[] => {
+  if (item.kind === "path") return [item.value.join(".")];
+  if (item.kind === "functionCall") return [item.path.value.join(".")];
+  return [];
+};
+
+const describeColumns = (
+  fields: SchemaExpression[],
+  references: SchemaExpression[],
+): string =>
+  `fields: [${fields.flatMap(columnNameOf).join(", ")}], ` +
+  `references: [${references.flatMap(columnNameOf).join(", ")}]`;
+
+const violationsOfField = (
+  modelName: string,
+  field: FieldDeclaration,
+): CompositeRelationViolation[] => {
+  const attribute = findFirstAttribute(field.attributes, "relation");
+  if (!attribute) return [];
+
+  const fields = argumentItems(attribute.args, "fields");
+  const references = argumentItems(attribute.args, "references");
+  if (fields.length < 2 && references.length < 2) return [];
+
+  return [
+    {
+      target: `${modelName}.${field.name.value}`,
+      columns: describeColumns(fields, references),
+      reason: COMPOSITE_RELATION_REASON,
+    },
+  ];
+};
+
+const violationsOfModel = (
+  model: ModelDeclaration,
+): CompositeRelationViolation[] =>
+  model.members.flatMap((member) =>
+    member.kind === "field" ? violationsOfField(model.name.value, member) : [],
+  );
+
+const collectCompositeRelations = (
+  schemaText: string,
+): CompositeRelationViolation[] => {
+  const ast = parsePrismaSchema(schemaText);
+  return ast.declarations.flatMap((decl) =>
+    decl.kind === "model" ? violationsOfModel(decl) : [],
+  );
+};
+
+const assertNoCompositeRelations = (schemaText: string): void => {
+  const violations = collectCompositeRelations(schemaText);
+  if (violations.length === 0) return;
+  throw new CompositeRelationError(violations);
+};
+
+export { assertNoCompositeRelations, collectCompositeRelations };

--- a/packages/cli/src/generate/read/assertNoUnsupportedAttributes.ts
+++ b/packages/cli/src/generate/read/assertNoUnsupportedAttributes.ts
@@ -11,20 +11,11 @@ import {
   type UnsupportedAttributeViolation,
 } from "../../error/mainError";
 
-const UNIQUENESS_REASON =
-  "GASsma cannot enforce uniqueness on a spreadsheet.\n" +
-  "Remove it, or check uniqueness in your code.";
-
 const NATIVE_TYPE_REASON =
   "GASsma cannot control how a spreadsheet stores a value, so the native type has no effect.\n" +
   "Remove it.";
 
-const fieldAttributeReasons = new Map<string, string>([
-  ["unique", UNIQUENESS_REASON],
-]);
-
 const blockAttributeReasons = new Map<string, string>([
-  ["unique", UNIQUENESS_REASON],
   [
     "id",
     "GASsma cannot declare a composite primary key on a spreadsheet.\n" +
@@ -73,13 +64,14 @@ const violationsOfField = (
 ): UnsupportedAttributeViolation[] =>
   (field.attributes ?? []).flatMap((attribute) => {
     const path = attribute.path.value;
-    const target = `${modelName}.${field.name.value}`;
-    if (path.length > 1)
-      return [
-        { attribute: `@${path.join(".")}`, target, reason: NATIVE_TYPE_REASON },
-      ];
-    const reason = fieldAttributeReasons.get(path[0]);
-    return reason ? [{ attribute: `@${path[0]}`, target, reason }] : [];
+    if (path.length === 1) return [];
+    return [
+      {
+        attribute: `@${path.join(".")}`,
+        target: `${modelName}.${field.name.value}`,
+        reason: NATIVE_TYPE_REASON,
+      },
+    ];
   });
 
 const violationsOfBlockAttribute = (

--- a/packages/cli/src/validate/validate.ts
+++ b/packages/cli/src/validate/validate.ts
@@ -2,6 +2,7 @@ import { parsePrismaSchema } from "@loancrate/prisma-schema-parser";
 import { IgnoredRelationColumnError } from "../error/mainError";
 import { countModelsInAst } from "../generate/read/countModels";
 import { collectUnsupportedAttributes } from "../generate/read/assertNoUnsupportedAttributes";
+import { collectCompositeRelations } from "../generate/read/assertNoCompositeRelations";
 import { extractRelations } from "../generate/read/extractRelations";
 
 type ValidationError = {
@@ -11,7 +12,8 @@ type ValidationError = {
     | "missingOutput"
     | "noModels"
     | "ignoredRelationColumn"
-    | "unsupportedAttribute";
+    | "unsupportedAttribute"
+    | "compositeRelation";
   message: string;
 };
 
@@ -43,6 +45,17 @@ const collectUnsupportedAttributeErrors = (
     type: "unsupportedAttribute",
     message:
       `\`${violation.attribute}\` on ${violation.target} is not supported. ` +
+      violation.reason.split("\n").join(" "),
+  }));
+
+const collectCompositeRelationErrors = (
+  schemaText: string,
+): ValidationError[] =>
+  collectCompositeRelations(schemaText).map((violation) => ({
+    type: "compositeRelation",
+    message:
+      `\`@relation\` on ${violation.target} spans more than one column ` +
+      `(${violation.columns}), which is not supported yet. ` +
       violation.reason.split("\n").join(" "),
   }));
 
@@ -88,6 +101,7 @@ const validateSchema = (schemaText: string): ValidationResult => {
 
     errors.push(...collectIgnoredRelationColumnErrors(schemaText));
     errors.push(...collectUnsupportedAttributeErrors(schemaText));
+    errors.push(...collectCompositeRelationErrors(schemaText));
   } catch (e) {
     errors.push({
       type: "syntax",


### PR DESCRIPTION
## 1. `@unique` / `@@unique` の拒否は誤りだった

#163 / #164 で「gassma が黙殺しているから」という理由で拒否したが、**Prisma はこれらを構造の検証に使っている。**

`npx prisma validate` で実測した4ケース:

| ケース | Prisma が要求するもの |
|---|---|
| 単一 FK の 1:1 | FK フィールドに **`@unique`** |
| 1:N で `@id` 以外を `references` | 参照先フィールドに **`@unique`** |
| 複合 FK の 1:N | 参照先モデルに **`@@unique([k1, k2])`** |
| 複合 FK の 1:1 | FK 側モデルに **`@@unique([r1, r2])`** |

**VS Code の Prisma 拡張が実際に赤いエラーを出すことを `mcp__ide__getDiagnostics` で実測した。**

```json
{ "message": "Error parsing attribute \"@relation\": A one-to-one relation must use unique fields
              on the defining side. Either add an `@unique` attribute to the field `userId`...",
  "severity": "Error", "source": "Prisma" }
```

つまり **1:1 を使うと「`@unique` を書けば `gassma generate` が落ちる／書かなければエディタが赤くなる」のどちらかを必ず踏む**状態だった。

**gassma 自身は `@unique` を一切見ていない。** 1:1 の判定は `extractRelations.ts:107` の `inverseIsListType ? "oneToMany" : "oneToOne"` で、フィールドの形だけを見ている。

### 判断基準を修正した

**「Prisma が構造の検証に使うものは通す。gassma にとっても Prisma にとっても飾りのものだけ弾く。」**

`@id` を許可しているのと同じ理屈（gassma は `@id` の一意性も強制していないが、`autoincrement()` に必須なので通している）。**「gassma が読んでいないから弾く」は誤った基準だった。**

| 属性 | 変更後 |
|---|---|
| **`@unique` / `@@unique`** | **通す** |
| `@@id` | 弾く（Prisma が要求することは無い。かつ `detectImplicitManyToMany` が `id` 列を決め打ちしているので複合主キーは gassma 側で壊れる。**弾くことが保護になる**） |
| `@@index` / `@@fulltext` / `@db.*` | 弾く |

型フィクスチャに `@unique` を戻す前後で、生成物 `client.d.ts` / `clientStrict.d.ts` が**バイト単位で同一**であることを確認済み。

**副産物**: `README.md:51` / `docs/README.ja.md:51` のクイックスタート（1:1 の FK に `@unique`）は現状 `generate` に落とされていたが、実 CLI で exit 0 を確認。**ドキュメント修正が不要になった。**

## 2. 複合 FK が黙って壊れていたので塞ぐ

`extractRelations.ts:64-65` が**先頭の要素だけ取って残りを黙って捨てていた。**

```ts
localField: fields[0],
foreignField: references[0],
```

```prisma
a A @relation(fields: [r1, r2], references: [k1, k2])
```
↓ 生成される設定（**`r2` / `k2` が消滅。エラーも警告も出ず exit 0**）
```json
"a": { "type": "manyToOne", "to": "A", "field": "r1", "reference": "k1" }
```

複合キーは2つ揃って初めて一意なので、`r1` だけで突き合わせると**本来一致しない行まで一致する**。`include` が余計な行を返し、**`onDelete: Cascade` なら関係ない行まで削除される**。データを壊す側に振れる黙殺だった。

**`@@unique` を許可に戻すとこの経路が開く**（複合 FK には `@@unique` か `@@id` が必要で、これまではどちらも拒否されていたため到達不能だった）ので、同じ PR で塞ぐ。

```
GASsmaCompositeRelationError: `@relation` over more than one column is not supported yet.
```

**文面は "not supported **yet**" で将来対応を明示している。** 本体側で複合キーの突き合わせを実装する方針が決まっており、`RelationDefinition` の `field` / `reference` を配列化してリレーション解決の全経路（`containsValue`・`collectKeys`・nested write・Cascade・N+1 対策の Map/Set 化）に手を入れる必要があるため、まず塞いだ。

**既存の `assertNoUnsupportedAttributes` には相乗りせず別検査にした。** 違反が全件 `@relation` になるので属性ごとのグルーピングが意味を成さず、かつ **`@relation` 自体はサポートされている**ので「`@relation` is not supported」という文面は誤りになるため。利用者から見た形（generate は全件まとめて1エラー・validate は1件1行）は既存と揃えてある。

## 3. `mainError.ts:65` の案内文が存在しないコマンドを指していた

#165 で `migrate` が `migrate dev` / `migrate deploy` に分割されたのに、案内文が `npx gassma migrate --output ./dist` のままだった。`migrate dev` に修正。

## 検証

- `npm test` **1665件 pass**（211ファイル）／`typecheck`・`test:types`・`lint`・`format:check`・`build` OK
- **`test:types:all` は TS 5.2.2〜7.0.2 × strict on/off の10通りすべて 0 エラー**
- **変異テスト13件すべて KILLED**（`path.length` の判定・`@@id` の削除・`@unique`/`@@unique` の再拒否・要素数判定の境界2種・`&&`→`||`・引数リストの空化・`references` の無視・各ゲートの削除・`migrate dev`→`migrate`）
- **実 CLI で12パターンを終了コードまで実測**（パイプ不使用）。私の側でも独立に再測した:

| スキーマ | generate | validate |
|---|---|---|
| 1:1 + `@unique`（Prisma が要求する形） | **0** | **0** |
| `@@unique` 単独 | **0** | **0** |
| 複合 FK | 1 | 1 |
| `@@id` | 1 | 1 |

- **Prisma 拡張の赤線が消えることを実測。** 同じ 1:1 スキーマに `@unique` を足すと `mcp__ide__getDiagnostics` の診断がゼロになる

## 判断が要る点

**`templates/schema.with-model.prisma.template` の `User.email` に `@unique` を戻していない。** このテンプレのモデルはリレーションを持たないので、`@unique` は Prisma にとっても飾りであり、gassma は一意性を強制しない。**bootstrap の最初の教材に効かない制約を書くのは #163 が潰そうとした黙殺そのもの**という判断。**1行で戻せるので、異論があれば戻す。**

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ