### PR TITLE
fix: stop reporting column drops for a model without columns

### DIFF
--- a/packages/cli/src/__test__/migrate/findDrops.test.ts
+++ b/packages/cli/src/__test__/migrate/findDrops.test.ts
@@ -59,6 +59,34 @@ describe("findDrops", () => {
     ]);
   });
 
+  it("should find nothing when the schema declares a model without columns", () => {
+    const models = [
+      { name: "User", columns: [] },
+      { name: "Memo", columns: ["id", "body"] },
+    ];
+
+    expect(findDrops(recorded, models)).toEqual([]);
+  });
+
+  it("should find the sheet when a model without columns is removed from the schema", () => {
+    const models = [{ name: "Memo", columns: ["id", "body"] }];
+
+    expect(findDrops(recorded, models)).toEqual([
+      { kind: "sheet", sheet: "User" },
+    ]);
+  });
+
+  it("should keep finding the columns of other models beside one without columns", () => {
+    const models = [
+      { name: "User", columns: [] },
+      { name: "Memo", columns: ["id"] },
+    ];
+
+    expect(findDrops(recorded, models)).toEqual([
+      { kind: "column", sheet: "Memo", column: "body" },
+    ]);
+  });
+
   it("should find nothing when the schema renamed nothing but reordered columns", () => {
     const models = [
       { name: "Memo", columns: ["body", "id"] },

--- a/packages/cli/src/__test__/migrate/migrateDevCommand.test.ts
+++ b/packages/cli/src/__test__/migrate/migrateDevCommand.test.ts
@@ -732,6 +732,25 @@ model User {
       expect(readStub()).toContain("Memo");
     });
 
+    it("should not ask when a model no longer declares any column", async () => {
+      writeSchema(schemaWithMemo);
+      await migrateDev({ output: "./out" }, fixedDeps);
+      writeSchema(`${schemaWithDatasource}
+model Memo {
+}
+`);
+      const output = createOutput();
+
+      await migrateDev(
+        { output: "./out" },
+        answerDeps("y\n", { output: output.stream }),
+      );
+
+      expect(output.text()).toBe("");
+      expect(readStub()).toContain('{ name: "Memo", columns: [] }');
+      expect(readStub()).not.toContain("acceptDataLoss");
+    });
+
     it("should not ask on the first migration", async () => {
       writeSchema(schemaWithDatasource);
       const output = createOutput();

--- a/packages/cli/src/migrate/findDrops.ts
+++ b/packages/cli/src/migrate/findDrops.ts
@@ -14,6 +14,7 @@ const findDrops = (
   return recorded.models.flatMap((model): Drop[] => {
     const columns = current.get(model.name);
     if (columns === undefined) return [{ kind: "sheet", sheet: model.name }];
+    if (columns.length === 0) return [];
 
     const kept = new Set(columns);
     return model.columns


### PR DESCRIPTION
## 不具合: `migrate dev` の確認が嘘をつく

**モデルからフィールドを全部消すと「これらの列が削除されます」と確認を求めるのに、実際には1列も削除されない。**

`findDrops` は前回の証跡の列と現在の列を比べるので、現在の `columns` が空だと**前回の全列が「消える」と判定される**。

```ts
const kept = new Set(columns);            // columns が [] なら kept は空
return model.columns
  .filter((column) => !kept.has(column))  // → 前回の全列が Drop になる
```

ところが**本体 gassma #231（マージ済み）で、`columns` が空のモデルはそのシートの列に一切触らなくなった**（`acceptDataLoss` が true でも削除しない）。

利用者は**存在しない削除について確認を求められ、y と答えても何も起きない。**

**「消えると言って消さない」**は、この一連の作業で潰してきた**「消さないと言って消す」の裏返し**。確認の信頼性が損なわれる。

## 修正

```diff
 if (columns === undefined) return [{ kind: "sheet", sheet: model.name }];
+if (columns.length === 0) return [];
```

**ガードはシート判定の直後に置いた。** `columns === undefined`（＝スキーマからモデルごと消えた）はシート削除の判定で、本体でいえば別経路にあたる。**手前に置くとシート削除まで黙殺してしまう。**

条件は本体 `migrateSheets.ts` のガードと同一（`columns.length === 0`）。

## 検証

- `npm test` **1669件 pass**（211ファイル、新規4件）／`lint`・`format:check`・`build` OK
- **変異テスト3種すべて検知。私の側でも独立に再測した**

| 変異 | 落ちたテスト |
|---|---|
| ガードを削除 | **3件** |
| **ガードをシート判定の前に移動** | **24件** |
| 境界を広げる（`length <= 1`） | 4件 |

**2番目が重要。** 「シート削除は今までどおり報告する」が実際に固定できていることの証拠になっている。

### 実 CLI 実測（終了コードはパイプ不使用）

| シナリオ | 修正前 | 修正後 |
|---|---|---|
| `Memo` のフィールドを全部消す | exit **1**、`column "id" in sheet "Memo"` などを削除すると警告 | exit **0**、確認なし、スタブは `acceptDataLoss` なし・`{ name: "Memo", columns: [] }` |
| `Memo` をスキーマから削除 | — | exit **1**、`sheet "Memo"` を報告（**従来どおり**） |

非 TTY 環境では確認が出ると `MigrateConfirmationRequiredError` で exit 1 になるので、それが「確認が出たか」の判別として機能している。

### `columns: []` が本当に生成されうるかを先に実測した

`model Memo { }`（空のボディ）と、リレーションのみのモデル（`model Memo { users User[] }`）の**両方**で `buildMigrateModels` が `columns: []` を返す。テストは前者を使った（後者は多対多の中間シートも同時に生成されるため）。

## 仕様追加はしていない

`dataLossConfirmation.ts` / `migrateDevCommand.ts` は無変更。削除ゼロ経路（`acceptDataLoss: false` でスタブ生成）が既存のまま通ることを実 CLI とテストで確認しただけ。

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ