### PR TITLE
chore: release 3.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gassma",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "GASsma is Google Apps Script(GAS) of SpreadSheet library that can be used like prisma.",
   "types": "index.d.ts",
   "bin": {


### PR DESCRIPTION
`packages/cli/package.json` を 2.0.0 → **3.0.0** に上げる。

## なぜメジャーか

2.0.0 以降に**破壊的変更が3種類**入っている。パッチやマイナーとして出すと `^2.0.0` で入れている人が黙って壊れる。

| 変更 | PR |
|---|---|
| **`gassma migrate` → `gassma migrate dev`**。`--accept-data-loss` も `migrate` から廃止（`db push` には残る） | #165 |
| **`@@id` / `@@index` / `@@fulltext` / `@db.*` / 複合 FK を拒否**。今まで通っていたスキーマが `generate` で落ちる | #164, #167 |
| **生成クライアントが `lock` を渡す**。**ライブラリ版 9 が必要**で、版 8 との組み合わせでは動かない | #159 |

本体も v8 → **v9** に上げており、**「本体 v9 と CLI 3.x が対」**という対応になる。

## `@gassma/gas-esbuild-plugin` は 0.1.0 のまま

0.1.0 の公開以降に変更が無いため据え置く。bootstrap テンプレートの `^0.1.0` もそのまま。

テンプレートの `"gassma": ""` は `patchPackageJson` が `getVersion()`（CLI 自身の版）で埋めるので、**テンプレートの編集は不要**。

## 検証

`npm test` **1669件 pass**／`build` OK。

## リリースノート

`LLM/release/v3-cli.md` に用意済み（gassma 本体リポジトリ側、gitignore 対象）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ