### PR TITLE
feat: check the GAS library version in the debug appsscript section

### DIFF
--- a/packages/cli/src/__test__/debug/appsscriptSection.test.ts
+++ b/packages/cli/src/__test__/debug/appsscriptSection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { GASSMA_LIBRARY } from "../../bootstrap/const/gassmaLibrary";
 import type { DebugFs } from "../../debug/env/debugFs";
 import {
   buildAppsscriptLines,
@@ -10,6 +11,15 @@ const plain = createStyler(false);
 
 const GASSMA_LIBRARY_ID =
   "1ZVuWMUYs4hVKDCcP3nVw74AY48VqLm50wRceKIQLFKL0wf4Hyou-FIBH";
+
+const EXPECTED_VERSION = GASSMA_LIBRARY.version;
+
+const versionMismatchNote =
+  `(expected \`${EXPECTED_VERSION}\` — this CLI targets library ` +
+  `v${EXPECTED_VERSION}; other versions can fail at runtime)`;
+
+const developmentModeNote =
+  "(ignored — developmentMode is true, so the library HEAD is used)";
 
 const fakeFs = (files: Record<string, string>): DebugFs => ({
   exists: (filePath) => filePath in files,
@@ -184,7 +194,11 @@ describe("buildAppsscriptLines", () => {
         kind: "found",
         manifestPath: "/proj/dist/appsscript.json",
         runtimeVersion: "V8",
-        library: { userSymbol: "Gassma", version: "0", developmentMode: true },
+        library: {
+          userSymbol: "Gassma",
+          version: EXPECTED_VERSION,
+          developmentMode: false,
+        },
       },
       "/proj",
       plain,
@@ -196,9 +210,68 @@ describe("buildAppsscriptLines", () => {
       "runtimeVersion: V8",
       "Gassma library: found",
       "- userSymbol: Gassma",
-      "- version: 0",
-      "- developmentMode: true",
+      `- version: ${EXPECTED_VERSION}`,
+      "- developmentMode: false",
     ]);
+  });
+
+  it("should render a matching version plainly when developmentMode is absent", () => {
+    const lines = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/appsscript.json",
+        runtimeVersion: "V8",
+        library: { userSymbol: "Gassma", version: EXPECTED_VERSION },
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toContain(`- version: ${EXPECTED_VERSION}`);
+  });
+
+  it("should flag a library version mismatch", () => {
+    const lines = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/appsscript.json",
+        runtimeVersion: "V8",
+        library: { userSymbol: "Gassma", version: "1", developmentMode: false },
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toContain(`- version: 1 ${versionMismatchNote}`);
+  });
+
+  it("should not report a version mismatch when developmentMode is true", () => {
+    const lines = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/appsscript.json",
+        runtimeVersion: "V8",
+        library: { userSymbol: "Gassma", version: "1", developmentMode: true },
+      },
+      "/proj",
+      plain,
+    );
+    const unsetVersion = buildAppsscriptLines(
+      {
+        kind: "found",
+        manifestPath: "/proj/appsscript.json",
+        runtimeVersion: "V8",
+        library: { userSymbol: "Gassma", developmentMode: true },
+      },
+      "/proj",
+      plain,
+    );
+
+    expect(lines).toContain(`- version: 1 ${developmentModeNote}`);
+    expect(lines.join("\n")).not.toContain(`expected \`${EXPECTED_VERSION}\``);
+    expect(unsetVersion).toContain(
+      `- version: (not set) ${developmentModeNote}`,
+    );
   });
 
   it("should flag a userSymbol mismatch", () => {
@@ -259,7 +332,7 @@ describe("buildAppsscriptLines", () => {
       plain,
     );
 
-    expect(lines).toContain("- version: (not set)");
+    expect(lines).toContain(`- version: (not set) ${versionMismatchNote}`);
     expect(lines).toContain("- developmentMode: (not set)");
   });
 

--- a/packages/cli/src/__test__/debug/debugCommand.test.ts
+++ b/packages/cli/src/__test__/debug/debugCommand.test.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GASSMA_LIBRARY } from "../../bootstrap/const/gassmaLibrary";
 import { debugCommand } from "../../debug/debugCommand";
 import type { TimedExecFn } from "../../debug/env/execWithTimeout";
 import { getVersion } from "../../version/getVersion";
@@ -125,7 +126,10 @@ describe("debugCommand", () => {
     expect(output).toContain("-- appsscript.json --");
     expect(output).toContain(`Path: ${path.join("out", "appsscript.json")}`);
     expect(output).toContain("runtimeVersion: V8");
-    expect(output).toContain("- version: 12");
+    expect(output).toContain(
+      `- version: 12 (expected \`${GASSMA_LIBRARY.version}\` — this CLI targets ` +
+        `library v${GASSMA_LIBRARY.version}; other versions can fail at runtime)`,
+    );
     expect(output).toContain("-- Generated client --");
     expect(output).toContain("Output: generated");
     expect(output).toContain("schemaClient.js: found");

--- a/packages/cli/src/debug/sections/appsscriptSection.ts
+++ b/packages/cli/src/debug/sections/appsscriptSection.ts
@@ -109,6 +109,19 @@ const buildUserSymbolLine = (userSymbol: string | undefined): string => {
   );
 };
 
+const buildVersionLine = (library: AppsscriptLibrary): string => {
+  const expected = GASSMA_LIBRARY.version;
+  const shown = library.version ?? "(not set)";
+  if (library.developmentMode === true) {
+    return `- version: ${shown} (ignored — developmentMode is true, so the library HEAD is used)`;
+  }
+  if (library.version === expected) return `- version: ${shown}`;
+  return (
+    `- version: ${shown} ` +
+    `(expected \`${expected}\` — this CLI targets library v${expected}; other versions can fail at runtime)`
+  );
+};
+
 const buildLibraryLines = (
   library: AppsscriptLibrary | undefined,
 ): string[] => {
@@ -118,7 +131,7 @@ const buildLibraryLines = (
   return [
     "Gassma library: found",
     buildUserSymbolLine(library.userSymbol),
-    `- version: ${library.version ?? "(not set)"}`,
+    buildVersionLine(library),
     `- developmentMode: ${
       library.developmentMode === undefined
         ? "(not set)"


### PR DESCRIPTION
## 背景

#171 で `GASSMA_LIBRARY` に**この CLI が対応するライブラリ版**を持たせた。それを `gassma debug` の診断に使う。

**本体 v9 と cli 3.x は対**で、組み合わせを間違えると動かない。特に **cli 2.x のクライアント + ライブラリ v9** は `$transaction` が `GassmaTransactionLockRequiredError` で落ちるが、そのメッセージは「`lock` を渡してください」と言うだけで、**本当の原因（ライブラリの版が合っていない）を教えない。** 生成クライアントの利用者は `lock` を渡しようがないので、そこで詰まる。

## 変更

`debug` の appsscript.json セクションで、version を期待値と照合する。**同じセクションの `userSymbol` が既に同じことをしているので、それに揃えた。**

```diff
-`- version: ${library.version ?? "(not set)"}`,
+buildVersionLine(library),
```

出力は4パターン。

```
一致          - version: 9
不一致        - version: 7 (expected `9` — this CLI targets library v9; other versions can fail at runtime)
未設定        - version: (not set) (expected `9` — ...)
devMode:true  - version: 0 (ignored — developmentMode is true, so the library HEAD is used)
```

### `developmentMode` を最優先で判定する

**`developmentMode: true` のとき、`version` は無視されてライブラリの HEAD が使われる。** ここで不一致を警告するのは誤り。**gassma-test がまさにこの設定**（`version: "0"` + `developmentMode: true`）で、HEAD を見て動いている。

## 検証

- `npm test` **1661件 pass**（211ファイル、新規4パターン + E2E）／`typecheck`・`lint`・`format:check`・`build` OK
- **実 CLI で確認。私の側でも独立に再測した**

```
gassma-test（developmentMode: true）
  - version: 0 (ignored — developmentMode is true, so the library HEAD is used)

版が 7 のプロジェクト
  - version: 7 (expected `9` — this CLI targets library v9; other versions can fail at runtime)
```

**gassma-test は実行前後とも git status がクリーン**（`src/debug/` に書き込み系 API が無いことも grep で確認済み）。

- **変異テスト8件すべて KILLED**（developmentMode 分岐の削除・反転、不一致でも警告しない、常に警告する、`===`→`!==`、期待値定数の差し替え、`(not set)` フォールバック削除、等価比較を長さ比較に）

## 判断

- **exit code は変えていない**（不一致でも 0）。`debug` は診断コマンドで、現状も異常があっても正常終了する
- **テストは版を直書きせず `GASSMA_LIBRARY.version` を参照した**。版を上げるたびに debug のテストが落ちるのを避けるため。値そのものを固定するピンは `bootstrap/const/gassmaLibrary.test.ts` の1本に集約されている
- 既存テスト2件の期待値を更新した（挙動変更なので不可避）。`should render a healthy manifest` のフィクスチャは `version: "0" + developmentMode: true` だったが、「healthy = 全部一致」を示すほうが読み手に親切なので `GASSMA_LIBRARY.version + developmentMode: false` に変え、`developmentMode: true` は独立したテストに分けた
- 不一致の文言に `$transaction` などの具体的な症状名は入れず、`userSymbol` 行と同じ粒度（期待値＋理由1文）に揃えた

バージョンは上げていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ