### PR TITLE
fix: reject select and include given together at the top level

### DIFF
--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaCommonTypes.test.ts
@@ -124,6 +124,18 @@ describe("getGassmaCommonTypes", () => {
     );
   });
 
+  it("should generate IncludeSelectCheck rejecting select together with include", () => {
+    expect(result).toContain(
+      "type SelectAndInclude = { select: unknown; include: unknown };",
+    );
+    expect(result).toContain(
+      "type IncludeSelectCheck<T> = T extends SelectAndInclude",
+    );
+    expect(result).toContain(
+      '? \'Error: Please either choose "select" or "include"\'',
+    );
+  });
+
   describe("strict mode", () => {
     const strictResult = getGassmaCommonTypes(true);
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaController.test.ts
@@ -5,6 +5,8 @@ describe("getOneGassmaController", () => {
   const result = getOneGassmaController("", "User", ["id"]);
   const res = `GassmaUserFindResult<T["select"], T["include"], T["omit"], GO, O, CMap>`;
   const sub = (dataType: string) => `T & Gassma.Subset<T, ${dataType}>`;
+  const subExclusive = (dataType: string) =>
+    `${sub(dataType)} & Gassma.IncludeSelectCheck<T>`;
   const withComputed = (dataType: string) =>
     `${dataType} & Gassma.ComputedArgs<Gassma.At<CMap, "User">>`;
 
@@ -52,49 +54,82 @@ describe("getOneGassmaController", () => {
 
   it("should have generic delete method with model-specific type", () => {
     expect(result).toContain(
-      `delete<T extends ${withComputed("GassmaUserDeleteSingleData")}>(deleteData: ${sub(withComputed("GassmaUserDeleteSingleData"))}): ${res} | null`,
+      `delete<T extends ${withComputed("GassmaUserDeleteSingleData")}>(deleteData: ${subExclusive(withComputed("GassmaUserDeleteSingleData"))}): ${res} | null`,
     );
   });
 
   it("should have generic upsert method with model-specific type", () => {
     expect(result).toContain(
-      `upsert<T extends ${withComputed("GassmaUserUpsertSingleData")}>(upsertData: ${sub(withComputed("GassmaUserUpsertSingleData"))}): ${res}`,
+      `upsert<T extends ${withComputed("GassmaUserUpsertSingleData")}>(upsertData: ${subExclusive(withComputed("GassmaUserUpsertSingleData"))}): ${res}`,
     );
   });
 
   it("should include createManyAndReturn method with generic type", () => {
     expect(result).toContain(
-      `createManyAndReturn<T extends ${withComputed("GassmaUserCreateManyAndReturnData")}>(createdData: ${sub(withComputed("GassmaUserCreateManyAndReturnData"))}): ${res}[]`,
+      `createManyAndReturn<T extends ${withComputed("GassmaUserCreateManyAndReturnData")}>(createdData: ${subExclusive(withComputed("GassmaUserCreateManyAndReturnData"))}): ${res}[]`,
     );
   });
 
   it("should include updateManyAndReturn method with generic type", () => {
     expect(result).toContain(
-      `updateManyAndReturn<T extends ${withComputed("GassmaUserUpdateManyAndReturnData")}>(updateData: ${sub(withComputed("GassmaUserUpdateManyAndReturnData"))}): ${res}[]`,
+      `updateManyAndReturn<T extends ${withComputed("GassmaUserUpdateManyAndReturnData")}>(updateData: ${subExclusive(withComputed("GassmaUserUpdateManyAndReturnData"))}): ${res}[]`,
     );
   });
 
   it("should use FindFirstData for findFirst", () => {
     expect(result).toContain(
-      `findFirst<T extends ${withComputed("GassmaUserFindFirstData")}>(findData: ${sub(withComputed("GassmaUserFindFirstData"))}): ${res} | null`,
+      `findFirst<T extends ${withComputed("GassmaUserFindFirstData")}>(findData: ${subExclusive(withComputed("GassmaUserFindFirstData"))}): ${res} | null`,
     );
   });
 
   it("should use FindFirstData for findFirstOrThrow", () => {
     expect(result).toContain(
-      `findFirstOrThrow<T extends ${withComputed("GassmaUserFindFirstData")}>(findData: ${sub(withComputed("GassmaUserFindFirstData"))}): ${res}`,
+      `findFirstOrThrow<T extends ${withComputed("GassmaUserFindFirstData")}>(findData: ${subExclusive(withComputed("GassmaUserFindFirstData"))}): ${res}`,
     );
   });
 
   it("should have generic create method with FindResult return", () => {
     expect(result).toContain(
-      `create<T extends ${withComputed("GassmaUserCreateData")}>(createdData: ${sub(withComputed("GassmaUserCreateData"))}): ${res}`,
+      `create<T extends ${withComputed("GassmaUserCreateData")}>(createdData: ${subExclusive(withComputed("GassmaUserCreateData"))}): ${res}`,
     );
   });
 
   it("should have generic update method with model-specific type", () => {
     expect(result).toContain(
-      `update<T extends ${withComputed("GassmaUserUpdateSingleData")}>(updateData: ${sub(withComputed("GassmaUserUpdateSingleData"))}): ${res} | null`,
+      `update<T extends ${withComputed("GassmaUserUpdateSingleData")}>(updateData: ${subExclusive(withComputed("GassmaUserUpdateSingleData"))}): ${res} | null`,
+    );
+  });
+
+  it("should guard every select/include-taking operation against the conflict", () => {
+    const guarded = [
+      ["createManyAndReturn", "GassmaUserCreateManyAndReturnData"],
+      ["create", "GassmaUserCreateData"],
+      ["findFirst", "GassmaUserFindFirstData"],
+      ["findFirstOrThrow", "GassmaUserFindFirstData"],
+      ["findMany", "GassmaUserFindManyData"],
+      ["update", "GassmaUserUpdateSingleData"],
+      ["updateManyAndReturn", "GassmaUserUpdateManyAndReturnData"],
+      ["upsert", "GassmaUserUpsertSingleData"],
+      ["delete", "GassmaUserDeleteSingleData"],
+    ];
+
+    guarded.forEach(([method, dataType]) => {
+      expect(result).toContain(
+        `${method}<T extends ${withComputed(dataType)}>(`,
+      );
+      expect(result).toContain(subExclusive(withComputed(dataType)));
+    });
+  });
+
+  it("should not guard operations that never take both select and include", () => {
+    expect(result).toContain(
+      `aggregate<T extends GassmaUserAggregateData>(aggregateData: ${sub("GassmaUserAggregateData")}):`,
+    );
+    expect(result).toContain(
+      `count<T extends GassmaUserCountData>(countData: ${sub("GassmaUserCountData")}):`,
+    );
+    expect(result).not.toContain(
+      "GassmaUserGroupByData> & Gassma.IncludeSelectCheck<T>",
     );
   });
 

--- a/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
+++ b/packages/cli/src/__test__/generate/typeGenerate/gassmaControllerOptionalArgs.test.ts
@@ -27,7 +27,7 @@ describe("getOneGassmaController no-arg overloads", () => {
 
   it("should keep the argument-taking signatures next to the no-arg overloads", () => {
     expect(result).toContain(
-      `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T & Gassma.Subset<T, GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>)`,
+      `findMany<T extends GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>>(findData: T & Gassma.Subset<T, GassmaUserFindManyData & Gassma.ComputedArgs<Gassma.At<CMap, "User">>> & Gassma.IncludeSelectCheck<T>)`,
     );
     expect(result).toContain(
       "count<T extends GassmaUserCountData>(countData: T & Gassma.Subset<T, GassmaUserCountData>): GassmaUserCountResult<T>;",

--- a/packages/cli/src/__test__/types/nostrict/selectIncludeConflict.test-d.ts
+++ b/packages/cli/src/__test__/types/nostrict/selectIncludeConflict.test-d.ts
@@ -1,0 +1,68 @@
+import { expectTypeOf } from "vitest";
+import { GassmaClient } from "../__generated__/client";
+
+// strictNullChecks が off でも select と include の同時指定が弾かれる
+const client = new GassmaClient();
+
+{
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.findMany({ select: { id: true }, include: { author: true } });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.findFirst({ select: { id: true }, include: { author: true } });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.create({
+    data: { title: "t", authorId: 1 },
+    select: { id: true },
+    include: { author: true },
+  });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.update({
+    where: { id: 1 },
+    data: { title: "t" },
+    select: { id: true },
+    include: { author: true },
+  });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.delete({
+    where: { id: 1 },
+    select: { id: true },
+    include: { author: true },
+  });
+}
+
+{
+  client.Post.findMany({ select: { id: true } });
+  client.Post.findMany({ include: { author: true } });
+  client.Post.findMany({ omit: { title: true } });
+  client.Post.findMany({
+    where: { published: true },
+    include: { author: true },
+    take: 10,
+  });
+  client.Post.create({
+    data: { title: "t", authorId: 1 },
+    include: { author: true },
+  });
+  client.Post.update({
+    where: { id: 1 },
+    data: { title: "t" },
+    select: { id: true },
+  });
+  // ネストの select + include は型では弾かない
+  client.User.findMany({
+    include: { posts: { select: { id: true }, include: { author: true } } },
+  });
+}
+
+// 結果型の解決が非 strict でも壊れない
+{
+  const p = client.Post.findFirstOrThrow({ include: { author: true } });
+  expectTypeOf<(typeof p)["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<
+    NonNullable<(typeof p)["author"]>["email"]
+  >().toEqualTypeOf<string>();
+
+  const s = client.Post.findFirstOrThrow({ select: { id: true } });
+  expectTypeOf<(typeof s)["id"]>().toEqualTypeOf<number>();
+  expectTypeOf(s).not.toHaveProperty("title");
+}

--- a/packages/cli/src/__test__/types/query/selectIncludeConflict.test-d.ts
+++ b/packages/cli/src/__test__/types/query/selectIncludeConflict.test-d.ts
@@ -1,0 +1,183 @@
+import { expectTypeOf } from "vitest";
+import type {
+  GassmaClient,
+  GassmaPostFindManyData,
+} from "../__generated__/client";
+
+declare const client: GassmaClient;
+declare const prebuiltArgs: GassmaPostFindManyData;
+
+// トップレベルで select と include を同時に指定できない（本体の
+// GassmaIncludeSelectConflictError に相当する制約を型で表す）
+{
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.findMany({ select: { id: true }, include: { author: true } });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.findFirst({ select: { id: true }, include: { author: true } });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.findFirstOrThrow({
+    select: { id: true },
+    include: { author: true },
+  });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.create({
+    data: { title: "t", authorId: 1 },
+    select: { id: true },
+    include: { author: true },
+  });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.createManyAndReturn({
+    data: [{ title: "t", authorId: 1 }],
+    select: { id: true },
+    include: { author: true },
+  });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.update({
+    where: { id: 1 },
+    data: { title: "t" },
+    select: { id: true },
+    include: { author: true },
+  });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.updateManyAndReturn({
+    data: { title: "t" },
+    select: { id: true },
+    include: { author: true },
+  });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.upsert({
+    where: { id: 1 },
+    create: { title: "t", authorId: 1 },
+    update: { title: "t" },
+    select: { id: true },
+    include: { author: true },
+  });
+  // @ts-expect-error select と include は同時に指定できない
+  client.Post.delete({
+    where: { id: 1 },
+    select: { id: true },
+    include: { author: true },
+  });
+}
+
+// 片方だけなら通る
+{
+  client.Post.findMany({ select: { id: true } });
+  client.Post.findMany({ include: { author: true } });
+  client.Post.findMany({ omit: { title: true } });
+  client.Post.findMany({
+    where: { published: true },
+    include: { author: true },
+    take: 10,
+  });
+  client.Post.create({ data: { title: "t", authorId: 1 } });
+  client.Post.create({
+    data: { title: "t", authorId: 1 },
+    include: { author: true },
+  });
+  client.Post.update({
+    where: { id: 1 },
+    data: { title: "t" },
+    select: { id: true },
+  });
+  client.Post.upsert({
+    where: { id: 1 },
+    create: { title: "t", authorId: 1 },
+    update: { title: "t" },
+    include: { author: true },
+  });
+  client.Post.delete({ where: { id: 1 }, include: { author: true } });
+  client.Post.createManyAndReturn({
+    data: [{ title: "t", authorId: 1 }],
+    select: { id: true },
+  });
+  client.Post.updateManyAndReturn({
+    data: { title: "t" },
+    omit: { title: true },
+  });
+}
+
+// 事前に組み立てた引数（select / include が任意キーのまま）は拒否されない
+{
+  client.Post.findMany(prebuiltArgs);
+}
+
+// select + omit の同時指定は従来どおり拒否される
+{
+  // @ts-expect-error select と omit は同時に指定できない
+  client.Post.findMany({ select: { id: true }, omit: { title: true } });
+}
+
+// ネストした select + include は Prisma と同じく型では弾かない
+// （本体の IncludeSelectIncludeConflictError が実行時に弾く）
+{
+  client.User.findMany({
+    include: { posts: { select: { id: true }, include: { author: true } } },
+  });
+  client.User.findMany({
+    select: { posts: { select: { id: true }, include: { author: true } } },
+  });
+}
+
+// 結果型の解決は変わらない
+{
+  const withInclude = client.Post.findMany({ include: { author: true } });
+  type P = (typeof withInclude)[number];
+  expectTypeOf<P["title"]>().toEqualTypeOf<string>();
+  expectTypeOf<P["author"]["email"]>().toEqualTypeOf<string>();
+
+  const withSelect = client.Post.findMany({ select: { id: true } });
+  expectTypeOf<typeof withSelect>().branded.toEqualTypeOf<{ id: number }[]>();
+
+  const nested = client.User.findFirstOrThrow({
+    include: { posts: { select: { title: true } } },
+  });
+  expectTypeOf<(typeof nested)["posts"][number]>().branded.toEqualTypeOf<{
+    title: string;
+  }>();
+
+  const created = client.Post.create({
+    data: { title: "t", authorId: 1 },
+    include: { author: true },
+  });
+  expectTypeOf<(typeof created)["author"]["email"]>().toEqualTypeOf<string>();
+
+  const updated = client.Post.update({
+    where: { id: 1 },
+    data: { title: "t" },
+    select: { id: true },
+  });
+  expectTypeOf<NonNullable<typeof updated>>().branded.toEqualTypeOf<{
+    id: number;
+  }>();
+
+  const upserted = client.Post.upsert({
+    where: { id: 1 },
+    create: { title: "t", authorId: 1 },
+    update: { title: "t" },
+    include: { author: true },
+  });
+  expectTypeOf<(typeof upserted)["author"]["email"]>().toEqualTypeOf<string>();
+
+  const deleted = client.Post.delete({
+    where: { id: 1 },
+    include: { author: true },
+  });
+  expectTypeOf<
+    NonNullable<typeof deleted>["author"]["email"]
+  >().toEqualTypeOf<string>();
+
+  const returned = client.Post.createManyAndReturn({
+    data: [{ title: "t", authorId: 1 }],
+    include: { author: true },
+  });
+  expectTypeOf<
+    (typeof returned)[number]["author"]["email"]
+  >().toEqualTypeOf<string>();
+
+  const manyUpdated = client.Post.updateManyAndReturn({
+    data: { title: "t" },
+    select: { id: true },
+  });
+  expectTypeOf<typeof manyUpdated>().branded.toEqualTypeOf<{ id: number }[]>();
+}

--- a/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaCommonTypes.ts
@@ -126,6 +126,10 @@ const getGassmaCommonTypes = (strict?: boolean) => {
   type GroupByOrderByFieldCheck<T> = [GroupByStrayOrderFields<T>] extends [never]
     ? unknown
     : { [P in GroupByStrayOrderFields<T>]: \`Error: Field "\${P}" in "orderBy" needs to be provided in "by"\` }[GroupByStrayOrderFields<T>];
+  type SelectAndInclude = { select: unknown; include: unknown };
+  type IncludeSelectCheck<T> = T extends SelectAndInclude
+    ? 'Error: Please either choose "select" or "include"'
+    : unknown;
   type ExactKeys<T, Shape> = Shape & { [K in Exclude<keyof T, keyof Shape>]?: never };
   type StrictGlobalOmit<O, Config> = Config & {
     [K in keyof O]?: K extends keyof Config

--- a/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
+++ b/packages/cli/src/generate/typeGenerate/gassmaController/oneGassmaController.ts
@@ -28,6 +28,9 @@ const getOneGassmaController = (
   const arg = (dataSuffix: string) => `T extends ${withComputed(dataSuffix)}`;
   const sub = (dataSuffix: string) =>
     `T & Gassma.Subset<T, ${withComputed(dataSuffix)}>`;
+  // select と include を両方受け付ける操作だけに衝突チェックを足す
+  const subExclusive = (dataSuffix: string) =>
+    `${sub(dataSuffix)} & Gassma.IncludeSelectCheck<T>`;
 
   return `
 ${docs.controllerClass}export declare class ${self}Controller<GO extends ${self}Omit = {}, O = {}, CMap = {}> {
@@ -40,19 +43,19 @@ ${docs.changeSettings}  changeSettings(
     endColumnValue: number | string
   ): void;
 ${docs.createMany}  createMany(createdData: ${self}CreateManyData): CreateManyReturn;
-${docs.createManyAndReturn}  createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: ${sub("CreateManyAndReturnData")}): ${res}[];
-${docs.create}  create<${arg("CreateData")}>(createdData: ${sub("CreateData")}): ${res};
-${docs.findFirst}  findFirst<${arg("FindFirstData")}>(findData: ${sub("FindFirstData")}): ${res} | null;
+${docs.createManyAndReturn}  createManyAndReturn<${arg("CreateManyAndReturnData")}>(createdData: ${subExclusive("CreateManyAndReturnData")}): ${res}[];
+${docs.create}  create<${arg("CreateData")}>(createdData: ${subExclusive("CreateData")}): ${res};
+${docs.findFirst}  findFirst<${arg("FindFirstData")}>(findData: ${subExclusive("FindFirstData")}): ${res} | null;
 ${docs.findFirstNoArgs}  findFirst(): ${resNoArg} | null;
-${docs.findFirstOrThrow}  findFirstOrThrow<${arg("FindFirstData")}>(findData: ${sub("FindFirstData")}): ${res};
+${docs.findFirstOrThrow}  findFirstOrThrow<${arg("FindFirstData")}>(findData: ${subExclusive("FindFirstData")}): ${res};
 ${docs.findFirstOrThrowNoArgs}  findFirstOrThrow(): ${resNoArg};
-${docs.findMany}  findMany<${arg("FindManyData")}>(findData: ${sub("FindManyData")}): ${res}[];
+${docs.findMany}  findMany<${arg("FindManyData")}>(findData: ${subExclusive("FindManyData")}): ${res}[];
 ${docs.findManyNoArgs}  findMany(): ${resNoArg}[];
-${docs.update}  update<${arg("UpdateSingleData")}>(updateData: ${sub("UpdateSingleData")}): ${res} | null;
+${docs.update}  update<${arg("UpdateSingleData")}>(updateData: ${subExclusive("UpdateSingleData")}): ${res} | null;
 ${docs.updateMany}  updateMany(updateData: ${self}UpdateData): UpdateManyReturn;
-${docs.updateManyAndReturn}  updateManyAndReturn<${arg("UpdateManyAndReturnData")}>(updateData: ${sub("UpdateManyAndReturnData")}): ${res}[];
-${docs.upsert}  upsert<${arg("UpsertSingleData")}>(upsertData: ${sub("UpsertSingleData")}): ${res};
-${docs.deleteSingle}  delete<${arg("DeleteSingleData")}>(deleteData: ${sub("DeleteSingleData")}): ${res} | null;
+${docs.updateManyAndReturn}  updateManyAndReturn<${arg("UpdateManyAndReturnData")}>(updateData: ${subExclusive("UpdateManyAndReturnData")}): ${res}[];
+${docs.upsert}  upsert<${arg("UpsertSingleData")}>(upsertData: ${subExclusive("UpsertSingleData")}): ${res};
+${docs.deleteSingle}  delete<${arg("DeleteSingleData")}>(deleteData: ${subExclusive("DeleteSingleData")}): ${res} | null;
 ${docs.deleteMany}  deleteMany(deleteData: ${self}DeleteData): DeleteManyReturn;
 ${docs.deleteManyNoArgs}  deleteMany(): DeleteManyReturn;
 ${docs.aggregate}  aggregate<T extends ${self}AggregateData>(aggregateData: T & Gassma.Subset<T, ${self}AggregateData>): ${self}AggregateResult<T>;


### PR DESCRIPTION
## 概要

トップレベルで `select` と `include` を同時に指定できてしまう問題を型で塞ぎます。

```ts
// main の HEAD では tsc を通ってしまっていた
client.Post.findMany({ select: { id: true }, include: { author: true } });
```

本体は実行時に `GassmaIncludeSelectConflictError`（`"Cannot use both include and select in the same query"`、`src/gassmaController.ts` の3箇所）で弾いていましたが、型では素通りでした。Prisma は型で弾くため、型の段階で気づける形に揃えます。

## Prisma の実測結果

**トップレベルは弾く。**

```
Type '{ select: { id: true; }; include: { posts: true; }; }' is not assignable to type
  '"Please either choose `select` or `include`."'.
```

**ネストは弾かない（実測）。** 以下は Prisma でも型エラーになりません。

```ts
p.author.findMany({ include: { posts: { select: { id: true }, include: { author: true } } } });
p.author.findMany({ select:  { posts: { select: { id: true }, include: { author: true } } } });
```

gassma もネストは本体の実行時（`IncludeSelectIncludeConflictError`、`src/util/relation/validation/validateIncludeOptions.ts`）に任せることで Prisma と一致します。**本 PR はトップレベルだけを対象にしています。**

## 実装

`gassmaCommonTypes.ts` に Prisma と同じ形のチェック型を追加しました。

```ts
type SelectAndInclude = { select: unknown; include: unknown };
type IncludeSelectCheck<T> = T extends SelectAndInclude
  ? 'Error: Please either choose "select" or "include"'
  : unknown;
```

`oneGassmaController.ts` で、`select` と `include` を両方受け付ける操作の引数型に `& Gassma.IncludeSelectCheck<T>` を交差させます（#173 の `GroupByPaginationCheck` / `GroupByOrderByFieldCheck` と同じ形）。

### `keyof T` ではなく `T extends { select: unknown; include: unknown }` にした理由

最初 #173 と同じく `"select" extends keyof T` で書いたところ、`query/excessKeys.test-d.ts` が落ちました。**任意プロパティも `keyof` に出るため、`GassmaUserFindData` 型の変数を組み立てて渡す呼び出しまで拒否されます。** Prisma の `SelectSubset` と同じく「必須プロパティとして両方持つか」で判定する形に直しました。オブジェクトリテラルは書いたキーだけが必須で推論されるので、リテラルでは意図どおり弾き、事前に組み立てた引数は通ります。この境界は型テストに固定してあります。

### 既存の `select` + `omit` との関係

`select` + `omit` はデータ型側のユニオン（`{ select?: S; omit?: never } | { select?: never; omit?: O }`）で既に弾けており、**今回は触っていません**。理由は2つです。

- `select` を `omit` と `include` の両方から排他にするようユニオンを組み替えると `include` がユニオンの中に入り、`FindResult` の解決（`SelectOf` / `IncludeOf` / `OmitOf`）に波及するリスクがあります。**結果型を壊さないことを優先しました。**
- 交差型のチェックは Prisma と同じくエラー本文にメッセージが出るため、`omit` 側もこの方式に寄せる改善余地はありますが、挙動変更を伴うため本 PR の範囲外としています。

結果としてメッセージの形は2種類になります。

```
# select + include（今回追加）
Type '{ select: ...; include: ...; }' is not assignable to type '"Error: Please either choose "select" or "include""'.

# select + omit（従来どおり）
Types of property 'omit' are incompatible. Type '{ title: true; }' is not assignable to type 'undefined'.
```

## 対象にした操作

生成器で `select` と `include` を両方持つデータ型を列挙し（`include?:` をトップレベルに持つ生成器8ファイル）、それを使う9つのシグネチャすべてに入れました。

| 操作 | データ型 |
| --- | --- |
| `create` | `CreateData` |
| `createManyAndReturn` | `CreateManyAndReturnData` |
| `findFirst` | `FindFirstData` |
| `findFirstOrThrow` | `FindFirstData` |
| `findMany` | `FindManyData` |
| `update` | `UpdateSingleData` |
| `updateManyAndReturn` | `UpdateManyAndReturnData` |
| `upsert` | `UpsertSingleData` |
| `delete` | `DeleteSingleData` |

対象外: `createMany` / `updateMany` / `deleteMany` / `aggregate` / `groupBy`（`select` と `include` を両方持たない）、`count`（`select` のみ）。`findUnique` / `findUniqueOrThrow` は gassma に存在しません。

## 実際の生成型に対する実測

gassma-test の本物のスキーマから `gassma generate` して probe を通しました。「落ちるべき例」と「通るべき例」を同じファイルに並べています。

**修正前**（gassma-test にチェックインされている生成物）: 落ちたのは `select` + `omit` の1件のみ。**トップレベルの `select` + `include` 9件はすべて素通り。**

**修正後**: 9件すべてが以下のメッセージで落ちます。

```
probe.ts(6,17): error TS2345: Argument of type '{ select: { id: true; }; include: { author: true; }; }' is not assignable to parameter of type ...
  Type '{ select: { id: true; }; include: { author: true; }; }' is not assignable to type '"Error: Please either choose \"select\" or \"include\""'.
```

通るべき例（すべてエラーなし）:

```ts
c.Post.findMany({ select: { id: true } });
c.Post.findMany({ include: { author: true } });
c.Post.findMany({ omit: { title: true } });
c.Post.findMany({ include: { author: { select: { id: true } } } });
c.Post.findMany({ where: { published: true }, include: { author: true }, take: 10 });
c.Post.create({ data: { title: "t", authorId: 1, debugInfo: "d" }, include: { author: true } });
c.Post.update({ where: { id: 1 }, data: { title: "t" }, select: { id: true } });
// ネストの select + include は型では弾かない
c.User.findMany({ include: { posts: { select: { id: true }, include: { author: true } } } });
c.User.findMany({ select:  { posts: { select: { id: true }, include: { author: true } } } });
```

## 結果型が壊れていないことの確認

probe 内で `@ts-expect-error` を使い、絞り込みが効いていることを実測しました（未使用なら TS2578 になるので、絞り込みが消えたら検出できます）。

- `include` した結果のリレーション（`author.email` / `comments[].text`）が解決される
- `select` で絞った結果に他のフィールドが無い
- `omit` したフィールドが結果型に無い
- ネストの `select` の絞り込みが効く
- `create` / `update` の `include` / `select` も同様

型テスト側でも `expectTypeOf(...).branded.toEqualTypeOf<...>()` で9操作すべての結果型を固定しています。

## gassma-test のコンパイル

生成物を差し替えた gassma-test のコピーに対して `npx tsc --noEmit` を実行しました。**新しい型で落ちるのは意図した2箇所だけ**です。

```
src/test/error/testErrorClasses.ts(23,28): error TS2345 ...
src/test/error/testErrorClasses.ts(34,29): error TS2345 ...
```

これは `GassmaIncludeSelectConflictError` の実行時挙動を確認するために**意図的に `select` + `include` を書いている**テストです。この2箇所に `// @ts-expect-error` を1行足せば gassma-test 全体がクリーンにコンパイルできることを確認済みです（本 PR では gassma-test を変更していません）。それ以外の全テストコードは無変更でコンパイルできるため、結果型の解決は保たれています。

## テスト

- 型テストを strict / 非 strict の2ファイルに追加
  - `src/__test__/types/query/selectIncludeConflict.test-d.ts`
  - `src/__test__/types/nostrict/selectIncludeConflict.test-d.ts`
- 型マトリクス10通り（TS 5.2.2 / 5.6.3 / 5.9.3 / 6.0.3 / 7.0.2 × strict on/off）すべて OK
- `vitest run` 1666 件パス / `test:types` 型エラーなし
- 両パッケージの test / typecheck / build / lint / format パス

バージョンは上げていません。本体（gassma）・gassma-test は変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ