### PR TITLE
fix: enforce groupBy orderBy constraints in generated types

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -108,6 +108,22 @@ describe("getGassmaCommonTypes", () => {
     );
   });
 
+  it("should generate GroupByOrderByFieldCheck requiring orderBy fields to be in by", () => {
+    expect(result).toContain(
+      "type GroupByOrderFields<O> = O extends readonly (infer E)[] ? GroupByOrderFields<E> : O extends object ? Exclude<keyof O, `_${string}`> & string : never;",
+    );
+    expect(result).toContain(
+      "type GroupByByFields<B> = B extends readonly (infer E)[] ? GroupByByFields<E> : B;",
+    );
+    expect(result).toContain("type GroupByStrayOrderFields<T> = Exclude<");
+    expect(result).toContain(
+      "type GroupByOrderByFieldCheck<T> = [GroupByStrayOrderFields<T>] extends [never]",
+    );
+    expect(result).toContain(
+      '`Error: Field "${P}" in "orderBy" needs to be provided in "by"`',
+    );
+  });
+
   describe("strict mode", () => {
     const strictResult = getGassmaCommonTypes(true);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -94,6 +94,20 @@ describe("getGassmaCommonTypes", () => {
     );
   });
 
+  it("should generate GroupByPaginationCheck requiring orderBy for take and skip", () => {
+    expect(result).toContain(
+      'type GroupByPaginationCheck<T, D extends { orderBy?: unknown }> = "orderBy" extends keyof T',
+    );
+    expect(result).toContain('"take" extends keyof T');
+    expect(result).toContain('"skip" extends keyof T');
+    expect(result).toContain(
+      'Required<Pick<D, "orderBy">> & \'Error: If you provide "take", you also need to provide "orderBy"\'',
+    );
+    expect(result).toContain(
+      'Required<Pick<D, "orderBy">> & \'Error: If you provide "skip", you also need to provide "orderBy"\'',
+    );
+  });
+
   describe("strict mode", () => {
     const strictResult = getGassmaCommonTypes(true);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -106,7 +106,7 @@ describe("getOneGassmaController", () => {
       `count<T extends GassmaUserCountData>(countData: ${sub("GassmaUserCountData")}): GassmaUserCountResult<T>`,
     );
     expect(result).toContain(
-      `groupBy<T extends GassmaUserGroupByData>(groupByData: ${sub("GassmaUserGroupByData")} & Gassma.GroupByPaginationCheck<T, GassmaUserGroupByData>): GassmaUserGroupByResult<T>[]`,
+      `groupBy<T extends GassmaUserGroupByData>(groupByData: ${sub("GassmaUserGroupByData")} & Gassma.GroupByPaginationCheck<T, GassmaUserGroupByData> & Gassma.GroupByOrderByFieldCheck<T>): GassmaUserGroupByResult<T>[]`,
     );
     expect(result).toContain(
       "createMany(createdData: GassmaUserCreateManyData): CreateManyReturn",

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -106,7 +106,7 @@ describe("getOneGassmaController", () => {
       `count<T extends GassmaUserCountData>(countData: ${sub("GassmaUserCountData")}): GassmaUserCountResult<T>`,
     );
     expect(result).toContain(
-      `groupBy<T extends GassmaUserGroupByData>(groupByData: ${sub("GassmaUserGroupByData")}): GassmaUserGroupByResult<T>[]`,
+      `groupBy<T extends GassmaUserGroupByData>(groupByData: ${sub("GassmaUserGroupByData")} & Gassma.GroupByPaginationCheck<T, GassmaUserGroupByData>): GassmaUserGroupByResult<T>[]`,
     );
     expect(result).toContain(
       "createMany(createdData: GassmaUserCreateManyData): CreateManyReturn",

--- a/packages/cli/src/__test__/types/aggregate/groupBy.test-d.ts
+++ b/packages/cli/src/__test__/types/aggregate/groupBy.test-d.ts
@@ -258,8 +258,9 @@ declare const client: GassmaClient;
   });
 }
 
-// groupBy: by に含まれないスカラー列は型では通る（実行時に本体が弾く）
+// groupBy: by に含まれないスカラー列ではソートできない（Prisma パリティ）
 {
+  // @ts-expect-error "age" は by に無い
   client.User.groupBy({ by: ["isActive"], orderBy: { age: "asc" } });
 }
 

--- a/packages/cli/src/__test__/types/aggregate/groupByOrderByFields.test-d.ts
+++ b/packages/cli/src/__test__/types/aggregate/groupByOrderByFields.test-d.ts
@@ -1,0 +1,134 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+import { GassmaClient as StrictClient } from "../__generated__/clientStrict";
+
+declare const client: GassmaClient;
+
+// groupBy: by に含まれない列では orderBy できない（Prisma パリティ）
+{
+  // @ts-expect-error "age" は by に無い
+  client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    orderBy: { age: "asc" },
+  });
+}
+
+// groupBy: by が単一文字列でも効く
+{
+  // @ts-expect-error "id" は by に無い
+  client.Member.groupBy({
+    by: "role",
+    _count: { id: true },
+    orderBy: { id: "asc" },
+  });
+}
+
+// groupBy: 配列 orderBy の一つでも by に無ければ拒否
+{
+  // @ts-expect-error "title" は by に無い
+  client.Post.groupBy({
+    by: ["published", "authorId"],
+    _count: { id: true },
+    orderBy: [{ published: "asc" }, { title: "asc" }],
+  });
+}
+
+// groupBy: by に含まれる列なら orderBy できる
+{
+  client.User.groupBy({ by: ["isActive"], orderBy: { isActive: "asc" } });
+  client.Member.groupBy({
+    by: "role",
+    _count: { id: true },
+    orderBy: { role: "asc" },
+  });
+  client.User.groupBy({
+    by: ["isActive", "age"],
+    orderBy: [{ isActive: "asc" }, { age: "desc" }],
+  });
+}
+
+// groupBy: 集計値の orderBy は by に無くても通る（本体 #158 / #226）
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    orderBy: { _count: { id: "desc" } },
+  });
+  client.User.groupBy({ by: ["isActive"], orderBy: { _sum: { age: "desc" } } });
+  client.User.groupBy({ by: ["isActive"], orderBy: { _avg: { age: "asc" } } });
+  client.User.groupBy({
+    by: ["isActive"],
+    orderBy: { _max: { email: "asc" } },
+  });
+  client.User.groupBy({
+    by: ["isActive"],
+    orderBy: { _min: { createdAt: "desc" } },
+  });
+}
+
+// groupBy: 集計値と by の列を混ぜた配列 orderBy も通る
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    orderBy: [{ _count: { id: "desc" } }, { isActive: "asc" }],
+  });
+}
+
+// groupBy: SortOrderInput 形式でも by に含まれていれば通る
+{
+  client.User.groupBy({
+    by: ["age"],
+    orderBy: { age: { sort: "asc", nulls: "last" } },
+  });
+}
+
+// groupBy: 2つの制約は同時に効く（by に無い列 + take）
+{
+  // @ts-expect-error "age" は by に無い
+  client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    take: 10,
+    orderBy: { age: "asc" },
+  });
+}
+
+// gassma-test の実機テストで使われている形（型エラーにならないこと）
+{
+  const posts = client.Post.groupBy({
+    by: ["published", "authorId"],
+    _count: { id: true },
+    orderBy: [{ published: "asc" }, { authorId: "asc" }],
+    take: 10,
+  });
+  expectTypeOf<(typeof posts)[number]["published"]>().toEqualTypeOf<boolean>();
+  expectTypeOf<
+    (typeof posts)[number]["_count"]["id"]
+  >().toEqualTypeOf<number>();
+
+  const members = client.Member.groupBy({
+    by: "role",
+    _count: { id: true },
+    orderBy: { _count: { id: "desc" } },
+    take: 1,
+  });
+  expectTypeOf<(typeof members)[number]["role"]>().toEqualTypeOf<
+    "ADMIN" | "USER" | "MODERATOR"
+  >();
+}
+
+// findMany / aggregate は by を持たないので影響しない
+{
+  client.User.findMany({ orderBy: { age: "asc" } });
+  client.User.aggregate({ _count: { id: true }, orderBy: { age: "asc" } });
+}
+
+// strictUndefinedChecks 生成物でも同じ制約がかかる
+{
+  const strictClient = new StrictClient();
+  // @ts-expect-error "age" は by に無い
+  strictClient.User.groupBy({ by: ["isActive"], orderBy: { age: "asc" } });
+  strictClient.User.groupBy({ by: ["isActive"], orderBy: { isActive: "asc" } });
+}

--- a/packages/cli/src/__test__/types/aggregate/groupByPagination.test-d.ts
+++ b/packages/cli/src/__test__/types/aggregate/groupByPagination.test-d.ts
@@ -1,0 +1,112 @@
+import { expectTypeOf } from "vitest";
+import type { GassmaClient } from "../__generated__/client";
+import { GassmaClient as StrictClient } from "../__generated__/clientStrict";
+
+declare const client: GassmaClient;
+
+// groupBy: take があるのに orderBy が無いと拒否（Prisma パリティ）
+{
+  // @ts-expect-error take を指定するなら orderBy も必要
+  client.User.groupBy({ by: ["isActive"], _count: { id: true }, take: 10 });
+}
+
+// groupBy: skip があるのに orderBy が無いと拒否
+{
+  // @ts-expect-error skip を指定するなら orderBy も必要
+  client.User.groupBy({ by: ["isActive"], _count: { id: true }, skip: 1 });
+}
+
+// groupBy: skip が 0 でも拒否（型はキーの有無だけを見る・Prisma パリティ）
+{
+  // @ts-expect-error skip を指定するなら orderBy も必要
+  client.User.groupBy({ by: ["isActive"], _count: { id: true }, skip: 0 });
+}
+
+// groupBy: take: undefined でも拒否（キーが書かれているため・Prisma パリティ）
+{
+  // @ts-expect-error take を指定するなら orderBy も必要
+  client.User.groupBy({ by: ["isActive"], take: undefined });
+}
+
+// groupBy: take と skip を両方書いても拒否
+{
+  // @ts-expect-error take / skip を指定するなら orderBy も必要
+  client.User.groupBy({ by: ["isActive"], take: 10, skip: 5 });
+}
+
+// groupBy: orderBy があれば take / skip を書ける
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    take: 10,
+    orderBy: { isActive: "asc" },
+  });
+  client.User.groupBy({
+    by: ["isActive"],
+    skip: 1,
+    orderBy: [{ isActive: "asc" }],
+  });
+  client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    take: 10,
+    skip: 5,
+    orderBy: { _count: { id: "desc" } },
+  });
+}
+
+// groupBy: take / skip が無ければ従来どおり orderBy は任意
+{
+  client.User.groupBy({ by: ["isActive"] });
+  client.User.groupBy({ by: ["isActive"], _count: { id: true } });
+  client.User.groupBy({
+    by: ["isActive"],
+    having: { age: { _avg: { gt: 1 } } },
+  });
+}
+
+// groupBy: take + orderBy でも結果型はこれまでどおり解決する
+{
+  const r = client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    take: 10,
+    orderBy: { _count: { id: "desc" } },
+  });
+  expectTypeOf<typeof r>().toBeArray();
+  expectTypeOf<(typeof r)[number]["isActive"]>().toEqualTypeOf<boolean>();
+  expectTypeOf<(typeof r)[number]["_count"]["id"]>().toEqualTypeOf<number>();
+}
+
+// groupBy: 制約が付いても by の誤りは引き続き検出する
+{
+  // @ts-expect-error "nonexistent" は User のフィールドでない
+  client.User.groupBy({ by: ["nonexistent"], take: 1, orderBy: { id: "asc" } });
+}
+
+// findMany: 同じ制約は無い（Prisma 実測。take だけで通る）
+{
+  client.User.findMany({ take: 10 });
+  client.User.findMany({ skip: 5 });
+  client.User.findMany({ take: 10, skip: 5 });
+  client.User.findFirst({ take: 1 });
+}
+
+// aggregate: 同じ制約は無い（Prisma 実測）
+{
+  client.User.aggregate({ _count: { id: true }, take: 10 });
+  client.User.aggregate({ _count: { id: true }, skip: 1 });
+}
+
+// strictUndefinedChecks 生成物でも同じ制約がかかる
+{
+  const strictClient = new StrictClient();
+  // @ts-expect-error take を指定するなら orderBy も必要
+  strictClient.User.groupBy({ by: ["isActive"], take: 10 });
+  strictClient.User.groupBy({
+    by: ["isActive"],
+    take: 10,
+    orderBy: { isActive: "asc" },
+  });
+}

--- a/packages/cli/src/__test__/types/nostrict/groupByPagination.test-d.ts
+++ b/packages/cli/src/__test__/types/nostrict/groupByPagination.test-d.ts
@@ -1,6 +1,6 @@
 import { GassmaClient } from "../__generated__/client";
 
-// strictNullChecks が off でも take / skip は orderBy を要求する
+// strictNullChecks が off でも groupBy の2つの制約が効く
 const client = new GassmaClient();
 
 {
@@ -14,12 +14,21 @@ const client = new GassmaClient();
 }
 
 {
+  // @ts-expect-error "age" は by に無い
+  client.User.groupBy({ by: ["isActive"], orderBy: { age: "asc" } });
+}
+
+{
   client.User.groupBy({
     by: ["isActive"],
     _count: { id: true },
     take: 10,
     orderBy: { isActive: "asc" },
   });
+  client.User.groupBy({
+    by: ["isActive"],
+    orderBy: { _count: { id: "desc" } },
+  });
   client.User.groupBy({ by: ["isActive"], _count: { id: true } });
-  client.User.findMany({ take: 10, skip: 5 });
+  client.User.findMany({ take: 10, skip: 5, orderBy: { age: "asc" } });
 }

--- a/packages/cli/src/__test__/types/nostrict/groupByPagination.test-d.ts
+++ b/packages/cli/src/__test__/types/nostrict/groupByPagination.test-d.ts
@@ -1,0 +1,25 @@
+import { GassmaClient } from "../__generated__/client";
+
+// strictNullChecks が off でも take / skip は orderBy を要求する
+const client = new GassmaClient();
+
+{
+  // @ts-expect-error take を指定するなら orderBy も必要
+  client.User.groupBy({ by: ["isActive"], _count: { id: true }, take: 10 });
+}
+
+{
+  // @ts-expect-error skip を指定するなら orderBy も必要
+  client.User.groupBy({ by: ["isActive"], skip: 0 });
+}
+
+{
+  client.User.groupBy({
+    by: ["isActive"],
+    _count: { id: true },
+    take: 10,
+    orderBy: { isActive: "asc" },
+  });
+  client.User.groupBy({ by: ["isActive"], _count: { id: true } });
+  client.User.findMany({ take: 10, skip: 5 });
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -117,6 +117,15 @@ const getGassmaCommonTypes = (strict?: boolean) => {
       : "skip" extends keyof T
         ? Required<Pick<D, "orderBy">> & 'Error: If you provide "skip", you also need to provide "orderBy"'
         : unknown;
+  type GroupByOrderFields<O> = O extends readonly (infer E)[] ? GroupByOrderFields<E> : O extends object ? Exclude<keyof O, \`_\${string}\`> & string : never;
+  type GroupByByFields<B> = B extends readonly (infer E)[] ? GroupByByFields<E> : B;
+  type GroupByStrayOrderFields<T> = Exclude<
+    GroupByOrderFields<T extends { orderBy: infer O } ? O : never>,
+    GroupByByFields<T extends { by: infer B } ? B : never>
+  >;
+  type GroupByOrderByFieldCheck<T> = [GroupByStrayOrderFields<T>] extends [never]
+    ? unknown
+    : { [P in GroupByStrayOrderFields<T>]: \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\` }[GroupByStrayOrderFields<T>];
   type ExactKeys<T, Shape> = Shape & { [K in Exclude<keyof T, keyof Shape>]?: never };
   type StrictGlobalOmit<O, Config> = Config & {
     [K in keyof O]?: K extends keyof Config

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -110,6 +110,13 @@ const getGassmaCommonTypes = (strict?: boolean) => {
       : Omit<Base, keyof ActiveComputed<C, QO>> & ActiveComputed<C, QO>;
 
   type Subset<T, U> = { [K in keyof T]: K extends keyof U ? T[K] : never };
+  type GroupByPaginationCheck<T, D extends { orderBy?: unknown }> = "orderBy" extends keyof T
+    ? unknown
+    : "take" extends keyof T
+      ? Required<Pick<D, "orderBy">> & 'Error: If you provide "take", you also need to provide "orderBy"'
+      : "skip" extends keyof T
+        ? Required<Pick<D, "orderBy">> & 'Error: If you provide "skip", you also need to provide "orderBy"'
+        : unknown;
   type ExactKeys<T, Shape> = Shape & { [K in Exclude<keyof T, keyof Shape>]?: never };
   type StrictGlobalOmit<O, Config> = Config & {
     [K in keyof O]?: K extends keyof Config

--- a/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -58,7 +58,7 @@ ${docs.deleteManyNoArgs}  deleteMany(): DeleteManyReturn;
 ${docs.aggregate}  aggregate<T extends ${self}AggregateData>(aggregateData: T & Gassma.Subset<T, ${self}AggregateData>): ${self}AggregateResult<T>;
 ${docs.count}  count<T extends ${self}CountData>(countData: T & Gassma.Subset<T, ${self}CountData>): ${self}CountResult<T>;
 ${docs.countNoArgs}  count(): number;
-${docs.groupBy}  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData> & Gassma.GroupByPaginationCheck<T, ${self}GroupByData>): ${self}GroupByResult<T>[];
+${docs.groupBy}  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData> & Gassma.GroupByPaginationCheck<T, ${self}GroupByData> & Gassma.GroupByOrderByFieldCheck<T>): ${self}GroupByResult<T>[];
 ${docs.getAutoincrement}  $getAutoincrement(field: ${counterField}): number;
 ${docs.setAutoincrement}  $setAutoincrement(field: ${counterField}, next: number): void;
 ${docs.syncAutoincrement}  $syncAutoincrement(field: ${counterField}): number;

--- a/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -58,7 +58,7 @@ ${docs.deleteManyNoArgs}  deleteMany(): DeleteManyReturn;
 ${docs.aggregate}  aggregate<T extends ${self}AggregateData>(aggregateData: T & Gassma.Subset<T, ${self}AggregateData>): ${self}AggregateResult<T>;
 ${docs.count}  count<T extends ${self}CountData>(countData: T & Gassma.Subset<T, ${self}CountData>): ${self}CountResult<T>;
 ${docs.countNoArgs}  count(): number;
-${docs.groupBy}  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData>): ${self}GroupByResult<T>[];
+${docs.groupBy}  groupBy<T extends ${self}GroupByData>(groupByData: T & Gassma.Subset<T, ${self}GroupByData> & Gassma.GroupByPaginationCheck<T, ${self}GroupByData>): ${self}GroupByResult<T>[];
 ${docs.getAutoincrement}  $getAutoincrement(field: ${counterField}): number;
 ${docs.setAutoincrement}  $setAutoincrement(field: ${counterField}, next: number): void;
 ${docs.syncAutoincrement}  $syncAutoincrement(field: ${counterField}): number;


### PR DESCRIPTION
## 概要

生成型の `groupBy` に、本体（実行時）が強制している制約が**2つとも**ありませんでした。どちらも `tsc` を通ってしまい、実機で初めて落ちます。この PR で両方を型で弾きます。

| # | 制約 | 実行時に出るエラー |
|---|---|---|
| 1 | `take` / `skip` を使うなら `orderBy` が必要 | `GassmaGroupByOrderByRequiredError` |
| 2 | `orderBy` の列は `by` に含まれていなければならない | `GassmaUnknownArgumentError` |

**1件目は実際にこれで実機テストが落ちました。**

```ts
client.Post.groupBy({ by: ["published", "authorId"], _count: { id: true }, take: 10 }); // ← orderBy が無い
```

```
GassmaGroupByOrderByRequiredError: groupBy requires `orderBy` when using `take`.
  Specify `orderBy` with at least one field, or remove `take`.
```

**2件目は現行 HEAD で実測して確認しました。**

```ts
client.User.groupBy({ by: "role", _count: { id: true }, orderBy: { id: "asc" } }); // "id" は by に無い
```

本体の `src/util/groupby/groubyUtil/groupOrderByKeys.ts` の `buildFieldSortKey` が `by.includes(field)` で判定し、実行時に `GassmaUnknownArgumentError` を投げます（本体ユニットテスト `groupbyPipeline.test.ts` に固定済み）。

`tsc` が通ってしまう以上、利用者は GAS にデプロイして実行するまで気付けません。Prisma はどちらも**型で**弾いているので、そこに合わせます。

## Prisma の挙動（prisma-test で実測）

Prisma は引数の型に「**必要な `orderBy` の形**」と「**エラーメッセージの文字列リテラル型**」を交差させることで、型レベルで強制しています。文字列リテラルを混ぜているのは、TS のエラー本文に理由を出すためです。

### 制約1: `take` / `skip` は `orderBy` を要求する

| 書き方 | Prisma の型 |
|---|---|
| `groupBy` + `take` あり・`orderBy` なし | **エラー** |
| `groupBy` + `skip: 1` あり・`orderBy` なし | **エラー** |
| `groupBy` + `skip: 0` あり・`orderBy` なし | **エラー** |
| `groupBy` + `take: undefined` あり・`orderBy` なし | **エラー** |
| `groupBy` + `take` + `orderBy` あり | OK |
| `groupBy` + `take` も `skip` も無し | OK |
| **`findMany` + `take` / `skip` ・`orderBy` なし** | **OK（制約なし）** |
| **`aggregate` + `take` / `skip` ・`orderBy` なし** | **OK（制約なし）** |

```
error TS2345: Argument of type '{ by: "is"[]; _count: { id: true; }; take: 10; }' is not assignable to parameter of type
  '{ by: "is"[]; _count: { id: true; }; take: 10; }
   & { orderBy: TestOrderByWithAggregationInput | TestOrderByWithAggregationInput[]; }
   & "Error: If you provide \"take\", you also need to provide \"orderBy\""'.
```

```
error TS2345: ... & "Error: If you provide \"skip\", you also need to provide \"orderBy\""'.
```

### 制約2: `orderBy` の列は `by` に無ければならない

| 書き方 | Prisma の型 |
|---|---|
| `by: ["label"]` + `orderBy: { id: "asc" }` | **エラー** |
| `by: "label"`（単一文字列）+ `orderBy: { id: "asc" }` | **エラー** |
| `by: ["label"]` + `orderBy: [{ label: "asc" }, { id: "asc" }]` | **エラー**（配列の一つでも外れていれば） |
| `by: ["label"]` + `orderBy: { label: "asc" }` | OK |
| `by: "label"`（単一文字列）+ `orderBy: { label: "asc" }` | OK |
| `by: ["label"]` + `orderBy: { _count: { id: "desc" } }` | **OK（集計値は by の対象外）** |
| `by: ["label", "col"]` + `orderBy: [{ label: "asc" }, { col: "asc" }]` | OK |
| `by: ["label"]` + `orderBy: [{ _count: { id: "desc" } }, { label: "asc" }]` | OK（集計と混在） |
| `by: ["col"]` + `orderBy: { col: { sort: "asc", nulls: "last" } }` | OK（SortOrderInput 形式） |
| **`findMany` の `orderBy`** | **OK（`by` の概念が無い）** |

```
error TS2345: Argument of type '{ by: "label"[]; _count: { id: true; }; orderBy: { id: "asc"; }; }' is not assignable to parameter of type
  '{ by: "label"[]; _count: { id: true; }; orderBy: { id: "asc"; }; }
   & { orderBy?: ItemOrderByWithAggregationInput | ItemOrderByWithAggregationInput[]; }
   & "Error: Field \"id\" in \"orderBy\" needs to be provided in \"by\""'.
```

**どちらの制約も `groupBy` にしか付かない**ことを実測で確認しています（`findMany` / `aggregate` は `take` だけ・`skip` だけでも通り、`orderBy` に任意の列を指定できる）。今回の変更でも `groupBy` 以外には一切手を入れていません。

## なぜ型と実行時で判定基準が違うのか（制約1）

**型は「キーの有無」で判定し、値は見ません。** `skip: 0` でも `take: undefined` でもエラーになります。型の世界に届くのはキーの並びだけで、`skip` に入る値が実行時に 0 になるかは分からないからです。

**実行時は値で判定します。** 本体の `src/util/groupby/groubyUtil/groupPagination.ts` の `usedPaginationArguments` は `...(skip ? ["skip"] : [])` と書かれており、`skip` が 0 のときは通します。これは Prisma の実行時挙動に合わせた意図的なもので、コメントにも「Prisma 実測」と記されています。**本体は変更していません。**

つまり `skip: 0` は「型ではエラー・実行時は素通り」になりますが、これは Prisma とまったく同じ非対称であり、意図した状態です。厳しい側（型）で先に止まるので、実機で落ちる経路は塞がれます。

## 変更内容

### 1. `Gassma.GroupByPaginationCheck` — `take` / `skip` が `orderBy` を要求する

`packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts`

```ts
type GroupByPaginationCheck<T, D extends { orderBy?: unknown }> = "orderBy" extends keyof T
  ? unknown
  : "take" extends keyof T
    ? Required<Pick<D, "orderBy">> & 'Error: If you provide "take", you also need to provide "orderBy"'
    : "skip" extends keyof T
      ? Required<Pick<D, "orderBy">> & 'Error: If you provide "skip", you also need to provide "orderBy"'
      : unknown;
```

- 制約を満たしているときは `unknown` を返すので、交差しても元の型と同一のままです（`X & unknown` は `X`）。
- `orderBy` の型は `Required<Pick<D, "orderBy">>` としてモデルごとの `GroupByData` から導出しています。モデル名や `strictUndefinedChecks` 有効時の `| SkipValue` を組み立て直さずに済み、`GroupByData` の変更に自動で追従します。

### 2. `Gassma.GroupByOrderByFieldCheck` — `orderBy` の列が `by` に無ければ拒否

```ts
type GroupByOrderFields<O> = O extends readonly (infer E)[]
  ? GroupByOrderFields<E>
  : O extends object ? Exclude<keyof O, `_${string}`> & string : never;
type GroupByByFields<B> = B extends readonly (infer E)[] ? GroupByByFields<E> : B;
type GroupByStrayOrderFields<T> = Exclude<
  GroupByOrderFields<T extends { orderBy: infer O } ? O : never>,
  GroupByByFields<T extends { by: infer B } ? B : never>
>;
type GroupByOrderByFieldCheck<T> = [GroupByStrayOrderFields<T>] extends [never]
  ? unknown
  : { [P in GroupByStrayOrderFields<T>]: `Error: Field "${P}" in "orderBy" needs to be provided in "by"` }[GroupByStrayOrderFields<T>];
```

- `GroupByOrderFields` / `GroupByByFields` は**再帰的な条件型**です。`readonly (infer E)[]` で配列を剥がしたあと裸の型パラメータで再帰するので**共用体に分配される**のがポイントで、これにより `by: "role"`（単一文字列）と `by: ["published", "authorId"]`（配列）、`orderBy: {...}` と `orderBy: [{...}, {...}]` が同じ経路で扱えます。
  - 配列リテラルは `({ published: "asc" } | { title: "asc" })[]` のように**要素が共用体**として推論されます。素の `keyof` だとキーの積（= `never`）になって検出できないため、分配が必須でした。
- `` Exclude<keyof O, `_${string}`> `` で `_count` / `_avg` / `_sum` / `_min` / `_max` を除外します。**集計値のソート（本体 #158 / #226）は `by` の対象外**という Prisma の扱いに一致します。
- `O extends object` のガードは `strictUndefinedChecks` の `orderBy: Gassma.skip` のためです。`Gassma.skip` は `unique symbol` なので、これが無いと `keyof` が `Symbol.prototype` のメンバー（`toString` / `valueOf` / `description`）を拾って誤検出します（実際に既存の `strict/skip.test-d.ts` が落ちて気付きました）。
- 逸脱した列が無ければ `unknown` を返します。ここで `never` を返すと交差した瞬間に全ての呼び出しが不可能になるため、`[X] extends [never]` で明示的に分岐しています。

### 3. `groupBy` のシグネチャに交差させる

`packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts`

```diff
-groupBy<T extends GassmaUserGroupByData>(groupByData: T & Gassma.Subset<T, GassmaUserGroupByData>): GassmaUserGroupByResult<T>[];
+groupBy<T extends GassmaUserGroupByData>(groupByData: T & Gassma.Subset<T, GassmaUserGroupByData> & Gassma.GroupByPaginationCheck<T, GassmaUserGroupByData> & Gassma.GroupByOrderByFieldCheck<T>): GassmaUserGroupByResult<T>[];
```

2つのチェックは**同時にエラーになりません**（制約1は `orderBy` が無いときだけ、制約2は `orderBy` があるときだけ発火する）ので、常に片方が `unknown` になり、エラー本文には一方のメッセージだけが出ます。`aggregate` / `count` / `findMany` / `findFirst` などの行は変更していません。

## 実際の生成型に対する実測結果

**fixture だけでなく、gassma-test の本物のスキーマ（全16モデル）から生成した型に対しても実測しました。**

```
cp -r gassma-test/gassma <一時ディレクトリ>/ && cd <一時ディレクトリ>
node <worktree>/packages/cli/bin/index.js generate
```

### 落ちるべきもの（本物のスキーマ・修正後）

```
error TS2345: Argument of type '{ by: "role"; _count: { id: true; }; orderBy: { id: "asc"; }; }' is not assignable to parameter of type
  '... & "Error: Field \"id\" in \"orderBy\" needs to be provided in \"by\""'.
```

```
error TS2345: Argument of type '{ by: ("published" | "authorId")[]; orderBy: ({ published: "asc"; } | { title: "asc"; })[]; }' is not assignable to parameter of type
  '... & "Error: Field \"title\" in \"orderBy\" needs to be provided in \"by\""'.
```

```
error TS2345: Argument of type '{ by: ("published" | "authorId")[]; _count: { id: true; }; take: 10; }' is not assignable to parameter of type
  '... & Required<...> & "Error: If you provide \"take\", you also need to provide \"orderBy\""'.
  Property 'orderBy' is missing in type '{ by: ("published" | "authorId")[]; _count: { id: true; }; take: 10; }'
  but required in type 'Required<Pick<GassmaPostGroupByData, "orderBy">>'.
```

`skip: 0` も同様に `"Error: If you provide \"skip\", you also need to provide \"orderBy\""` で落ちます。**メッセージの文言は Prisma と同一です。**

### 通らなければならないもの（gassma-test の実機テストで今まさに使われている6形）

以下はすべて `tsc` exit 0 でした。

```ts
client.Post.groupBy({
  by: ["published", "authorId"], _count: { id: true },
  orderBy: [{ published: "asc" }, { authorId: "asc" }], take: 10,
});
client.User.groupBy({ by: "role", orderBy: { role: "asc" }, take: 2, _count: { id: true } });
client.User.groupBy({ by: "role", orderBy: { role: "asc" }, skip: 2, _count: { id: true } });
client.User.groupBy({ by: "role", _count: { id: true }, orderBy: { _count: { id: "desc" } } });
client.User.groupBy({ by: "role", _count: { id: true }, orderBy: { _count: { id: "desc" } }, take: 1 });
client.Order.groupBy({ by: "status", _count: { id: true }, _sum: { totalAmount: true } });
```

### 波及していないこと（本物のスキーマ）

```ts
client.Post.findMany({ take: 10, skip: 5 });                       // OK
client.Post.findMany({ orderBy: { title: "asc" }, take: 3 });       // OK
client.Post.aggregate({ _count: { id: true }, take: 10, skip: 1 }); // OK
client.Post.aggregate({ _count: { id: true }, orderBy: { title: "asc" } }); // OK
```

この本物スキーマの検証は **TypeScript 5.2.2 / 5.6.3 / 5.9.3 / 6.0.3 / 7.0.2 × `strict` on/off の10通りすべてで exit 0** です。

## テスト

### 型テスト（新規3ファイル・既存1件更新）

- `packages/cli/src/__test__/types/aggregate/groupByPagination.test-d.ts`（制約1）
  - `take` のみ / `skip: 1` のみ / `skip: 0` のみ / `take: undefined` のみ / `take` + `skip` → すべて `@ts-expect-error`
  - `orderBy` を足せば `take` / `skip` / 両方が通る（スカラーソート・集計ソート・配列ソートの各形）
  - `take` / `skip` が無ければ従来どおり `orderBy` は任意
  - `take` + `orderBy` でも結果型がこれまでどおり解決する
  - **`findMany` / `findFirst` / `aggregate` には同じ制約が無い**（回帰ガード）
  - `strictUndefinedChecks` 生成物でも同じ制約がかかる
- `packages/cli/src/__test__/types/aggregate/groupByOrderByFields.test-d.ts`（制約2）
  - `by` に無い列の `orderBy` → `@ts-expect-error`（`by` が配列 / 単一文字列 / 配列 `orderBy` の一要素、の3形）
  - `by` に含まれる列なら通る（配列 `by` / 単一文字列 `by` / 複数キーの配列 `orderBy`）
  - **集計値の `orderBy`（`_count` / `_sum` / `_avg` / `_max` / `_min`）は通る**
  - 集計値と `by` の列を混ぜた配列 `orderBy` も通る
  - `SortOrderInput` 形式（`{ sort, nulls }`）も通る
  - 2つの制約の併用（`by` に無い列 + `take`）
  - **gassma-test の実機テストで使われている形をそのまま**（結果型の解決まで検証）
  - `findMany` / `aggregate` は無影響
  - `strictUndefinedChecks` 生成物でも同じ制約がかかる
- `packages/cli/src/__test__/types/nostrict/groupByPagination.test-d.ts`
  - `strictNullChecks` off でも両方の制約が同じ判定になること
- `aggregate/groupBy.test-d.ts` の既存 1 件を更新
  - 「`by` に含まれないスカラー列は型では通る（実行時に本体が弾く）」という**今回直したバグそのものを固定していたケース**を `@ts-expect-error` に変更しました。

### 単体テスト

- `gassmaCommonTypes.test.ts` に `GroupByPaginationCheck` / `GroupByOrderByFieldCheck` の出力を検証するケースを追加
- `gassmaController.test.ts` の `groupBy` シグネチャ期待値を更新

### 実行結果

型テストマトリクス（TypeScript 5.2.2 / 5.6.3 / 5.9.3 / 6.0.3 / 7.0.2 × `strict` on/off の10通り）が全て緑です。

```
TypeScript	strict	結果	エラー数
5.2.2	on	OK	0
5.2.2	off	OK	0
5.6.3	on	OK	0
5.6.3	off	OK	0
5.9.3	on	OK	0
5.9.3	off	OK	0
6.0.3	on	OK	0
6.0.3	off	OK	0
7.0.2	on	OK	0
7.0.2	off	OK	0
```

- `packages/cli`: `npm test` 1663 件通過 / `typecheck` OK / `build` OK / `lint` OK / `format` OK
- `packages/gas-esbuild-plugin`: `npm test` 15 件通過 / `typecheck` OK / `build` OK

TDD で進めており、両方の制約とも実装前に型テストを書いて **`@ts-expect-error` が「Unused」で落ちる赤**（制約1で8件、制約2で7件）を確認してから実装しています。

## 影響範囲

- 本体（gassma 本体リポジトリ）は無変更です。
- バージョンは上げていません。
- これまで `tsc` を通っていた次の2種類のコードは型エラーになります。ただし**どちらも実行時に必ず例外で落ちていたコード**なので、動いていたものが壊れることはありません。
  - `groupBy` に `take` / `skip` だけ書いたコード → `GassmaGroupByOrderByRequiredError`
  - `groupBy` の `orderBy` に `by` 外の列を書いたコード → `GassmaUnknownArgumentError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ