### PR TITLE
fix: treat blank datasource urls as unset when resolving the studio url

### DIFF
--- a/packages/cli/src/__test__/generate/configOption.test.ts
+++ b/packages/cli/src/__test__/generate/configOption.test.ts
@@ -76,6 +76,55 @@ describe("generate with --config", () => {
     expect(clientJs).toContain(`id: "configSheetId123"`);
   });
 
+  it("should not emit a spreadsheet id when datasource.url in the config is empty", () => {
+    fs.writeFileSync(
+      path.join(confDir, "schemas", "main.prisma"),
+      schemaText(outDir),
+    );
+    fs.writeFileSync(
+      path.join(confDir, "custom.config.ts"),
+      `export default {
+  schema: "schemas/main.prisma",
+  datasource: { url: "" },
+};`,
+    );
+
+    generate({ config: "conf/custom.config.ts" });
+
+    const clientJs = fs.readFileSync(
+      path.join(outDir, "mainClient.js"),
+      "utf-8",
+    );
+    expect(clientJs).not.toContain("id:");
+  });
+
+  it("should not emit a spreadsheet id when the schema datasource url is empty", () => {
+    fs.writeFileSync(
+      path.join(confDir, "schemas", "main.prisma"),
+      `datasource db {
+  provider = "gassma"
+  url      = ""
+}
+
+${schemaText(outDir)}`,
+    );
+    fs.writeFileSync(
+      path.join(confDir, "custom.config.ts"),
+      `export default {
+  schema: "schemas/main.prisma",
+  datasource: { url: "configSheetId123" },
+};`,
+    );
+
+    generate({ config: "conf/custom.config.ts" });
+
+    const clientJs = fs.readFileSync(
+      path.join(outDir, "mainClient.js"),
+      "utf-8",
+    );
+    expect(clientJs).not.toContain("id:");
+  });
+
   it("should throw ConfigFileNotFoundError when --config does not exist", () => {
     expect(() => generate({ config: "conf/missing.config.ts" })).toThrow(
       ConfigFileNotFoundError,

--- a/packages/cli/src/__test__/studio/resolveStudioUrl.test.ts
+++ b/packages/cli/src/__test__/studio/resolveStudioUrl.test.ts
@@ -156,14 +156,12 @@ describe("resolveStudioUrl", () => {
     );
   });
 
-  it("should fall back to the clasp parentId when datasource.url in the config is blank", () => {
+  it("should throw NoDatasourceUrlError when datasource.url in the config is blank", () => {
     writeSchema(SCHEMA_WITHOUT_URL);
     writeConfig(`export default { datasource: { url: "   " } };`);
     writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
 
-    expect(resolveStudioUrl()).toBe(
-      "https://docs.google.com/spreadsheets/d/claspId123/edit",
-    );
+    expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
   });
 
   it("should fall back to the config datasource url when the schema datasource url is empty", () => {
@@ -184,13 +182,11 @@ describe("resolveStudioUrl", () => {
     );
   });
 
-  it("should fall back to the clasp parentId when the schema datasource url is blank", () => {
+  it("should throw NoDatasourceUrlError when the schema datasource url is blank", () => {
     writeSchema(schemaWithUrl("   "));
     writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
 
-    expect(resolveStudioUrl()).toBe(
-      "https://docs.google.com/spreadsheets/d/claspId123/edit",
-    );
+    expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
   });
 
   it("should skip empty schema and config urls before reaching the clasp parentId", () => {

--- a/packages/cli/src/__test__/studio/resolveStudioUrl.test.ts
+++ b/packages/cli/src/__test__/studio/resolveStudioUrl.test.ts
@@ -50,6 +50,10 @@ describe("resolveStudioUrl", () => {
     fs.writeFileSync(path.join(tmpDir, ".clasp.json"), content);
   };
 
+  const writeConfig = (content: string) => {
+    fs.writeFileSync(path.join(tmpDir, "gassma.config.ts"), content);
+  };
+
   it("should resolve a full URL from the schema datasource block", () => {
     const url = "https://docs.google.com/spreadsheets/d/schemaId123/edit";
     writeSchema(schemaWithUrl(url));
@@ -67,10 +71,7 @@ describe("resolveStudioUrl", () => {
 
   it("should fall back to datasource.url in gassma.config.ts", () => {
     writeSchema(SCHEMA_WITHOUT_URL);
-    fs.writeFileSync(
-      path.join(tmpDir, "gassma.config.ts"),
-      `export default { datasource: { url: "configId456" } };`,
-    );
+    writeConfig(`export default { datasource: { url: "configId456" } };`);
 
     expect(resolveStudioUrl()).toBe(
       "https://docs.google.com/spreadsheets/d/configId456/edit",
@@ -79,10 +80,7 @@ describe("resolveStudioUrl", () => {
 
   it("should prefer the schema datasource url over the config", () => {
     writeSchema(schemaWithUrl("schemaId123"));
-    fs.writeFileSync(
-      path.join(tmpDir, "gassma.config.ts"),
-      `export default { datasource: { url: "configId456" } };`,
-    );
+    writeConfig(`export default { datasource: { url: "configId456" } };`);
 
     expect(resolveStudioUrl()).toBe(
       "https://docs.google.com/spreadsheets/d/schemaId123/edit",
@@ -109,10 +107,7 @@ describe("resolveStudioUrl", () => {
 
   it("should prefer the config datasource url over the clasp parentId", () => {
     writeSchema(SCHEMA_WITHOUT_URL);
-    fs.writeFileSync(
-      path.join(tmpDir, "gassma.config.ts"),
-      `export default { datasource: { url: "configId456" } };`,
-    );
+    writeConfig(`export default { datasource: { url: "configId456" } };`);
     writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
 
     expect(resolveStudioUrl()).toBe(
@@ -149,6 +144,85 @@ describe("resolveStudioUrl", () => {
     expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
     expect(() => resolveStudioUrl()).toThrow(/GASsmaNoDatasourceUrlError/);
     expect(() => resolveStudioUrl()).toThrow(/\.clasp\.json/);
+  });
+
+  it("should fall back to the clasp parentId when datasource.url in the config is empty", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    writeConfig(`export default { datasource: { url: "" } };`);
+    writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/claspId123/edit",
+    );
+  });
+
+  it("should fall back to the clasp parentId when datasource.url in the config is blank", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    writeConfig(`export default { datasource: { url: "   " } };`);
+    writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/claspId123/edit",
+    );
+  });
+
+  it("should fall back to the config datasource url when the schema datasource url is empty", () => {
+    writeSchema(schemaWithUrl(""));
+    writeConfig(`export default { datasource: { url: "configId456" } };`);
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/configId456/edit",
+    );
+  });
+
+  it("should fall back to the clasp parentId when the schema datasource url is empty", () => {
+    writeSchema(schemaWithUrl(""));
+    writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/claspId123/edit",
+    );
+  });
+
+  it("should fall back to the clasp parentId when the schema datasource url is blank", () => {
+    writeSchema(schemaWithUrl("   "));
+    writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/claspId123/edit",
+    );
+  });
+
+  it("should skip empty schema and config urls before reaching the clasp parentId", () => {
+    writeSchema(schemaWithUrl(""));
+    writeConfig(`export default { datasource: { url: "" } };`);
+    writeClaspJson(JSON.stringify({ parentId: "claspId123" }));
+
+    expect(resolveStudioUrl()).toBe(
+      "https://docs.google.com/spreadsheets/d/claspId123/edit",
+    );
+  });
+
+  it("should throw NoDatasourceUrlError when every candidate is empty", () => {
+    writeSchema(schemaWithUrl(""));
+    writeConfig(`export default { datasource: { url: "" } };`);
+    writeClaspJson(JSON.stringify({ parentId: "" }));
+
+    expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
+  });
+
+  it("should throw NoDatasourceUrlError when the clasp parentId is blank", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    writeClaspJson(JSON.stringify({ parentId: "   " }));
+
+    expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
+  });
+
+  it("should throw NoDatasourceUrlError when the array parentId holds a blank id", () => {
+    writeSchema(SCHEMA_WITHOUT_URL);
+    writeClaspJson(JSON.stringify({ parentId: ["   "] }));
+
+    expect(() => resolveStudioUrl()).toThrow(NoDatasourceUrlError);
   });
 
   it("should resolve from a config given by the config option", () => {

--- a/packages/cli/src/studio/resolveStudioUrl.ts
+++ b/packages/cli/src/studio/resolveStudioUrl.ts
@@ -10,16 +10,20 @@ type StudioUrlOptions = {
   config?: string;
 };
 
+const configured = (value: string | null | undefined): string | undefined =>
+  typeof value === "string" && value.trim() !== "" ? value : undefined;
+
 const resolveStudioUrl = (options?: StudioUrlOptions): string => {
   const files = resolveSchemaFiles({ config: options?.config });
   const schemaText = mergeSchemaFiles(files.map((f) => f.filePath));
   const loaded = loadConfig(options?.config);
-  const urlOrId =
-    extractDatasourceUrl(schemaText) ??
-    loaded?.config.datasource?.url ??
-    readClaspParentId(process.cwd());
+  const candidate =
+    configured(extractDatasourceUrl(schemaText)) ??
+    configured(loaded?.config.datasource?.url) ??
+    configured(readClaspParentId(process.cwd()));
 
-  if (urlOrId === undefined || urlOrId === null) {
+  const urlOrId = configured(candidate);
+  if (urlOrId === undefined) {
     throw new NoDatasourceUrlError();
   }
 

--- a/packages/cli/src/studio/resolveStudioUrl.ts
+++ b/packages/cli/src/studio/resolveStudioUrl.ts
@@ -10,20 +10,16 @@ type StudioUrlOptions = {
   config?: string;
 };
 
-const configured = (value: string | null | undefined): string | undefined =>
-  typeof value === "string" && value.trim() !== "" ? value : undefined;
-
 const resolveStudioUrl = (options?: StudioUrlOptions): string => {
   const files = resolveSchemaFiles({ config: options?.config });
   const schemaText = mergeSchemaFiles(files.map((f) => f.filePath));
   const loaded = loadConfig(options?.config);
-  const candidate =
-    configured(extractDatasourceUrl(schemaText)) ??
-    configured(loaded?.config.datasource?.url) ??
-    configured(readClaspParentId(process.cwd()));
+  const urlOrId =
+    extractDatasourceUrl(schemaText) ||
+    loaded?.config.datasource?.url ||
+    readClaspParentId(process.cwd());
 
-  const urlOrId = configured(candidate);
-  if (urlOrId === undefined) {
+  if (!urlOrId || urlOrId.trim() === "") {
     throw new NoDatasourceUrlError();
   }
 


### PR DESCRIPTION
## 不具合（利用者からの報告）

`npx gassma studio` が**空の URL を開こうとする。**

```
$ npx gassma studio
🚀 Opening https://docs.google.com/spreadsheets/d//edit
終了コード = 0
```

`.clasp.json` に `parentId` があるのに使われない。**しかも終了コードは 0** で、失敗として扱われない。

## 原因

`??` は `null` と `undefined` しか拾わない。**空文字列は「値がある」と判定されて素通りする。**

```ts
const urlOrId =
  extractDatasourceUrl(schemaText) ??
  loaded?.config.datasource?.url ??     // "" は ?? を通り抜ける
  readClaspParentId(process.cwd());     // ← 到達しない

if (urlOrId === undefined || urlOrId === null) {  // "" を弾かない
  throw new NoDatasourceUrlError();
}
return buildSpreadsheetUrl("");                    // → .../d//edit
```

**フォールバックの連鎖が最初の1段で止まり、最終ガードも通り抜けていた。**

### 影響範囲は報告された1プロジェクトではない

**`gassma bootstrap` が生成する `gassma.config.ts` のテンプレートが `url: ""` を出力する。**

```ts
export default defineConfig({
  schema: "gassma/schema.prisma",
  datasource: {
    url: "",
  },
});
```

つまり **bootstrap で作った全プロジェクトがこの経路を踏み、#160 で足した `.clasp.json` フォールバックが一度も発火しない。** 機能が本来の対象者に対して死んでいた。

## 修正

**`??` を `||` にする。** それだけ。

```diff
 const urlOrId =
-  extractDatasourceUrl(schemaText) ??
-  loaded?.config.datasource?.url ??
+  extractDatasourceUrl(schemaText) ||
+  loaded?.config.datasource?.url ||
   readClaspParentId(process.cwd());

-if (urlOrId === undefined || urlOrId === null) {
+if (!urlOrId || urlOrId.trim() === "") {
   throw new NoDatasourceUrlError();
 }
```

**候補は全部 `string | null | undefined` なので、falsy な文字列は `""` しかない。** `||` で過不足なく落ちる。正規化用のヘルパーを挟む案も試したが、この型の範囲では `||` と同じ結果になるだけの不要な抽象だったのでやめた。

`trim()` は**最終ガードだけ**に残した。空白のみが書かれていたときに `.../d/   /edit` を開かないため。空白のみは次の候補へ落とさず**エラーで止める** — 「URL でないものが書かれている」と伝えるほうが、黙って別の場所を見に行くより素直だと判断した。

**`templates/gassma.config.ts.template` は変更していない。** `url: ""` は「ここに書いてください」という placeholder として妥当で、直すべきは受け取る側。

**`extractDatasourceUrl` / `loadConfig` 側は触っていない。** そこで正規化すると `generate` の挙動が変わる（`generate.ts:63` も同じ `??` 連鎖なので、「スキーマ `url = ""` + config に URL あり」で config の ID が埋め込まれるようになる）。studio の不具合修正の範囲外の仕様変更なので入れなかった。

## 検証

- `npm test` **1680件 pass**（211ファイル、新規11件）／`typecheck`・`lint`・`format:check`・`build` OK
- **実プロジェクトで end-to-end 確認。私の側でも独立に再測した**

```
修正前: https://docs.google.com/spreadsheets/d//edit
修正後: https://docs.google.com/spreadsheets/d/1O9fYIwTIuIiVXNuSBsEnBNBXBp84BowJ9jYtj1kpWgY/edit
```

`.clasp.json` が無い場合は `GASsmaNoDatasourceUrlError` で **exit 1**（従来は空 URL で exit 0）。

- **`||` を `??` に戻すとテストが4件落ちる**ので、退行を検知できる

### `generate` が変わっていないことを固定した

`configOption.test.ts` に2件追加（config `url: ""` / スキーマ `url = ""` + config に URL あり、どちらも生成 JS に `id:` が出ない）。**`extractDatasourceUrl` を空文字→`null` に正規化する変異を入れるとこのテストが落ちる**ので、うっかり generate 側を変えた場合に検知できる。

## 未対応（報告のみ）

**`generate` にも同じ `??` 空文字問題が残っている。** `generate.ts:63` はスキーマに `url = ""` があると config の URL に落ちない。今は `generateClientJs` の `if (datasourceUrl)` に救われて実害ゼロ（ID が埋まらないだけ）なので、仕様変更を避けて**現状のまま固定するテストを追加**した。

**値が入っている候補は trim していない。** `url: "  abc  "` はそのまま。「空白のみは未設定扱い」だけが対象で、値のトリムは仕様追加と判断した。

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ
