### PR TITLE
chore: target library version 10 and release 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6086,7 +6086,7 @@
     },
     "packages/cli": {
       "name": "gassma",
-      "version": "2.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gassma",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "GASsma is Google Apps Script(GAS) of SpreadSheet library that can be used like prisma.",
   "types": "index.d.ts",
   "bin": {

--- a/packages/cli/src/__test__/bootstrap/const/gassmaLibrary.test.ts
+++ b/packages/cli/src/__test__/bootstrap/const/gassmaLibrary.test.ts
@@ -3,6 +3,6 @@ import { GASSMA_LIBRARY } from "../../../bootstrap/const/gassmaLibrary";
 
 describe("GASSMA_LIBRARY", () => {
   it("should pin the library version this CLI is paired with", () => {
-    expect(GASSMA_LIBRARY.version).toBe("9");
+    expect(GASSMA_LIBRARY.version).toBe("10");
   });
 });

--- a/packages/cli/src/bootstrap/const/gassmaLibrary.ts
+++ b/packages/cli/src/bootstrap/const/gassmaLibrary.ts
@@ -7,7 +7,7 @@ type GassmaLibrary = {
 const GASSMA_LIBRARY: GassmaLibrary = {
   scriptId: "1ZVuWMUYs4hVKDCcP3nVw74AY48VqLm50wRceKIQLFKL0wf4Hyou-FIBH",
   userSymbol: "Gassma",
-  version: "9",
+  version: "10",
 };
 
 export { GASSMA_LIBRARY };


### PR DESCRIPTION
## 何をしたか

**GAS ライブラリ版 10 に対応させ、3.1.0 として出します。**

- `GASSMA_LIBRARY.version` を `"9"` → `"10"`
- `packages/cli` の version を `3.0.0` → `3.1.0`

## ライブラリ版を上げる理由

**本体のビルドが webpack から esbuild に変わった**ためです（gassma #233）。公開するシンボルは62件のまま変わっていませんが、バンドルの中身は総入れ替えで、webpack ランタイムの883箇所が消えています。**別物として版を切るのが妥当**だと判断しました。

`bootstrap` は `GASSMA_LIBRARY.version` を新規プロジェクトの `appsscript.json` にそのまま書き込みます。**利用者が入れた CLI の版が、組み合わせるライブラリの版を決める**設計（#171）なので、ここを上げないと新規プロジェクトに版 10 が伝わりません。

## 3.1.0 に含まれるもの

| PR | 内容 |
|---|---|
| #170 | `studio` の空 URL 修正。**bootstrap で作った全プロジェクトで `studio` が壊れていた** |
| #171 | ライブラリ版を CLI の定数に固定 |
| #172 | `gassma debug` での版の照合 |
| #173 | `groupBy` の型の制約2件（`take`/`skip` に `orderBy` 必須、`orderBy` の列は `by` に含まれること） |
| #174 | `select` と `include` の排他 |

**#171 が bootstrap の挙動を変える**のでマイナーを上げています。

## TDD

先に `gassmaLibrary.test.ts` の期待値を `"10"` に変えて赤（`expected '9' to be '10'`）を確認してから実装しています。**逆順だと実装漏れが自動では落ちません。**

## 検証

CI と同じ順序（`test:types` がフィクスチャを生成してから `typecheck`）で実行しました。

```
test        1680 passed (1681)   ← 後述の1件を除き全通過
test:types  1666 passed (259 files)
typecheck   exit 0
lint        exit 0
format:check exit 0
build       exit 0
```

## ⚠️ 既知の失敗が1件あります（この変更とは無関係）

`packages/cli/src/__test__/debug/detectCi.test.ts` の `should stay false when no CI indicator is present` が**手元でのみ落ちます**。

- **`main`（無変更）でも同じように落ちる**ことを確認済み
- **CI では green**（#173 / #174 のマージ時とも success）
- 単体で `ci-info` を読むと `isCI=false name=null` になるので、同ファイル内の先行テストが `TEAMCITY_VERSION` を立てて import した状態が `vi.resetModules()` で戻りきっていない疑いがあります

**この PR で扱う範囲を超えるので手を付けていません。** 別途調べる価値はあります。

## マージ前に必要なこと

**ライブラリ版 10 が実際にデプロイされてからマージしてください。** 存在しない版を `bootstrap` が書き込む状態になるためです。本体側の版数記録は gassma の `chore/library-version-10` で用意してあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ